### PR TITLE
Update EventSchema.md

### DIFF
--- a/docs/EventSchema.md
+++ b/docs/EventSchema.md
@@ -12,10 +12,10 @@ oneOf:
 definitions:
   EventMetaData:
     type: object
-
     properties:
       id: { type: string, format: uuid }
-      created: { type: string, format: data-time }
+      event_time: { type: string, format: date-time, description: "time at which the event occured, UTC" }
+      created: { type: string, format: date-time, description: "time at which this message was created, UTC" }
       root_id: { type: string, format: uuid }
       parent_id: { type: string, format: uuid }
       content_type: 
@@ -29,7 +29,7 @@ definitions:
       scopes:
         type: array
         items: { type: string }
-    required: [ id, created, content_type ]
+    required: [ id, event_time, content_type ]
 
   BusinessEvent:   
     properties:


### PR DESCRIPTION
Some ideas: 
1 We should have a fixed place where the information determining the Kafka topic goes. I call it content-type here. The Create/Update/Delete OP goes to a separate field. (data_op_type).
2 Resource Events have three extra mandatory fields (data, data_key and data_op_type) that business events are not allowed to use, which allows for more effective validation.
3 Business Events are not allowed to create sub-objects.
