### PR TITLE
ARUHA-88 All endpoints can (with low probability) respond with a 503.…

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -139,7 +139,7 @@ paths:
           schema:
             $ref: '#/definitions/Problem'
         '503':
-          description: Service (temporary) not available
+          description: Service (temporarily) unavailable
           schema:
             $ref: '#/definitions/Problem'
   /event-types:
@@ -171,7 +171,7 @@ paths:
           schema:
             $ref: '#/definitions/Problem'
         '503':
-          description: Service (temporary) not available
+          description: Service (temporarily) unavailable
           schema:
             $ref: '#/definitions/Problem'
 
@@ -251,7 +251,7 @@ paths:
           schema:
             $ref: '#/definitions/Problem'
         '503':
-          description: Service (temporary) not available
+          description: Service (temporarily) unavailable
           schema:
             $ref: '#/definitions/Problem'
 
@@ -293,7 +293,7 @@ paths:
           schema:
             $ref: '#/definitions/Problem'
         '503':
-          description: Service (temporary) not available
+          description: Service (temporarily) unavailable
           schema:
             $ref: '#/definitions/Problem'
 
@@ -347,7 +347,7 @@ paths:
           schema:
             $ref: '#/definitions/Problem'
         '503':
-          description: Service (temporary) not available
+          description: Service (temporarily) unavailable
           schema:
             $ref: '#/definitions/Problem'
 
@@ -430,7 +430,7 @@ paths:
           schema:
             $ref: '#/definitions/Problem'
         '503':
-          description: Service (temporary) not available
+          description: Service (temporarily) unavailable
           schema:
             $ref: '#/definitions/Problem'
     get:
@@ -587,7 +587,7 @@ paths:
           schema:
             $ref: '#/definitions/Problem'
         '503':
-          description: Service (temporary) not available
+          description: Service (temporarily) unavailable
           schema:
             $ref: '#/definitions/Problem'
 
@@ -634,7 +634,7 @@ paths:
           schema:
             $ref: '#/definitions/Problem'
         '503':
-          description: Service (temporary) not available
+          description: Service (temporarily) unavailable
           schema:
             $ref: '#/definitions/Problem'
 
@@ -680,7 +680,7 @@ paths:
           schema:
             $ref: '#/definitions/Problem'
         '503':
-          description: Service (temporary) not available
+          description: Service (temporarily) unavailable
           schema:
             $ref: '#/definitions/Problem'
 
@@ -705,7 +705,7 @@ paths:
           schema:
             $ref: '#/definitions/Problem'
         '503':
-          description: Service (temporary) not available
+          description: Service (temporarily) unavailable
           schema:
             $ref: '#/definitions/Problem'
 
@@ -730,7 +730,7 @@ paths:
           schema:
             $ref: '#/definitions/Problem'
         '503':
-          description: Service (temporary) not available
+          description: Service (temporarily) unavailable
           schema:
             $ref: '#/definitions/Problem'
 
@@ -756,7 +756,7 @@ paths:
           schema:
             $ref: '#/definitions/Problem'
         '503':
-          description: Service (temporary) not available
+          description: Service (temporarily) unavailable
           schema:
             $ref: '#/definitions/Problem'
 

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -139,7 +139,7 @@ paths:
           schema:
             $ref: '#/definitions/Problem'
         '503':
-          description: Not available
+          description: Service (temporary) not available
           schema:
             $ref: '#/definitions/Problem'
   /event-types:
@@ -168,6 +168,10 @@ paths:
             $ref: '#/definitions/Problem'
         '500':
           description: Server error
+          schema:
+            $ref: '#/definitions/Problem'
+        '503':
+          description: Service (temporary) not available
           schema:
             $ref: '#/definitions/Problem'
 
@@ -246,6 +250,10 @@ paths:
           description: Server error
           schema:
             $ref: '#/definitions/Problem'
+        '503':
+          description: Service (temporary) not available
+          schema:
+            $ref: '#/definitions/Problem'
 
 
   /event-types/{name}:
@@ -282,6 +290,10 @@ paths:
             $ref: '#/definitions/Problem'
         '500':
           description: Server error
+          schema:
+            $ref: '#/definitions/Problem'
+        '503':
+          description: Service (temporary) not available
           schema:
             $ref: '#/definitions/Problem'
 
@@ -332,6 +344,10 @@ paths:
             $ref: '#/definitions/Problem'
         '500':
           description: Server error
+          schema:
+            $ref: '#/definitions/Problem'
+        '503':
+          description: Service (temporary) not available
           schema:
             $ref: '#/definitions/Problem'
 
@@ -411,6 +427,10 @@ paths:
             $ref: '#/definitions/Problem'
         '500':
           description: Server error
+          schema:
+            $ref: '#/definitions/Problem'
+        '503':
+          description: Service (temporary) not available
           schema:
             $ref: '#/definitions/Problem'
     get:
@@ -566,6 +586,10 @@ paths:
           description: Internal Server Error. Details are provided on the returned `Problem`.
           schema:
             $ref: '#/definitions/Problem'
+        '503':
+          description: Service (temporary) not available
+          schema:
+            $ref: '#/definitions/Problem'
 
   /event-types/{name}/partitions':
     get:
@@ -607,6 +631,10 @@ paths:
             $ref: '#/definitions/Problem'
         '500':
           description: Server error
+          schema:
+            $ref: '#/definitions/Problem'
+        '503':
+          description: Service (temporary) not available
           schema:
             $ref: '#/definitions/Problem'
 
@@ -651,6 +679,10 @@ paths:
           description: Server error
           schema:
             $ref: '#/definitions/Problem'
+        '503':
+          description: Service (temporary) not available
+          schema:
+            $ref: '#/definitions/Problem'
 
   '/registry/validation-strategies':
     get:
@@ -668,6 +700,14 @@ paths:
             type: array
             items:
               $ref: '#/definitions/EventValidationStrategy'
+        '500':
+          description: Server error
+          schema:
+            $ref: '#/definitions/Problem'
+        '503':
+          description: Service (temporary) not available
+          schema:
+            $ref: '#/definitions/Problem'
 
   '/registry/enrichment-strategies':
     get:
@@ -685,6 +725,14 @@ paths:
             type: array
             items:
               $ref: '#/definitions/EventEnrichmentStrategy'
+        '500':
+          description: Server error
+          schema:
+            $ref: '#/definitions/Problem'
+        '503':
+          description: Service (temporary) not available
+          schema:
+            $ref: '#/definitions/Problem'
 
 
   '/registry/partitioning-strategies':
@@ -703,6 +751,14 @@ paths:
             type: array
             items:
               $ref: '#/definitions/PartitionResolutionStrategy'
+        '500':
+          description: Server error
+          schema:
+            $ref: '#/definitions/Problem'
+        '503':
+          description: Service (temporary) not available
+          schema:
+            $ref: '#/definitions/Problem'
 
 
 # ################################### #


### PR DESCRIPTION
@v-stepanov @CyberDem0n @jkliff @rcillo Please review and discuss

All endpoints can (with low probability) respond with a 503 "Service Unavailable". This happens if an underlying service (e.g. Kafka, ZooKeeper, Postgres) is not working properly. A 503 is meant to emphasise that it is probably a temporary problem and not a misbehaviour in the application itself.

However it's still nothing that can be fixed on the client side.