### PR TITLE
Limit Traffic into the LB to HTTPS

### DIFF
--- a/senza.yaml
+++ b/senza.yaml
@@ -163,5 +163,5 @@ Resources:
       # https
       - IpProtocol: tcp
         FromPort: 443
-        ToPort: 8080
+        ToPort: 443
         CidrIp: "{{Arguments.LimitTrafficToCidr}}"


### PR DESCRIPTION
There is no reason why we should expose more than 443.

@v-stepanov @CyberDem0n @rcillo @jkliff Please review