### PR TITLE
ARUHA-50 Using snake case instead of camel case

### DIFF
--- a/src/main/java/de/zalando/aruha/nakadi/domain/EventType.java
+++ b/src/main/java/de/zalando/aruha/nakadi/domain/EventType.java
@@ -15,6 +15,7 @@ public class EventType {
     @Size(min = 1, message = "may not be empty")
     private String name;
 
+    @JsonProperty("owning_application")
     private String owningApplication;
 
     @NotNull


### PR DESCRIPTION
Due to a spring boot problem, the wrong mapper bean is wired during application boot. That causes an issue where camel cases are not properly mapped to snake case.

So I'm explicitly mapping properties as snake case.