### PR TITLE
This unchecked cast causes a warning

### DIFF
--- a/src/main/java/de/zalando/aruha/nakadi/config/JsonConfig.java
+++ b/src/main/java/de/zalando/aruha/nakadi/config/JsonConfig.java
@@ -71,6 +71,7 @@ public class JsonConfig {
 
         @Override
         public Enum deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+            @SuppressWarnings("unchecked")
             Class<? extends Enum> rawClass = (Class<Enum<?>>) type.getRawClass();
             return Enum.valueOf(rawClass, jp.getValueAsString().toUpperCase());
         }


### PR DESCRIPTION
...that breaks the build if the compiler is configured to be restrictive.

@v-stepanov @CyberDem0n @rcillo @jkliff Please review

Any better suggestion to get rid of that warning?