### PR TITLE
new stream format suggestion

### DIFF
--- a/streaming.json
+++ b/streaming.json
@@ -1,0 +1,24 @@
+//this cas be a stream for batch size 6
+{
+  "events": {
+    "0":["Dummy","Dummy","Dummy"],
+    "1":["Dummy"],
+    "2":["Dummy","Dummy"]
+  },
+  "commit_id": "NCSLUIVWHGROQ7TY473GH347"
+}
+\n
+{
+  "events": {
+    "0":["Dummy","Dummy"],
+    "4":["Dummy","Dummy","Dummy","Dummy"]
+  },
+  "commit_id": "IOJIJQIVBN8J4JPK43M34FER"
+}
+\n
+{
+  "events": {
+    "3":["Dummy","Dummy","Dummy","Dummy","Dummy","Dummy"]
+  },
+  "commit_id": "DGKYGSDDOIH&8723824YU387"
+}


### PR DESCRIPTION
I really like our new high level api idea with event types. What I don't like is that in the streaming format we expose things like partitions and offsets. Yes, we can't get rid of exposing partitions but we can at least get rid of offsets exposing. And with that we will avoid all these discussions about if this is offset of last read element or the next element, should it be inclusive or exclusive etc.

Here's the format I suggest to have. Do you see any problems with it? Do you like old format better? Feel free to criticise. I think it fits more to our high-level api.

P.S. sorry for raising this topic again.

@valgog @jkliff @CyberDem0n @tmuehl
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/zalando/nakadi/pull/50%23issuecomment-167758502%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/zalando/nakadi/pull/50%23issuecomment-167758502%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22commit_id%20here%20always%20holds%20the%20offsets%20of%20all%20partitions%20that%20client%20reads%20from%20%28even%20that%20he%20doesn%27t%20get%20any%20events%20for%20that%20partition%20in%20the%20last%20batch%29.%20So%20the%20commit_id%20can%20be%20just%20the%20encoded%20string%20of%20something%20like%20%5C%220%3A5467902%2C1%3A5435645%2C2%3A42343554%2C3%3A2290450%2C4%3A5495498%2C5%3A33854574%2C6%3A2266598%2C7%3A9965430%5C%22%5Cr%5Cn%28another%20possibility%20is%20to%20have%20a%20key-value%20storage%2C%20in%20that%20case%20it%20will%20allow%20to%20keep%20commit_id%20quite%20short%29%22%2C%20%22created_at%22%3A%20%222015-12-29T09%3A55%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/13309177%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/v-stepanov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/zalando/nakadi/pull/50#issuecomment-167758502'>General Comment</a></b>
- <a href='https://github.com/v-stepanov'><img border=0 src='https://avatars.githubusercontent.com/u/13309177?v=3' height=16 width=16'></a> commit_id here always holds the offsets of all partitions that client reads from (even that he doesn't get any events for that partition in the last batch). So the commit_id can be just the encoded string of something like "0:5467902,1:5435645,2:42343554,3:2290450,4:5495498,5:33854574,6:2266598,7:9965430"
(another possibility is to have a key-value storage, in that case it will allow to keep commit_id quite short)


<a href='https://www.codereviewhub.com/zalando/nakadi/pull/50?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/zalando/nakadi/pull/50?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/zalando/nakadi/pull/50'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>