### PR TITLE
Fixed #33. This definition was accidentally changed.

### DIFF
--- a/nakadi/swagger.yaml
+++ b/nakadi/swagger.yaml
@@ -713,13 +713,13 @@ definitions:
       It should be used as a base definition for all events, that flow through
       Nakadi by extending attributes of this object type.
     properties:
-      event:
+      event_type:
         type: string
         example: 'https://resource-events.zalando.com/ResourceCreated'
       partitioning_key:
         type: string
         example: 'ARTICLE:ABC123XXX-001'
-      meta_data:
+      metadata:
         $ref: '#/definitions/EventMetaData'
   EventMetaData:
     type: object


### PR DESCRIPTION
What is implemented all the time is event_type and metadata. To avoid misleading assumptions and confusion sync the swagger file with the implementation and the so far vision.

@v-stepanov @valgog @jkliff