### PR TITLE
Aruha 61 validate persistency of schemas

### DIFF
--- a/src/acceptance-test/java/de/zalando/aruha/nakadi/repository/db/EventTypeDbRepositoryTest.java
+++ b/src/acceptance-test/java/de/zalando/aruha/nakadi/repository/db/EventTypeDbRepositoryTest.java
@@ -71,8 +71,8 @@ public class EventTypeDbRepositoryTest {
 
         assertThat(persisted.getCategory(), equalTo(eventType.getCategory()));
         assertThat(persisted.getName(), equalTo(eventType.getName()));
-        assertThat(persisted.getEventTypeSchema().getType(), equalTo(eventType.getEventTypeSchema().getType()));
-        assertThat(persisted.getEventTypeSchema().getSchema(), equalTo(eventType.getEventTypeSchema().getSchema()));
+        assertThat(persisted.getSchema().getType(), equalTo(eventType.getSchema().getType()));
+        assertThat(persisted.getSchema().getSchema(), equalTo(eventType.getSchema().getSchema()));
     }
 
     @Test(expected = DuplicatedEventTypeNameException.class)
@@ -122,8 +122,8 @@ public class EventTypeDbRepositoryTest {
 
         assertThat(persisted.getCategory(), equalTo(eventType.getCategory()));
         assertThat(persisted.getName(), equalTo(eventType.getName()));
-        assertThat(persisted.getEventTypeSchema().getType(), equalTo(eventType.getEventTypeSchema().getType()));
-        assertThat(persisted.getEventTypeSchema().getSchema(), equalTo(eventType.getEventTypeSchema().getSchema()));
+        assertThat(persisted.getSchema().getType(), equalTo(eventType.getSchema().getType()));
+        assertThat(persisted.getSchema().getSchema(), equalTo(eventType.getSchema().getSchema()));
     }
 
     @Test
@@ -167,7 +167,7 @@ public class EventTypeDbRepositoryTest {
 
         eventType.setName("event-name");
         eventType.setCategory("event-category");
-        eventType.setEventTypeSchema(schema);
+        eventType.setSchema(schema);
 
         return eventType;
     }

--- a/src/acceptance-test/java/de/zalando/aruha/nakadi/webservice/EventTypeAT.java
+++ b/src/acceptance-test/java/de/zalando/aruha/nakadi/webservice/EventTypeAT.java
@@ -95,7 +95,7 @@ public class EventTypeAT extends BaseAT {
 
         eventType.setName(name);
         eventType.setCategory(name + "-category");
-        eventType.setEventTypeSchema(schema);
+        eventType.setSchema(schema);
 
         return eventType;
     }

--- a/src/main/java/de/zalando/aruha/nakadi/controller/EventTypeController.java
+++ b/src/main/java/de/zalando/aruha/nakadi/controller/EventTypeController.java
@@ -149,8 +149,8 @@ public class EventTypeController {
     }
 
     private void validateSchema(final EventType eventType, final EventType existingEventType, final Errors errors) {
-        if (!existingEventType.getEventTypeSchema().equals(eventType.getEventTypeSchema())) {
-            errors.rejectValue("eventTypeSchema", "", "The schema you've just submitted is different from the one in our system.");
+        if (!existingEventType.getSchema().equals(eventType.getSchema())) {
+            errors.rejectValue("schema", "", "The schema you've just submitted is different from the one in our system.");
         }
     }
 }

--- a/src/main/java/de/zalando/aruha/nakadi/domain/EventType.java
+++ b/src/main/java/de/zalando/aruha/nakadi/domain/EventType.java
@@ -24,10 +24,9 @@ public class EventType {
     @JsonIgnore
     private final List<ValidationStrategyConfiguration> validationStrategies = Lists.newArrayList();
 
-    @JsonProperty("schema")
     @NotNull
     @Valid
-    private EventTypeSchema eventTypeSchema;
+    private EventTypeSchema schema;
 
     public String getName() { return name; }
 
@@ -53,11 +52,11 @@ public class EventType {
         return validationStrategies;
     }
 
-    public EventTypeSchema getEventTypeSchema() {
-        return eventTypeSchema;
+    public EventTypeSchema getSchema() {
+        return schema;
     }
 
-    public void setEventTypeSchema(final EventTypeSchema eventTypeSchema) {
-        this.eventTypeSchema = eventTypeSchema;
+    public void setSchema(final EventTypeSchema schema) {
+        this.schema = schema;
     }
 }

--- a/src/main/java/de/zalando/aruha/nakadi/domain/EventType.java
+++ b/src/main/java/de/zalando/aruha/nakadi/domain/EventType.java
@@ -1,7 +1,6 @@
 package de.zalando.aruha.nakadi.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Lists;
 
 import javax.validation.Valid;

--- a/src/test/java/de/zalando/aruha/nakadi/controller/EventTypeControllerTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/controller/EventTypeControllerTest.java
@@ -278,6 +278,32 @@ public class EventTypeControllerTest {
 
     }
 
+    @Test
+    public void whenEventTypeSchemaJsonIsMalformedThen422() throws Exception {
+        EventType eventType = buildEventType();
+        eventType.getSchema().setSchema("invalid-json");
+
+        Problem expectedProblem = invalidProblem("schema.schema", "must be a valid json");
+
+        postEventType(eventType)
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect((content().string(matchesProblem(expectedProblem))));
+    }
+
+    @Test
+    public void invalidEventTypeSchemaJsonSchemaThen422() throws Exception {
+        EventType eventType = buildEventType();
+
+        final String jsonSchemaString = Resources.toString(Resources.getResource("sample-invalid-json-schema.json"), Charsets.UTF_8);
+        eventType.getSchema().setSchema(jsonSchemaString);
+
+        Problem expectedProblem = invalidProblem("schema.schema", "must be valid json-schema (http://json-schema.org)");
+
+        postEventType(eventType)
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect((content().string(matchesProblem(expectedProblem))));
+    }
+
     private ResultActions postEventType(EventType eventType) throws Exception {
         String content = objectMapper.writeValueAsString(eventType);
 

--- a/src/test/java/de/zalando/aruha/nakadi/controller/EventTypeControllerTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/controller/EventTypeControllerTest.java
@@ -2,6 +2,8 @@ package de.zalando.aruha.nakadi.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
 import de.zalando.aruha.nakadi.config.NakadiConfig;
 import de.zalando.aruha.nakadi.domain.EventType;
 import de.zalando.aruha.nakadi.domain.EventTypeSchema;
@@ -56,7 +58,7 @@ public class EventTypeControllerTest {
     private final ObjectMapper objectMapper = new NakadiConfig().jacksonObjectMapper();
     private final MockMvc mockMvc;
 
-    public EventTypeControllerTest() {
+    public EventTypeControllerTest() throws Exception {
         EventTypeController controller = new EventTypeController(eventTypeRepository, topicRepository);
 
         final MappingJackson2HttpMessageConverter jackson2HttpMessageConverter =
@@ -195,9 +197,9 @@ public class EventTypeControllerTest {
     public void whenPUTDifferentEventTypeSchemaThen422() throws Exception {
         EventType eventType = buildEventType();
         EventType persistedEventType = buildEventType();
-        persistedEventType.getEventTypeSchema().setSchema("different");
+        persistedEventType.getSchema().setSchema("different");
 
-        Problem expectedProblem = invalidProblem("eventTypeSchema",
+        Problem expectedProblem = invalidProblem("schema",
                 "The schema you've just submitted is different from the one in our system.");
 
         Mockito
@@ -334,7 +336,7 @@ public class EventTypeControllerTest {
 
         eventType.setName(EVENT_TYPE_NAME);
         eventType.setCategory(EVENT_TYPE_NAME + "-category");
-        eventType.setEventTypeSchema(schema);
+        eventType.setSchema(schema);
 
         return eventType;
     }

--- a/src/test/java/de/zalando/aruha/nakadi/validation/EventBodyMustRespectSchema.java
+++ b/src/test/java/de/zalando/aruha/nakadi/validation/EventBodyMustRespectSchema.java
@@ -37,7 +37,7 @@ public class EventBodyMustRespectSchema extends ValidationStrategy {
     public EventValidator materialize(final EventType eventType, final ValidationStrategyConfiguration vsc) {
 
         final JSONSchemaValidator defaultSchemaValidator = new JSONSchemaValidator(
-                new JSONObject(eventType.getEventTypeSchema().getSchema()));
+                new JSONObject(eventType.getSchema().getSchema()));
         if (vsc.getAdditionalConfiguration() == null) {
             return defaultSchemaValidator;
         }
@@ -46,7 +46,7 @@ public class EventBodyMustRespectSchema extends ValidationStrategy {
         mapper.registerModule(new JsonOrgModule());
 
         final Function<OverrideDefinition, OverrideDefinition> enhanceWithQualifiedSchema = definition -> {
-            final JSONObject schema = new JSONObject(eventType.getEventTypeSchema().getSchema());
+            final JSONObject schema = new JSONObject(eventType.getSchema().getSchema());
             final JSONObject copy = new JSONObject(schema, JSONObject.getNames(schema));
 
             definition.getIgnoredProperties().forEach(name -> {

--- a/src/test/java/de/zalando/aruha/nakadi/validation/JSONSchemaValidationTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/validation/JSONSchemaValidationTest.java
@@ -85,7 +85,7 @@ public class JSONSchemaValidationTest {
         final EventTypeSchema ets = new EventTypeSchema();
         ets.setType(Type.JSON_SCHEMA);
         ets.setSchema(schema.toString());
-        et.setEventTypeSchema(ets);
+        et.setSchema(ets);
 
         return et;
     }

--- a/src/test/resources/sample-invalid-json-schema.json
+++ b/src/test/resources/sample-invalid-json-schema.json
@@ -1,0 +1,10 @@
+{
+  "title": "Example Schema",
+  "type": "object",
+  "properties": {
+    "firstName": {
+      "type": "invalid-type"
+    }
+  },
+  "required": ["firstName"]
+}


### PR DESCRIPTION
In order to validate submitted events we need to make sure that each
`EventType` has a valid json-schema definition.

We are not to much strict on the schema data, e.g. if someone submits a
Swager definition, it should work just fine.

Examples of rejected schemas can be found in the added tests.

I also made a minor rename refactor in order to make it easier to compose error messages related to fields and to make our domain more similar to the API definition.