### PR TITLE
Fixes 138 Allow dots in event-type names

### DIFF
--- a/src/acceptance-test/java/de/zalando/aruha/nakadi/webservice/UserJourneyAT.java
+++ b/src/acceptance-test/java/de/zalando/aruha/nakadi/webservice/UserJourneyAT.java
@@ -9,6 +9,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import static com.jayway.restassured.http.ContentType.JSON;
 import static de.zalando.aruha.nakadi.utils.TestUtils.randomString;
@@ -19,7 +21,8 @@ import static org.springframework.http.HttpStatus.OK;
 
 public class UserJourneyAT extends RealEnvironmentAT {
 
-    private static final String TEST_EVENT_TYPE = "order.ORDER_CANCELLED";
+    private static final String TEST_EVENT_TYPE = "UserJourneyAT." + timeString();
+
     private static final String EVENT1 = "{\"foo\":\"" + randomString() + "\"}";
     private static final String EVENT2 = "{\"foo\":\"" + randomString() + "\"}";
 
@@ -147,4 +150,9 @@ public class UserJourneyAT extends RealEnvironmentAT {
         final String json = Resources.toString(Resources.getResource(resourceName), Charsets.UTF_8);
         return json.replace("NAME_PLACEHOLDER", TEST_EVENT_TYPE);
     }
+
+    private static String timeString() {
+        return DateTimeFormatter.ofPattern("yyyy_MM_dd_HH_mm_ss_SSS").format(LocalDateTime.now());
+    }
+
 }

--- a/src/acceptance-test/java/de/zalando/aruha/nakadi/webservice/UserJourneyAT.java
+++ b/src/acceptance-test/java/de/zalando/aruha/nakadi/webservice/UserJourneyAT.java
@@ -19,7 +19,7 @@ import static org.springframework.http.HttpStatus.OK;
 
 public class UserJourneyAT extends RealEnvironmentAT {
 
-    private static final String TEST_EVENT_TYPE = randomString();
+    private static final String TEST_EVENT_TYPE = "order.ORDER_CANCELLED";
     private static final String EVENT1 = "{\"foo\":\"" + randomString() + "\"}";
     private static final String EVENT2 = "{\"foo\":\"" + randomString() + "\"}";
 

--- a/src/main/java/de/zalando/aruha/nakadi/config/WebConfig.java
+++ b/src/main/java/de/zalando/aruha/nakadi/config/WebConfig.java
@@ -16,6 +16,7 @@ import org.springframework.http.converter.xml.SourceHttpMessageConverter;
 import org.springframework.web.context.request.async.TimeoutCallableProcessingInterceptor;
 import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 import java.util.List;
 
@@ -66,5 +67,12 @@ public class WebConfig extends WebMvcConfigurationSupport {
 
         converters.add(mappingJackson2HttpMessageConverter());
         super.configureMessageConverters(converters);
+    }
+
+    @Override
+    public RequestMappingHandlerMapping requestMappingHandlerMapping() {
+        final RequestMappingHandlerMapping handlerMapping = super.requestMappingHandlerMapping();
+        handlerMapping.setUseSuffixPatternMatch(false);
+        return handlerMapping;
     }
 }


### PR DESCRIPTION
Disables suffix detection by Spring, e.g. ".htm", ".xml" or ".json". Hence, content-type negotiation via file type suffix isn't possible anymore. On the other hand, it's now possible to have `PathVariable`s containing a dot.