### PR TITLE
aruha-63 validate event schema on publish

### DIFF
--- a/src/acceptance-test/java/de/zalando/aruha/nakadi/webservice/UserJourneyAT.java
+++ b/src/acceptance-test/java/de/zalando/aruha/nakadi/webservice/UserJourneyAT.java
@@ -20,8 +20,8 @@ import static org.springframework.http.HttpStatus.OK;
 public class UserJourneyAT extends RealEnvironmentAT {
 
     private static final String TEST_EVENT_TYPE = randomString();
-    private static final String EVENT1 = "\"" + randomString() + "\"";
-    private static final String EVENT2 = "\"" + randomString() + "\"";
+    private static final String EVENT1 = "{\"foo\":\"" + randomString() + "\"}";
+    private static final String EVENT2 = "{\"foo\":\"" + randomString() + "\"}";
 
     private String eventTypeBody;
     private String eventTypeBodyUpdate;
@@ -53,7 +53,7 @@ public class UserJourneyAT extends RealEnvironmentAT {
                 .body("owning_application", equalTo("article-producer"))
                 .body("category", equalTo("data"))
                 .body("schema.type", equalTo("JSON_SCHEMA"))
-                .body("schema.schema", equalTo("{ \"Article\": { \"properties\": { \"sku\": { \"type\": \"string\" }}}}"));
+                .body("schema.schema", equalTo("{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}}, \"required\": [\"foo\"]}"));
 
         // list event types
         jsonRequestSpec()

--- a/src/main/java/de/zalando/aruha/nakadi/controller/EventPublishingController.java
+++ b/src/main/java/de/zalando/aruha/nakadi/controller/EventPublishingController.java
@@ -1,10 +1,18 @@
 package de.zalando.aruha.nakadi.controller;
 
 import com.codahale.metrics.annotation.Timed;
+import de.zalando.aruha.nakadi.domain.EventType;
+import de.zalando.aruha.nakadi.domain.ValidationStrategyConfiguration;
 import de.zalando.aruha.nakadi.exceptions.NakadiException;
 import de.zalando.aruha.nakadi.exceptions.NoSuchEventTypeException;
 import de.zalando.aruha.nakadi.repository.EventTypeRepository;
 import de.zalando.aruha.nakadi.repository.TopicRepository;
+import de.zalando.aruha.nakadi.validation.EventBodyMustRespectSchema;
+import de.zalando.aruha.nakadi.validation.EventValidator;
+import de.zalando.aruha.nakadi.validation.ValidationError;
+import de.zalando.aruha.nakadi.validation.ValidationStrategy;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -14,6 +22,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.NativeWebRequest;
+import org.zalando.problem.MoreStatus;
+import org.zalando.problem.Problem;
+
+import java.util.Optional;
 
 import static org.springframework.http.ResponseEntity.status;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
@@ -40,12 +52,19 @@ public class EventPublishingController {
         LOG.trace("Received event {} for event type {}", event, eventTypeName);
 
         try {
-            eventTypeRepository.findByName(eventTypeName);
+            EventType eventType = eventTypeRepository.findByName(eventTypeName);
 
-            // Will be replaced later:
-            final String partitionId = "1";
-            topicRepository.postEvent(eventTypeName, partitionId, event);
-            return status(HttpStatus.CREATED).build();
+            Optional<ValidationError> error = validateSchema(event, eventType);
+
+            if (error.isPresent()) {
+                Problem p = Problem.valueOf(MoreStatus.UNPROCESSABLE_ENTITY, error.get().getMessage());
+                return create(p, nativeWebRequest);
+            } else {
+                // Will be replaced later:
+                final String partitionId = "1";
+                topicRepository.postEvent(eventTypeName, partitionId, event);
+                return status(HttpStatus.CREATED).build();
+            }
         } catch (NoSuchEventTypeException e) {
             LOG.debug("Could not process event.", e);
             return create(e.asProblem(), nativeWebRequest);
@@ -55,4 +74,15 @@ public class EventPublishingController {
         }
     }
 
+    private Optional<ValidationError> validateSchema(@RequestBody String event, EventType eventType) {
+        try {
+            ValidationStrategy validationStrategy = new EventBodyMustRespectSchema();
+            ValidationStrategyConfiguration vsc = new ValidationStrategyConfiguration();
+            EventValidator validator = validationStrategy.materialize(eventType, vsc);
+            return validator.accepts(new JSONObject(event));
+        } catch (JSONException e) {
+            LOG.debug("Event parsing error.", e);
+            return Optional.of(new ValidationError("payload must be a valid json"));
+        }
+    }
 }

--- a/src/main/java/de/zalando/aruha/nakadi/controller/EventPublishingController.java
+++ b/src/main/java/de/zalando/aruha/nakadi/controller/EventPublishingController.java
@@ -52,12 +52,12 @@ public class EventPublishingController {
         LOG.trace("Received event {} for event type {}", event, eventTypeName);
 
         try {
-            EventType eventType = eventTypeRepository.findByName(eventTypeName);
+            final EventType eventType = eventTypeRepository.findByName(eventTypeName);
 
-            Optional<ValidationError> error = validateSchema(event, eventType);
+            final Optional<ValidationError> error = validateSchema(event, eventType);
 
             if (error.isPresent()) {
-                Problem p = Problem.valueOf(MoreStatus.UNPROCESSABLE_ENTITY, error.get().getMessage());
+                final Problem p = Problem.valueOf(MoreStatus.UNPROCESSABLE_ENTITY, error.get().getMessage());
                 return create(p, nativeWebRequest);
             } else {
                 // Will be replaced later:
@@ -74,11 +74,11 @@ public class EventPublishingController {
         }
     }
 
-    private Optional<ValidationError> validateSchema(@RequestBody String event, EventType eventType) {
+    private Optional<ValidationError> validateSchema(final String event, final EventType eventType) {
         try {
-            ValidationStrategy validationStrategy = new EventBodyMustRespectSchema();
-            ValidationStrategyConfiguration vsc = new ValidationStrategyConfiguration();
-            EventValidator validator = validationStrategy.materialize(eventType, vsc);
+            final ValidationStrategy validationStrategy = new EventBodyMustRespectSchema();
+            final ValidationStrategyConfiguration vsc = new ValidationStrategyConfiguration();
+            final EventValidator validator = validationStrategy.materialize(eventType, vsc);
             return validator.accepts(new JSONObject(event));
         } catch (JSONException e) {
             LOG.debug("Event parsing error.", e);

--- a/src/main/java/de/zalando/aruha/nakadi/controller/EventPublishingController.java
+++ b/src/main/java/de/zalando/aruha/nakadi/controller/EventPublishingController.java
@@ -38,6 +38,8 @@ public class EventPublishingController {
 
     private final TopicRepository topicRepository;
     private final EventTypeRepository eventTypeRepository;
+    private final ValidationStrategy validationStrategy = new EventBodyMustRespectSchema();
+    private final ValidationStrategyConfiguration vsc = new ValidationStrategyConfiguration();
 
     public EventPublishingController(final TopicRepository topicRepository,
             final EventTypeRepository eventTypeRepository) {
@@ -76,8 +78,6 @@ public class EventPublishingController {
 
     private Optional<ValidationError> validateSchema(final String event, final EventType eventType) {
         try {
-            final ValidationStrategy validationStrategy = new EventBodyMustRespectSchema();
-            final ValidationStrategyConfiguration vsc = new ValidationStrategyConfiguration();
             final EventValidator validator = validationStrategy.materialize(eventType, vsc);
             return validator.accepts(new JSONObject(event));
         } catch (JSONException e) {

--- a/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
@@ -57,9 +57,9 @@ class EventTypeValidator {
         return validators
                 .stream()
                 .map(validator -> validator.accepts(event))
-                .filter(errorOptional -> errorOptional.isPresent())
+                .filter(Optional::isPresent)
                 .findFirst()
-                .map(errorOptionalOptional -> errorOptionalOptional.get());
+                .orElse(Optional.empty());
     }
 
     public EventTypeValidator withConfiguration(final ValidationStrategyConfiguration vsc) {

--- a/src/test/resources/sample-event-type-update.json
+++ b/src/test/resources/sample-event-type-update.json
@@ -4,6 +4,6 @@
   "category": "new-data",
   "schema": {
     "type": "JSON_SCHEMA",
-    "schema": "{ \"Article\": { \"properties\": { \"sku\": { \"type\": \"string\" }}}}"
+    "schema": "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}}, \"required\": [\"foo\"]}"
   }
 }

--- a/src/test/resources/sample-event-type.json
+++ b/src/test/resources/sample-event-type.json
@@ -4,6 +4,6 @@
   "category": "data",
   "schema": {
     "type": "JSON_SCHEMA",
-    "schema": "{ \"Article\": { \"properties\": { \"sku\": { \"type\": \"string\" }}}}"
+    "schema": "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}}, \"required\": [\"foo\"]}"
   }
 }


### PR DESCRIPTION
The purpose of this PR is to provide the simplest implementation
possible to the validation of event schema. It's not focused on
performance, which should be addressed in a future ticket.