### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ services:
 
 before_script:
   - sudo /etc/init.d/postgresql stop
-  - pip install codecov
-  - curl http://www.jpm4j.org/install/script | sudo sh
-  - sudo jpm install com.codacy:codacy-coverage-reporter:assembly
+  - pip install --user codecov
+#  - curl http://www.jpm4j.org/install/script | sudo sh
+#  - sudo jpm install com.codacy:codacy-coverage-reporter:assembly
   
 
 # run tests
@@ -21,5 +21,5 @@ script:
 
 after_success:
   - codecov
-  - CODACY_PROJECT_TOKEN=3b80c14af47147a185d106c4666d4999 codacy-coverage-reporter -l Java -r build/reports/jacoco/test/jacocoTestReport.xml
+#  - CODACY_PROJECT_TOKEN=3b80c14af47147a185d106c4666d4999 codacy-coverage-reporter -l Java -r build/reports/jacoco/test/jacocoTestReport.xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 
 before_script:
   - sudo /etc/init.d/postgresql stop
-  - pip install --user codecov
+  - pip install codecov
   - curl http://www.jpm4j.org/install/script | sudo sh
   - sudo jpm install com.codacy:codacy-coverage-reporter:assembly
   


### PR DESCRIPTION
I temporarily disabled codacy as it fails the build. Seems that repo.jpm4j.org doesn't work.
Will turn it back when it's good.
@jkliff @tmuehl @rcillo @CyberDem0n please review