### PR TITLE
aruha-104 validator cache

### DIFF
--- a/src/acceptance-test/java/de/zalando/aruha/nakadi/repository/db/EventTypeCacheTest.java
+++ b/src/acceptance-test/java/de/zalando/aruha/nakadi/repository/db/EventTypeCacheTest.java
@@ -105,8 +105,8 @@ public class EventTypeCacheTest {
                 .when(dbRepo)
                 .findByName(et.getName());
 
-        assertThat(etc.get(et.getName()), equalTo(et));
-        assertThat(etc.get(et.getName()), equalTo(et));
+        assertThat(etc.getEventType(et.getName()), equalTo(et));
+        assertThat(etc.getEventType(et.getName()), equalTo(et));
 
         verify(dbRepo, times(1)).findByName(et.getName());
     }
@@ -123,16 +123,14 @@ public class EventTypeCacheTest {
                 .findByName(et.getName());
 
         etc.created(et);
-        etc.get(et.getName());
+        etc.getEventType(et.getName());
         etc.updated(et.getName());
 
         executeWithRetry(() -> {
                     try {
-                        etc.get(et.getName());
+                        etc.getEventType(et.getName());
                         verify(dbRepo, times(2)).findByName(et.getName());
                     } catch (NoSuchEventTypeException e) {
-                        fail();
-                    } catch (ExecutionException e) {
                         fail();
                     } catch (Exception e) {
                         fail();

--- a/src/main/java/de/zalando/aruha/nakadi/config/NakadiConfig.java
+++ b/src/main/java/de/zalando/aruha/nakadi/config/NakadiConfig.java
@@ -9,6 +9,7 @@ import de.zalando.aruha.nakadi.controller.EventStreamController;
 import de.zalando.aruha.nakadi.controller.PartitionsController;
 import de.zalando.aruha.nakadi.repository.EventTypeRepository;
 import de.zalando.aruha.nakadi.repository.TopicRepository;
+import de.zalando.aruha.nakadi.repository.db.EventTypeCache;
 import de.zalando.aruha.nakadi.service.EventStreamFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.ServletRegistrationBean;
@@ -33,6 +34,9 @@ public class NakadiConfig {
 
     @Autowired
     private EventTypeRepository eventTypeRepository;
+
+    @Autowired
+    private EventTypeCache eventTypeCache;
 
     @Bean
     public TaskExecutor taskExecutor() {
@@ -72,9 +76,7 @@ public class NakadiConfig {
 
     @Bean
     public EventPublishingController eventPublishingController() {
-        return new EventPublishingController(topicRepository,
-                eventTypeRepository
-        );
+        return new EventPublishingController(topicRepository, eventTypeRepository, eventTypeCache);
     }
 
 }

--- a/src/main/java/de/zalando/aruha/nakadi/config/RepositoriesConfig.java
+++ b/src/main/java/de/zalando/aruha/nakadi/config/RepositoriesConfig.java
@@ -45,7 +45,7 @@ public class RepositoriesConfig {
 
         client.start();
 
-        EventBodyMustRespectSchema strategy = new EventBodyMustRespectSchema();
+        final EventBodyMustRespectSchema strategy = new EventBodyMustRespectSchema();
         ValidationStrategy.register(EventBodyMustRespectSchema.NAME, strategy);
 
         return new EventTypeCache(dbRepo(), client);

--- a/src/main/java/de/zalando/aruha/nakadi/controller/EventPublishingController.java
+++ b/src/main/java/de/zalando/aruha/nakadi/controller/EventPublishingController.java
@@ -2,8 +2,8 @@ package de.zalando.aruha.nakadi.controller;
 
 import com.codahale.metrics.annotation.Timed;
 import de.zalando.aruha.nakadi.domain.EventType;
-import de.zalando.aruha.nakadi.domain.ValidationStrategyConfiguration;
 import de.zalando.aruha.nakadi.exceptions.EventValidationException;
+import de.zalando.aruha.nakadi.exceptions.InternalNakadiException;
 import de.zalando.aruha.nakadi.exceptions.InvalidOrderingKeyFieldsException;
 import de.zalando.aruha.nakadi.exceptions.NakadiException;
 import de.zalando.aruha.nakadi.exceptions.NoSuchEventTypeException;
@@ -11,10 +11,9 @@ import de.zalando.aruha.nakadi.partitioning.OrderingKeyFieldsPartitioningStrateg
 import de.zalando.aruha.nakadi.partitioning.PartitioningStrategy;
 import de.zalando.aruha.nakadi.repository.EventTypeRepository;
 import de.zalando.aruha.nakadi.repository.TopicRepository;
-import de.zalando.aruha.nakadi.validation.EventBodyMustRespectSchema;
-import de.zalando.aruha.nakadi.validation.EventValidator;
+import de.zalando.aruha.nakadi.repository.db.EventTypeCache;
+import de.zalando.aruha.nakadi.validation.EventTypeValidator;
 import de.zalando.aruha.nakadi.validation.ValidationError;
-import de.zalando.aruha.nakadi.validation.ValidationStrategy;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -29,6 +28,7 @@ import org.springframework.web.context.request.NativeWebRequest;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 
 import static org.springframework.http.ResponseEntity.status;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
@@ -41,14 +41,15 @@ public class EventPublishingController {
 
     private final TopicRepository topicRepository;
     private final EventTypeRepository eventTypeRepository;
+    private final EventTypeCache cache;
     private final PartitioningStrategy orderingKeyFieldsPartitioningStrategy = new OrderingKeyFieldsPartitioningStrategy();
-    private final ValidationStrategy validationStrategy = new EventBodyMustRespectSchema();
-    private final ValidationStrategyConfiguration vsc = new ValidationStrategyConfiguration();
 
     public EventPublishingController(final TopicRepository topicRepository,
-                                     final EventTypeRepository eventTypeRepository) {
+                                     final EventTypeRepository eventTypeRepository,
+                                     final EventTypeCache cache) {
         this.topicRepository = topicRepository;
         this.eventTypeRepository = eventTypeRepository;
+        this.cache = cache;
     }
 
     @Timed(name = "post_events", absolute = true)
@@ -93,11 +94,17 @@ public class EventPublishingController {
         return partitionId;
     }
 
-    private void validateSchema(final JSONObject event, final EventType eventType) throws EventValidationException {
-        final EventValidator validator = validationStrategy.materialize(eventType, vsc);
-        final Optional<ValidationError> validationError = validator.accepts(event);
-        if (validationError.isPresent()) {
-            throw new EventValidationException(validationError.get());
+    private void validateSchema(final JSONObject event, final EventType eventType) throws EventValidationException, InternalNakadiException {
+        try {
+            final EventTypeValidator validator = cache.getValidator(eventType.getName());
+            final Optional<ValidationError> validationError = validator.validate(event);
+
+            if (validationError.isPresent()) {
+                throw new EventValidationException(validationError.get());
+            }
+        } catch (ExecutionException e) {
+            LOG.error("Error loading validator", e);
+            throw new InternalNakadiException("Error loading validator", e);
         }
     }
 

--- a/src/main/java/de/zalando/aruha/nakadi/repository/EventTypeRepository.java
+++ b/src/main/java/de/zalando/aruha/nakadi/repository/EventTypeRepository.java
@@ -3,6 +3,7 @@ package de.zalando.aruha.nakadi.repository;
 import de.zalando.aruha.nakadi.domain.EventType;
 import de.zalando.aruha.nakadi.exceptions.InternalNakadiException;
 import de.zalando.aruha.nakadi.exceptions.NoSuchEventTypeException;
+import de.zalando.aruha.nakadi.validation.EventTypeValidator;
 
 import java.util.List;
 

--- a/src/main/java/de/zalando/aruha/nakadi/repository/db/EventTypeCache.java
+++ b/src/main/java/de/zalando/aruha/nakadi/repository/db/EventTypeCache.java
@@ -92,7 +92,9 @@ public class EventTypeCache {
         }
     }
 
-    private void addCacheChangeListener(final LoadingCache<String, EventType> eventTypeCache, LoadingCache<String, EventTypeValidator> validatorCache, final PathChildrenCache cacheSync) {
+    private void addCacheChangeListener(final LoadingCache<String, EventType> eventTypeCache,
+                                        final LoadingCache<String, EventTypeValidator> validatorCache,
+                                        final PathChildrenCache cacheSync) {
         final PathChildrenCacheListener listener = new PathChildrenCacheListener() {
             @Override
             public void childEvent(final CuratorFramework client, final PathChildrenCacheEvent event) throws Exception {
@@ -125,7 +127,7 @@ public class EventTypeCache {
         return cacheSync;
     }
 
-    private LoadingCache<String, EventTypeValidator> setupInMemoryValidatorCache(LoadingCache<String, EventType> eventTypeCache) {
+    private LoadingCache<String, EventTypeValidator> setupInMemoryValidatorCache(final LoadingCache<String, EventType> eventTypeCache) {
         final CacheLoader<String, EventTypeValidator> loader = new CacheLoader<String, EventTypeValidator>() {
             public EventTypeValidator load(final String key) throws Exception {
                 final EventType et = eventTypeCache.get(key);

--- a/src/main/java/de/zalando/aruha/nakadi/repository/db/EventTypeCachedRepository.java
+++ b/src/main/java/de/zalando/aruha/nakadi/repository/db/EventTypeCachedRepository.java
@@ -44,12 +44,7 @@ public class EventTypeCachedRepository implements EventTypeRepository {
 
     @Override
     public EventType findByName(final String name) throws InternalNakadiException, NoSuchEventTypeException {
-        try {
-            return cache.get(name);
-        } catch (ExecutionException e) {
-            LOG.error("Failed to load event type from cache '" + name + "'", e);
-            throw new InternalNakadiException("Failed to load event type", e);
-        }
+        return cache.getEventType(name);
     }
 
     @Override

--- a/src/main/java/de/zalando/aruha/nakadi/validation/EventTypeValidator.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/EventTypeValidator.java
@@ -1,0 +1,36 @@
+package de.zalando.aruha.nakadi.validation;
+
+import com.google.common.collect.Lists;
+import de.zalando.aruha.nakadi.domain.EventType;
+import de.zalando.aruha.nakadi.domain.ValidationStrategyConfiguration;
+import org.json.JSONObject;
+
+import java.util.List;
+import java.util.Optional;
+
+public class EventTypeValidator {
+
+    private final EventType eventType;
+    private final List<EventValidator> validators = Lists.newArrayList();
+
+    public EventTypeValidator(final EventType eventType) {
+        this.eventType = eventType;
+    }
+
+    public Optional<ValidationError> validate(final JSONObject event) {
+        return validators
+                .stream()
+                .map(validator -> validator.accepts(event))
+                .filter(Optional::isPresent)
+                .findFirst()
+                .orElse(Optional.empty());
+    }
+
+    public EventTypeValidator withConfiguration(final ValidationStrategyConfiguration vsc) {
+        final ValidationStrategy vs = ValidationStrategy.lookup(vsc.getStrategyName());
+        validators.add(vs.materialize(eventType, vsc));
+
+        return this;
+    }
+
+}

--- a/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
@@ -1,17 +1,10 @@
 package de.zalando.aruha.nakadi.validation;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import org.json.JSONObject;
-
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-
 import de.zalando.aruha.nakadi.domain.EventType;
-import de.zalando.aruha.nakadi.domain.ValidationStrategyConfiguration;
+
+import java.util.Map;
 
 public class EventValidation {
 
@@ -44,29 +37,3 @@ public class EventValidation {
     }
 }
 
-class EventTypeValidator {
-
-    private final EventType eventType;
-    private final List<EventValidator> validators = Lists.newArrayList();
-
-    public EventTypeValidator(final EventType eventType) {
-        this.eventType = eventType;
-    }
-
-    public Optional<ValidationError> validate(final JSONObject event) {
-        return validators
-                .stream()
-                .map(validator -> validator.accepts(event))
-                .filter(Optional::isPresent)
-                .findFirst()
-                .orElse(Optional.empty());
-    }
-
-    public EventTypeValidator withConfiguration(final ValidationStrategyConfiguration vsc) {
-        final ValidationStrategy vs = ValidationStrategy.lookup(vsc.getStrategyName());
-        validators.add(vs.materialize(eventType, vsc));
-
-        return this;
-    }
-
-}

--- a/src/test/java/de/zalando/aruha/nakadi/controller/EventPublishingControllerTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/controller/EventPublishingControllerTest.java
@@ -8,7 +8,9 @@ import de.zalando.aruha.nakadi.exceptions.NakadiException;
 import de.zalando.aruha.nakadi.repository.EventTypeRepository;
 import de.zalando.aruha.nakadi.repository.InMemoryEventTypeRepository;
 import de.zalando.aruha.nakadi.repository.InMemoryTopicRepository;
+import de.zalando.aruha.nakadi.repository.db.EventTypeCache;
 import de.zalando.aruha.nakadi.utils.JsonTestHelper;
+import de.zalando.aruha.nakadi.validation.EventTypeValidator;
 import org.junit.Test;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -25,6 +27,7 @@ import java.util.LinkedList;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -57,7 +60,9 @@ public class EventPublishingControllerTest {
         eventTypeRepository.saveEventType(eventType(EVENT_TYPE_WITH_TOPIC));
         eventTypeRepository.saveEventType(eventType(EVENT_TYPE_WITHOUT_TOPIC));
 
-        final EventPublishingController controller = new EventPublishingController(topicRepository, eventTypeRepository);
+        final EventTypeCache cache = mock(EventTypeCache.class);
+
+        final EventPublishingController controller = new EventPublishingController(topicRepository, eventTypeRepository, cache);
 
         final MappingJackson2HttpMessageConverter jackson2HttpMessageConverter = new MappingJackson2HttpMessageConverter(objectMapper);
         mockMvc = standaloneSetup(controller)

--- a/src/test/java/de/zalando/aruha/nakadi/controller/EventPublishingControllerTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/controller/EventPublishingControllerTest.java
@@ -11,7 +11,9 @@ import de.zalando.aruha.nakadi.repository.InMemoryTopicRepository;
 import de.zalando.aruha.nakadi.repository.db.EventTypeCache;
 import de.zalando.aruha.nakadi.utils.JsonTestHelper;
 import de.zalando.aruha.nakadi.validation.EventTypeValidator;
+import de.zalando.aruha.nakadi.validation.ValidationError;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
@@ -23,10 +25,14 @@ import org.zalando.problem.ThrowableProblem;
 
 import javax.ws.rs.core.Response;
 import java.util.LinkedList;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -45,12 +51,14 @@ public class EventPublishingControllerTest {
     public static final String INVALID_JSON_EVENT = "not-a-json";
     public static final String[] PARTITIONS = new String[]{"0", "1", "2", "3", "4", "5", "6", "7"};
 
+    private final EventTypeCache cache;
+    private final EventTypeValidator validator;
     private final InMemoryTopicRepository topicRepository = new InMemoryTopicRepository();
     private final JsonTestHelper jsonHelper;
 
     private final MockMvc mockMvc;
 
-    public EventPublishingControllerTest() throws NakadiException {
+    public EventPublishingControllerTest() throws NakadiException, ExecutionException {
         final ObjectMapper objectMapper = new JsonConfig().jacksonObjectMapper();
 
         jsonHelper = new JsonTestHelper(objectMapper);
@@ -60,7 +68,13 @@ public class EventPublishingControllerTest {
         eventTypeRepository.saveEventType(eventType(EVENT_TYPE_WITH_TOPIC));
         eventTypeRepository.saveEventType(eventType(EVENT_TYPE_WITHOUT_TOPIC));
 
-        final EventTypeCache cache = mock(EventTypeCache.class);
+        cache = mock(EventTypeCache.class);
+        validator = mock(EventTypeValidator.class);
+
+        Mockito
+                .doReturn(validator)
+                .when(cache)
+                .getValidator(anyString());
 
         final EventPublishingController controller = new EventPublishingController(topicRepository, eventTypeRepository, cache);
 
@@ -72,6 +86,11 @@ public class EventPublishingControllerTest {
 
     @Test
     public void canPostEventsToTopic() throws Exception {
+        Mockito
+                .doReturn(Optional.empty())
+                .when(validator)
+                .validate(any());
+
         postEvent(EVENT_TYPE_WITH_TOPIC, EVENT1);
         postEvent(EVENT_TYPE_WITH_TOPIC, EVENT2);
         postEvent(EVENT_TYPE_WITH_TOPIC, EVENT3);
@@ -87,12 +106,22 @@ public class EventPublishingControllerTest {
 
     @Test
     public void returns2xxForValidPost() throws Exception {
+        Mockito
+                .doReturn(Optional.empty())
+                .when(validator)
+                .validate(any());
+
         postEvent(EVENT_TYPE_WITH_TOPIC, EVENT1).andExpect(status().is2xxSuccessful());
     }
 
     @Test
     public void returns5xxProblemIfTopicDoesNotExistForEventType() throws Exception  {
         final ThrowableProblem expectedProblem = Problem.valueOf(Response.Status.INTERNAL_SERVER_ERROR, "No such topic 'registered-but-without-topic'");
+
+        Mockito
+                .doReturn(Optional.empty())
+                .when(validator)
+                .validate(any());
 
         postEvent(EVENT_TYPE_WITHOUT_TOPIC, EVENT1)
                 .andExpect(status().is5xxServerError())
@@ -113,6 +142,11 @@ public class EventPublishingControllerTest {
     @Test
     public void returns422ProblemWhenEventSchemaIsInvalid() throws Exception  {
         final ThrowableProblem expectedProblem = Problem.valueOf(MoreStatus.UNPROCESSABLE_ENTITY, "#: required key [payload] not found");
+
+        Mockito
+                .doReturn(Optional.of(new ValidationError("#: required key [payload] not found")))
+                .when(validator)
+                .validate(any());
 
         postEvent(EVENT_TYPE_WITH_TOPIC, INVALID_SCHEMA_EVENT)
                 .andExpect(status().isUnprocessableEntity())


### PR DESCRIPTION
Caching the event type validator spares some CPU since its assembly is
CPU intensive.

Once event type and its validator is cached, we achieved a speedup of
2.2x, pushing time per request as low as 14ms, locally.

## After Validator caching

$ ab -p event.json -T application/json -c 10 -n 10000 http://localhost:8080/event-types/NAME_PLACEHOLDER/events
This is ApacheBench, Version 2.3 <$Revision: 1604373 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient)
Completed 1000 requests
Completed 2000 requests
Completed 3000 requests
Completed 4000 requests
Completed 5000 requests
Completed 6000 requests
Completed 7000 requests
Completed 8000 requests
Completed 9000 requests
Completed 10000 requests
Finished 10000 requests


Server Software:        Apache-Coyote/1.1
Server Hostname:        localhost
Server Port:            8080

Document Path:          /event-types/NAME_PLACEHOLDER/events
Document Length:        0 bytes

Concurrency Level:      10
Time taken for tests:   14.445 seconds
Complete requests:      10000
Failed requests:        0
Total transferred:      3450000 bytes
Total body sent:        1890000
HTML transferred:       0 bytes
Requests per second:    692.29 [#/sec] (mean)
Time per request:       14.445 [ms] (mean)
Time per request:       1.444 [ms] (mean, across all concurrent requests)
Transfer rate:          233.24 [Kbytes/sec] received
                        127.78 kb/s sent
                        361.02 kb/s total

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    3   2.4      3      14
Processing:     3   10   2.7     10      30
Waiting:        3    9   2.7      9      29
Total:          4   14   3.8     13      32

Percentage of the requests served within a certain time (ms)
  50%     13
  66%     15
  75%     16
  80%     17
  90%     19
  95%     21
  98%     22
  99%     24
 100%     32 (longest request)
