### PR TITLE
ARUHA-97 Tune connection pool

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,10 @@ spring:
     username: nakadi_app
     password: nakadi
     driverClassName: org.postgresql.Driver
+    initialSize: 2
+    maxActive: 20
+    testOnBorrow: true
+    validationQuery: SELECT 1
 nakadi:
   topic:
     default:


### PR DESCRIPTION
There are currently 2 major issues with the connection pool on the test
environment:

1. It tries to open too many connections with the database
2. It does not recover from a database restart (or a network problem)

In order to fix those issues, we are adding some checks and also
avoiding requesting too many connections during application boot.

It's not the most efficient solution, since it adds another query just to check for connection, but it's the most reliable and responsive solution.

Another approach would be to use `removeAbandoned` property http://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html#Common_Attributes or even implementing some custom validation class.

I considered this approach to be sufficient by now.