### PR TITLE
Aruha 108 category aware validation

### DIFF
--- a/src/acceptance-test/java/de/zalando/aruha/nakadi/webservice/UserJourneyAT.java
+++ b/src/acceptance-test/java/de/zalando/aruha/nakadi/webservice/UserJourneyAT.java
@@ -57,7 +57,7 @@ public class UserJourneyAT extends RealEnvironmentAT {
                 .and()
                 .body("name", equalTo(TEST_EVENT_TYPE))
                 .body("owning_application", equalTo("article-producer"))
-                .body("category", equalTo("data"))
+                .body("category", equalTo("undefined"))
                 .body("schema.type", equalTo("json_schema"))
                 .body("schema.schema", equalTo("{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}}, \"required\": [\"foo\"]}"));
 
@@ -92,8 +92,7 @@ public class UserJourneyAT extends RealEnvironmentAT {
                             .then()
                             .statusCode(OK.value())
                             .and()
-                            .body("owning_application", equalTo("my-app"))
-                            .body("category", equalTo("business"));
+                            .body("owning_application", equalTo("my-app"));
                 },
                 new RetryForSpecifiedTimeStrategy<Void>(5000).withExceptionsThatForceRetry(AssertionError.class)
                         .withWaitBetweenEachTry(500));

--- a/src/main/java/de/zalando/aruha/nakadi/config/RepositoriesConfig.java
+++ b/src/main/java/de/zalando/aruha/nakadi/config/RepositoriesConfig.java
@@ -6,7 +6,6 @@ import de.zalando.aruha.nakadi.repository.db.EventTypeCache;
 import de.zalando.aruha.nakadi.repository.db.EventTypeDbRepository;
 import de.zalando.aruha.nakadi.repository.kafka.KafkaConfig;
 import de.zalando.aruha.nakadi.repository.zookeeper.ZookeeperConfig;
-
 import de.zalando.aruha.nakadi.validation.EventBodyMustRespectSchema;
 import de.zalando.aruha.nakadi.validation.ValidationStrategy;
 import org.apache.curator.framework.CuratorFramework;
@@ -42,6 +41,8 @@ public class RepositoriesConfig {
 
         final EventBodyMustRespectSchema strategy = new EventBodyMustRespectSchema();
         ValidationStrategy.register(EventBodyMustRespectSchema.NAME, strategy);
+
+        // TODO register metadata validation
 
         return new EventTypeCache(dbRepo(), client);
     }

--- a/src/main/java/de/zalando/aruha/nakadi/repository/db/EventTypeCache.java
+++ b/src/main/java/de/zalando/aruha/nakadi/repository/db/EventTypeCache.java
@@ -10,6 +10,7 @@ import de.zalando.aruha.nakadi.exceptions.NoSuchEventTypeException;
 import de.zalando.aruha.nakadi.repository.EventTypeRepository;
 import de.zalando.aruha.nakadi.validation.EventBodyMustRespectSchema;
 import de.zalando.aruha.nakadi.validation.EventTypeValidator;
+import de.zalando.aruha.nakadi.validation.EventValidation;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
@@ -131,10 +132,7 @@ public class EventTypeCache {
         final CacheLoader<String, EventTypeValidator> loader = new CacheLoader<String, EventTypeValidator>() {
             public EventTypeValidator load(final String key) throws Exception {
                 final EventType et = eventTypeCache.get(key);
-                final EventTypeValidator etv = new EventTypeValidator(et);
-                final ValidationStrategyConfiguration vsc = new ValidationStrategyConfiguration();
-                vsc.setStrategyName(EventBodyMustRespectSchema.NAME);
-                return etv.withConfiguration(vsc);
+                return EventValidation.forType(et);
             }
         };
 

--- a/src/main/java/de/zalando/aruha/nakadi/validation/EventBodyMustRespectSchema.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/EventBodyMustRespectSchema.java
@@ -31,7 +31,7 @@ public class EventBodyMustRespectSchema extends ValidationStrategy {
     @Override
     public EventValidator materialize(final EventType eventType, final ValidationStrategyConfiguration vsc) {
 
-        JSONObject effectiveSchema = EventValidation.effectiveSchema(eventType);
+        final JSONObject effectiveSchema = EventValidation.effectiveSchema(eventType);
 
         final JSONSchemaValidator defaultSchemaValidator = new JSONSchemaValidator(effectiveSchema);
 

--- a/src/main/java/de/zalando/aruha/nakadi/validation/EventBodyMustRespectSchema.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/EventBodyMustRespectSchema.java
@@ -31,8 +31,10 @@ public class EventBodyMustRespectSchema extends ValidationStrategy {
     @Override
     public EventValidator materialize(final EventType eventType, final ValidationStrategyConfiguration vsc) {
 
-        final JSONSchemaValidator defaultSchemaValidator = new JSONSchemaValidator(
-                new JSONObject(eventType.getSchema().getSchema()));
+        JSONObject effectiveSchema = EventValidation.effectiveSchema(eventType);
+
+        final JSONSchemaValidator defaultSchemaValidator = new JSONSchemaValidator(effectiveSchema);
+
         if (vsc.getAdditionalConfiguration() == null) {
             return defaultSchemaValidator;
         }
@@ -151,10 +153,8 @@ class JSONSchemaValidator implements EventValidator {
     private static final Logger LOG = LoggerFactory.getLogger(JSONSchemaValidator.class);
 
     private final Schema schema;
-    private final JSONObject effectiveSchema;
 
     public JSONSchemaValidator(final JSONObject effectiveSchema) {
-        this.effectiveSchema = effectiveSchema;
         schema = SchemaLoader.load(effectiveSchema);
     }
 

--- a/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
@@ -36,11 +36,15 @@ public class EventValidation {
 
         normalizeSchema(wrapper);
 
+        addMetadata(wrapper);
+
         wrapper.getJSONObject("properties").put("data_type", new JSONObject("{\"type\": \"string\"}"));
 
         wrapper.getJSONObject("properties").put("data_op", new JSONObject("{\"type\": \"string\", \"enum\": [\"C\", \"U\", \"D\", \"S\"]}"));
 
         wrapper.getJSONObject("properties").put("data", schema);
+
+        wrapper.put("additionalProperties", false);
 
         addToRequired(wrapper, new String[]{ "data_type", "data_op", "data" });
 

--- a/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
@@ -1,8 +1,13 @@
 package de.zalando.aruha.nakadi.validation;
 
 import de.zalando.aruha.nakadi.domain.EventType;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 
 public class EventValidation {
     public static EventTypeValidator forType(final EventType eventType) {
@@ -10,7 +15,41 @@ public class EventValidation {
     }
 
     public static JSONObject effectiveSchema(EventType eventType) throws JSONException {
-        return new JSONObject(eventType.getSchema().getSchema());
+        final JSONObject schema = new JSONObject(eventType.getSchema().getSchema());
+
+        switch (eventType.getCategory()) {
+            case BUSINESS: {
+                return addMetadata(schema);
+            }
+            default: return schema;
+        }
+    }
+
+    private static JSONObject addMetadata(JSONObject schema) {
+        final JSONObject metadata = new JSONObject("{\"type\": \"object\"}");
+        schema.put("type", "object");
+
+        if (!schema.has("properties")) {
+            schema.put("properties", new HashMap());
+        }
+
+        if (!schema.has("required")) {
+            schema.put("required", new JSONArray());
+        }
+
+        schema.getJSONObject("properties").put("metadata", metadata);
+
+        Set required = new HashSet<String>();
+
+        for(int i = 0; i < schema.getJSONArray("required").length(); i++) {
+            required.add(schema.getJSONArray("required").get(i));
+        }
+
+        required.add("metadata");
+
+        schema.put("required", required);
+
+        return schema;
     }
 }
 

--- a/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
@@ -1,39 +1,10 @@
 package de.zalando.aruha.nakadi.validation;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
 import de.zalando.aruha.nakadi.domain.EventType;
 
-import java.util.Map;
-
 public class EventValidation {
-
-    private static final Map<String, EventTypeValidator> eventTypeValidators = Maps.newConcurrentMap();
-
     public static EventTypeValidator forType(final EventType eventType) {
-        return forType(eventType, false);
-    }
-
-    public static EventTypeValidator forType(final EventType eventType, final boolean incrementalEdit) {
-
-        final boolean contains = eventTypeValidators.containsKey(eventType.getName());
-        Preconditions.checkState(incrementalEdit || !contains, "Validator for EventType {} already defined",
-            eventType.getName());
-
-        if (!contains) {
-            final EventTypeValidator etsv = new EventTypeValidator(eventType);
-            eventTypeValidators.put(eventType.getName(), etsv);
-        }
-
-        return eventTypeValidators.get(eventType.getName());
-    }
-
-    public static EventTypeValidator lookup(final EventType eventType) {
-        return eventTypeValidators.get(eventType.getName());
-    }
-
-    public static void reset() {
-        eventTypeValidators.clear();
+        return new EventTypeValidator(eventType);
     }
 }
 

--- a/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
@@ -53,8 +53,10 @@ public class EventValidation {
     private static void addToRequired(final JSONObject schema, final String[] toBeRequired) {
         final Set<String> required = new HashSet<>(Arrays.asList(toBeRequired));
 
-        for(int i = 0; i < schema.getJSONArray("required").length(); i++) {
-            required.add(schema.getJSONArray("required").getString(i));
+        JSONArray currentRequired = schema.getJSONArray("required");
+
+        for(int i = 0; i < currentRequired.length(); i++) {
+            required.add(currentRequired.getString(i));
         }
 
         schema.put("required", required);

--- a/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
@@ -1,10 +1,16 @@
 package de.zalando.aruha.nakadi.validation;
 
 import de.zalando.aruha.nakadi.domain.EventType;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 public class EventValidation {
     public static EventTypeValidator forType(final EventType eventType) {
         return new EventTypeValidator(eventType);
+    }
+
+    public static JSONObject effectiveSchema(EventType eventType) throws JSONException {
+        return new JSONObject(eventType.getSchema().getSchema());
     }
 }
 

--- a/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
@@ -1,6 +1,7 @@
 package de.zalando.aruha.nakadi.validation;
 
 import de.zalando.aruha.nakadi.domain.EventType;
+import de.zalando.aruha.nakadi.domain.ValidationStrategyConfiguration;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -11,7 +12,13 @@ import java.util.Set;
 
 public class EventValidation {
     public static EventTypeValidator forType(final EventType eventType) {
-        return new EventTypeValidator(eventType);
+        final EventTypeValidator etv = new EventTypeValidator(eventType);
+        final ValidationStrategyConfiguration vsc = new ValidationStrategyConfiguration();
+        vsc.setStrategyName(EventBodyMustRespectSchema.NAME);
+
+        // TODO configure metadata validation on a per EventCategory basis
+
+        return etv.withConfiguration(vsc);
     }
 
     public static JSONObject effectiveSchema(final EventType eventType) throws JSONException {

--- a/src/main/java/de/zalando/aruha/nakadi/validation/ValidationStrategy.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/ValidationStrategy.java
@@ -1,12 +1,11 @@
 package de.zalando.aruha.nakadi.validation;
 
-import java.util.Map;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
-
 import de.zalando.aruha.nakadi.domain.EventType;
 import de.zalando.aruha.nakadi.domain.ValidationStrategyConfiguration;
+
+import java.util.Map;
 
 public abstract class ValidationStrategy {
 

--- a/src/test/java/de/zalando/aruha/nakadi/controller/EventTypeControllerTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/controller/EventTypeControllerTest.java
@@ -34,6 +34,7 @@ import uk.co.datumedge.hamcrest.json.SameJSONAs;
 import javax.ws.rs.core.Response;
 import java.util.Arrays;
 
+import static de.zalando.aruha.nakadi.domain.EventCategory.BUSINESS;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -105,6 +106,21 @@ public class EventTypeControllerTest {
 
         final String eventType = "{\"category\": \"data\", \"owning_application\": \"blah-app\", " +
                 "\"name\": \"blah-event-type\", \"schema\": { \"type\": \"JSON_SCHEMA\" }}";
+
+        postEventType(eventType)
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(content().contentType("application/problem+json"))
+                .andExpect(content().string(matchesProblem(expectedProblem)));
+    }
+
+    @Test
+    public void whenPOSTBusinessEventTypeMetadataThen422() throws Exception {
+        final EventType eventType = buildEventType();
+        eventType.getSchema().setSchema("{\"type\": \"object\", \"properties\": {\"metadata\": {\"type\": \"object\"} }}");
+        eventType.setCategory(BUSINESS);
+
+        final Problem expectedProblem = invalidProblem("schema.schema",
+                "The \"metadata\" property is reserved");
 
         postEventType(eventType)
                 .andExpect(status().isUnprocessableEntity())

--- a/src/test/java/de/zalando/aruha/nakadi/utils/TestUtils.java
+++ b/src/test/java/de/zalando/aruha/nakadi/utils/TestUtils.java
@@ -1,6 +1,9 @@
 package de.zalando.aruha.nakadi.utils;
 
+import de.zalando.aruha.nakadi.domain.EventType;
+import de.zalando.aruha.nakadi.domain.EventTypeSchema;
 import org.apache.commons.io.IOUtils;
+import org.json.JSONObject;
 
 import java.io.IOException;
 import java.util.Random;
@@ -34,6 +37,18 @@ public class TestUtils {
 
     public static String resourceAsString(final String resourceName, final Class clazz) throws IOException {
         return IOUtils.toString(clazz.getResourceAsStream(resourceName));
+    }
+
+    public static EventType buildEventType(final String name, final String schema) {
+        final EventType et = new EventType();
+        et.setName(name);
+
+        final EventTypeSchema ets = new EventTypeSchema();
+        ets.setType(EventTypeSchema.Type.JSON_SCHEMA);
+        ets.setSchema(schema);
+        et.setSchema(ets);
+
+        return et;
     }
 
 }

--- a/src/test/java/de/zalando/aruha/nakadi/utils/TestUtils.java
+++ b/src/test/java/de/zalando/aruha/nakadi/utils/TestUtils.java
@@ -1,5 +1,6 @@
 package de.zalando.aruha.nakadi.utils;
 
+import de.zalando.aruha.nakadi.domain.EventCategory;
 import de.zalando.aruha.nakadi.domain.EventType;
 import de.zalando.aruha.nakadi.domain.EventTypeSchema;
 import org.apache.commons.io.IOUtils;
@@ -47,6 +48,7 @@ public class TestUtils {
         ets.setType(EventTypeSchema.Type.JSON_SCHEMA);
         ets.setSchema(schema);
         et.setSchema(ets);
+        et.setCategory(EventCategory.UNDEFINED);
 
         return et;
     }

--- a/src/test/java/de/zalando/aruha/nakadi/validation/EventValidationTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/validation/EventValidationTest.java
@@ -1,0 +1,41 @@
+package de.zalando.aruha.nakadi.validation;
+
+import de.zalando.aruha.nakadi.domain.EventType;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import static de.zalando.aruha.nakadi.utils.TestUtils.buildEventType;
+import static junit.framework.Assert.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
+
+public class EventValidationTest {
+    @Test
+    public void whenTypeIsUnknownThenReturnsPlainSchema() {
+        final String schema = "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}, \"bar\": {\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}, \"bar\": {\"type\": \"string\"}}, \"required\": [\"foo\", \"bar\"]}}, \"required\": [\"foo\", \"bar\"]}";
+        final EventType et = buildEventType("some-event-type", schema);
+
+
+        assertThat(EventValidation.effectiveSchema(et).toString(), org.hamcrest.Matchers.is(sameJSONAs(schema)));
+    }
+
+    @Test
+    public void whenTypeIsBusinessThenAddMetadataField() {
+        fail();
+    }
+
+    @Test
+    public void whenTypeIsDataChangeThenAddMetadataField() {
+        fail();
+    }
+
+    @Test
+    public void whenTypeIsDataChangeThenAddDataOpField() {
+        fail();
+    }
+
+    @Test
+    public void whenTypeIsDataChangeThenNestSchemaInData() {
+        fail();
+    }
+}

--- a/src/test/java/de/zalando/aruha/nakadi/validation/EventValidationTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/validation/EventValidationTest.java
@@ -10,8 +10,9 @@ import static org.hamcrest.Matchers.is;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 
 public class EventValidationTest {
+
     @Test
-    public void whenTypeIsUnknownThenReturnsPlainSchema() {
+    public void whenTypeIsUndefinedThenReturnsPlainSchema() {
         final String schema = "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"} }, \"required\": [\"foo\"]}";
         final EventType et = buildEventType("some-event-type", schema);
 
@@ -63,14 +64,13 @@ public class EventValidationTest {
     }
 
     @Test
-    public void whenTypeIsDataChangeThenAddMetadataField() {
-    }
+    public void whenTypeIsDataChangeThenWrap() {
+        final String schema = "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"} }, \"required\": [\"foo\"]}";
+        final EventType et = buildEventType("some-event-type", schema);
+        et.setCategory(EventCategory.DATA);
 
-    @Test
-    public void whenTypeIsDataChangeThenAddDataOpField() {
-    }
+        final String dataSchema = "{\"type\": \"object\", \"properties\": { \"data_type\": { \"type\": \"string\" }, \"data_op\": { \"type\": \"string\", \"enum\": [\"C\", \"U\", \"D\", \"S\"] } ,\"data\": {\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"} }, \"required\": [\"foo\"]} }, \"required\": [\"data\", \"data_op\", \"data_type\"]}";
 
-    @Test
-    public void whenTypeIsDataChangeThenNestSchemaInData() {
+        assertThat(EventValidation.effectiveSchema(et).toString(), is(sameJSONAs(dataSchema).allowingAnyArrayOrdering()));
     }
 }

--- a/src/test/java/de/zalando/aruha/nakadi/validation/EventValidationTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/validation/EventValidationTest.java
@@ -69,7 +69,7 @@ public class EventValidationTest {
         final EventType et = buildEventType("some-event-type", schema);
         et.setCategory(EventCategory.DATA);
 
-        final String dataSchema = "{\"type\": \"object\", \"properties\": { \"data_type\": { \"type\": \"string\" }, \"data_op\": { \"type\": \"string\", \"enum\": [\"C\", \"U\", \"D\", \"S\"] } ,\"data\": {\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"} }, \"required\": [\"foo\"]} }, \"required\": [\"data\", \"data_op\", \"data_type\"]}";
+        final String dataSchema = "{\"type\": \"object\", \"properties\": { \"data_type\": { \"type\": \"string\" }, \"data_op\": { \"type\": \"string\", \"enum\": [\"C\", \"U\", \"D\", \"S\"] }, \"metadata\": {\"type\": \"object\"}, \"data\": {\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"} }, \"required\": [\"foo\"]} }, \"required\": [\"data\", \"data_op\", \"data_type\", \"metadata\"], \"additionalProperties\": false}";
 
         assertThat(EventValidation.effectiveSchema(et).toString(), is(sameJSONAs(dataSchema).allowingAnyArrayOrdering()));
     }

--- a/src/test/java/de/zalando/aruha/nakadi/validation/EventValidationTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/validation/EventValidationTest.java
@@ -1,41 +1,76 @@
 package de.zalando.aruha.nakadi.validation;
 
+import de.zalando.aruha.nakadi.domain.EventCategory;
 import de.zalando.aruha.nakadi.domain.EventType;
-import org.json.JSONObject;
 import org.junit.Test;
 
 import static de.zalando.aruha.nakadi.utils.TestUtils.buildEventType;
-import static junit.framework.Assert.fail;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 
 public class EventValidationTest {
     @Test
     public void whenTypeIsUnknownThenReturnsPlainSchema() {
-        final String schema = "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}, \"bar\": {\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}, \"bar\": {\"type\": \"string\"}}, \"required\": [\"foo\", \"bar\"]}}, \"required\": [\"foo\", \"bar\"]}";
+        final String schema = "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"} }, \"required\": [\"foo\"]}";
         final EventType et = buildEventType("some-event-type", schema);
 
+        assertThat(EventValidation.effectiveSchema(et).toString(), is(sameJSONAs(schema).allowingAnyArrayOrdering()));
+    }
 
-        assertThat(EventValidation.effectiveSchema(et).toString(), org.hamcrest.Matchers.is(sameJSONAs(schema)));
+    @Test
+    public void whenSchemaIsEmptyAddsPropetiesWithMetadata() {
+        final String schema = "{}";
+        final EventType et = buildEventType("some-event-type", schema);
+        et.setCategory(EventCategory.BUSINESS);
+
+        final String businessSchema = "{\"type\": \"object\", \"properties\": {\"metadata\": {\"type\": \"object\"} }, \"required\": [\"metadata\"]}";
+
+        assertThat(EventValidation.effectiveSchema(et).toString(), is(sameJSONAs(businessSchema).allowingAnyArrayOrdering()));
     }
 
     @Test
     public void whenTypeIsBusinessThenAddMetadataField() {
-        fail();
+        final String schema = "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"} }, \"required\": [\"foo\"]}";
+        final EventType et = buildEventType("some-event-type", schema);
+        et.setCategory(EventCategory.BUSINESS);
+
+        final String businessSchema = "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}, \"metadata\": {\"type\": \"object\"} }, \"required\": [\"foo\", \"metadata\"]}";
+
+        assertThat(EventValidation.effectiveSchema(et).toString(), is(sameJSONAs(businessSchema).allowingAnyArrayOrdering()));
+    }
+
+    @Test
+    public void addMetadataToRequiredArray() {
+        final String schema = "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}, \"metadata\": {\"type\": \"object\"} }, \"required\": [\"foo\"]}";
+        final EventType et = buildEventType("some-event-type", schema);
+        et.setCategory(EventCategory.BUSINESS);
+
+        final String businessSchema = "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}, \"metadata\": {\"type\": \"object\"} }, \"required\": [\"foo\", \"metadata\"]}";
+
+        assertThat(EventValidation.effectiveSchema(et).toString(), is(sameJSONAs(businessSchema).allowingAnyArrayOrdering()));
+    }
+
+    @Test
+    public void overridesCurrentDefinitionOfMetadata() {
+        final String schema = "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}, \"metadata\": {\"type\": \"string\"} }, \"required\": [\"foo\", \"metadata\"]}";
+        final EventType et = buildEventType("some-event-type", schema);
+        et.setCategory(EventCategory.BUSINESS);
+
+        final String businessSchema = "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}, \"metadata\": {\"type\": \"object\"} }, \"required\": [\"foo\", \"metadata\"]}";
+
+        assertThat(EventValidation.effectiveSchema(et).toString(), is(sameJSONAs(businessSchema).allowingAnyArrayOrdering()));
     }
 
     @Test
     public void whenTypeIsDataChangeThenAddMetadataField() {
-        fail();
     }
 
     @Test
     public void whenTypeIsDataChangeThenAddDataOpField() {
-        fail();
     }
 
     @Test
     public void whenTypeIsDataChangeThenNestSchemaInData() {
-        fail();
     }
 }

--- a/src/test/java/de/zalando/aruha/nakadi/validation/JSONSchemaValidationTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/validation/JSONSchemaValidationTest.java
@@ -5,15 +5,10 @@ import de.zalando.aruha.nakadi.domain.EventTypeSchema;
 import de.zalando.aruha.nakadi.domain.EventTypeSchema.Type;
 import de.zalando.aruha.nakadi.domain.ValidationStrategyConfiguration;
 import org.json.JSONObject;
-import org.junit.After;
 import org.junit.Test;
 
 import static de.zalando.aruha.nakadi.utils.IsOptional.isAbsent;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 
 public class JSONSchemaValidationTest {
@@ -23,39 +18,6 @@ public class JSONSchemaValidationTest {
     static {
         ValidationStrategy.register(EventBodyMustRespectSchema.NAME, new EventBodyMustRespectSchema());
         ValidationStrategy.register(FieldNameMustBeSet.NAME, new FieldNameMustBeSet());
-    }
-
-    @Test
-    public void eventValidationRegistryShouldResolveTypes() {
-        final EventType et = new EventType();
-        et.setName("some-event-type");
-
-        final EventType other = new EventType();
-        other.setName("some-other-event-type");
-
-        final EventTypeValidator validator = EventValidation.forType(et);
-        assertNotNull(validator);
-        assertEquals(validator, EventValidation.lookup(et));
-        assertNull(EventValidation.lookup(other));
-
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void eventValidationRegistryShouldDenyRespecification() {
-        final EventType et = new EventType();
-        et.setName("some-event-type");
-        EventValidation.forType(et);
-        EventValidation.forType(et);
-    }
-
-    @Test
-    public void eventValidationRegistryShouldAllowRespecificationIfRequestedExplicitly() {
-        final EventType et = new EventType();
-        et.setName("some-event-type");
-
-        final EventTypeValidator validator = EventValidation.forType(et);
-        assertNotNull(validator);
-        assertSame(validator, EventValidation.forType(et, true));
     }
 
     @Test
@@ -71,9 +33,8 @@ public class JSONSchemaValidationTest {
         final ValidationStrategyConfiguration vsc2 = new ValidationStrategyConfiguration();
         vsc2.setStrategyName(FieldNameMustBeSet.NAME);
         et.getValidationStrategies().add(vsc2);
-        EventValidation.forType(et).withConfiguration(vsc1).withConfiguration(vsc2);
 
-        final EventTypeValidator validator = EventValidation.lookup(et);
+        final EventTypeValidator validator = EventValidation.forType(et).withConfiguration(vsc1).withConfiguration(vsc2);
 
         final JSONObject validEvent = new JSONObject(
                 "{\"foo\": \"bar\", \"bar\": {\"foo\": \"baz\", \"bar\": \"baz\"}, \"extra\": \"i should be no problem\", \"name\": \"12345\"}");
@@ -115,9 +76,7 @@ public class JSONSchemaValidationTest {
                 "{\"overrides\": [{\"qualifier\": {\"field\": \"event-type\", \"match\" : \"D\"}, \"ignoredProperties\": [\"field-that-will-not-be-found\"]}]}"));
         et.getValidationStrategies().add(vsc1);
 
-        EventValidation.forType(et).withConfiguration(vsc1);
-
-        final EventTypeValidator validator = EventValidation.lookup(et);
+        final EventTypeValidator validator = EventValidation.forType(et).withConfiguration(vsc1);
 
         final JSONObject event = new JSONObject(
                 "{\"event-type\" : \"X\", \"extra\": \"i should be no problem\", \"name\": \"12345\", \"field-that-will-not-be-found\": {\"val\": \"i must be present since the matcher will not succeed\"}}");
@@ -142,9 +101,7 @@ public class JSONSchemaValidationTest {
                 "{\"overrides\": [{\"qualifier\": {\"field\": \"event-type\", \"match\" : \"D\"}, \"ignoredProperties\": [\"field-that-will-not-be-found\"]}]}"));
         et.getValidationStrategies().add(vsc1);
 
-        EventValidation.forType(et).withConfiguration(vsc1);
-
-        final EventTypeValidator validator = EventValidation.lookup(et);
+        final EventTypeValidator validator = EventValidation.forType(et).withConfiguration(vsc1);
 
         final JSONObject event = new JSONObject(
                 "{\"event-type\" : \"X\", \"field-that-will-not-be-found\": \"some useless value\", \"extra\": \"i should be no problem\", \"name\": \"12345\"}");
@@ -152,10 +109,5 @@ public class JSONSchemaValidationTest {
                 "{\"event-type\" : \"D\", \"extra\": \"i should be no problem\"}");
         assertThat(validator.validate(event), isAbsent());
         assertThat(validator.validate(eventDelete), isAbsent());
-    }
-
-    @After
-    public void teardown() {
-        EventValidation.reset();
     }
 }

--- a/src/test/java/de/zalando/aruha/nakadi/validation/JSONSchemaValidationTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/validation/JSONSchemaValidationTest.java
@@ -1,13 +1,12 @@
 package de.zalando.aruha.nakadi.validation;
 
 import de.zalando.aruha.nakadi.domain.EventType;
-import de.zalando.aruha.nakadi.domain.EventTypeSchema;
-import de.zalando.aruha.nakadi.domain.EventTypeSchema.Type;
 import de.zalando.aruha.nakadi.domain.ValidationStrategyConfiguration;
 import org.json.JSONObject;
 import org.junit.Test;
 
 import static de.zalando.aruha.nakadi.utils.IsOptional.isAbsent;
+import static de.zalando.aruha.nakadi.utils.TestUtils.buildEventType;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -22,9 +21,8 @@ public class JSONSchemaValidationTest {
 
     @Test
     public void schemaValidationShouldRespectEventTypeDefinition() {
-        final EventType et = buildAndRegisterEventType("some-event-type",
-                new JSONObject(
-                    "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}, \"bar\": {\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}, \"bar\": {\"type\": \"string\"}}, \"required\": [\"foo\", \"bar\"]}}, \"required\": [\"foo\", \"bar\"]}"));
+        final EventType et = buildEventType("some-event-type",
+                    "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}, \"bar\": {\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}, \"bar\": {\"type\": \"string\"}}, \"required\": [\"foo\", \"bar\"]}}, \"required\": [\"foo\", \"bar\"]}");
 
         final ValidationStrategyConfiguration vsc1 = new ValidationStrategyConfiguration();
         vsc1.setStrategyName(EventBodyMustRespectSchema.NAME);
@@ -52,23 +50,10 @@ public class JSONSchemaValidationTest {
                 equalTo("#: 2 schema violations found\n#/bar: 2 schema violations found\n#/bar: required key [foo] not found\n#/bar: required key [bar] not found\n#: required key [foo] not found"));
     }
 
-    private EventType buildAndRegisterEventType(final String name, final JSONObject schema) {
-        final EventType et = new EventType();
-        et.setName(name);
-
-        final EventTypeSchema ets = new EventTypeSchema();
-        ets.setType(Type.JSON_SCHEMA);
-        ets.setSchema(schema.toString());
-        et.setSchema(ets);
-
-        return et;
-    }
-
     @Test
     public void schemaValidationShouldRespectIgnoreConfigurationMatchRegular() {
-        final EventType et = buildAndRegisterEventType("some-event-type",
-                new JSONObject(
-                    "{\"type\": \"object\", \"properties\": {\"field-that-will-not-be-found\": {\"type\": \"object\"}, \"event-type\": {\"type\": \"string\"}}, \"required\": [\"field-that-will-not-be-found\", \"event-type\"]}"));
+        final EventType et = buildEventType("some-event-type",
+                    "{\"type\": \"object\", \"properties\": {\"field-that-will-not-be-found\": {\"type\": \"object\"}, \"event-type\": {\"type\": \"string\"}}, \"required\": [\"field-that-will-not-be-found\", \"event-type\"]}");
 
         final ValidationStrategyConfiguration vsc1 = new ValidationStrategyConfiguration();
         vsc1.setStrategyName(EventBodyMustRespectSchema.NAME);
@@ -91,9 +76,8 @@ public class JSONSchemaValidationTest {
 
     @Test
     public void schemaValidationShouldRespectIgnoreConfigurationMatchQualified() {
-        final EventType et = buildAndRegisterEventType("some-event-type",
-                new JSONObject(
-                    "{\"type\": \"object\", \"properties\": {\"field-that-will-not-be-found\": {\"type\": \"string\"}, \"event-type\": {\"type\": \"string\"}}, \"required\": [\"field-that-will-not-be-found\", \"event-type\"]}"));
+        final EventType et = buildEventType("some-event-type",
+                    "{\"type\": \"object\", \"properties\": {\"field-that-will-not-be-found\": {\"type\": \"string\"}, \"event-type\": {\"type\": \"string\"}}, \"required\": [\"field-that-will-not-be-found\", \"event-type\"]}");
 
         final ValidationStrategyConfiguration vsc1 = new ValidationStrategyConfiguration();
         vsc1.setStrategyName(EventBodyMustRespectSchema.NAME);

--- a/src/test/java/de/zalando/aruha/nakadi/validation/JSONSchemaValidationTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/validation/JSONSchemaValidationTest.java
@@ -1,9 +1,12 @@
 package de.zalando.aruha.nakadi.validation;
 
+import de.zalando.aruha.nakadi.domain.EventCategory;
 import de.zalando.aruha.nakadi.domain.EventType;
 import de.zalando.aruha.nakadi.domain.ValidationStrategyConfiguration;
 import org.json.JSONObject;
 import org.junit.Test;
+
+import java.util.Optional;
 
 import static de.zalando.aruha.nakadi.utils.IsOptional.isAbsent;
 import static de.zalando.aruha.nakadi.utils.TestUtils.buildEventType;
@@ -93,5 +96,44 @@ public class JSONSchemaValidationTest {
                 "{\"event-type\" : \"D\", \"extra\": \"i should be no problem\"}");
         assertThat(validator.validate(event), isAbsent());
         assertThat(validator.validate(eventDelete), isAbsent());
+    }
+
+    @Test
+    public void validationOfBusinessEventShouldRequiredMetadata() {
+        final EventType et = buildEventType("some-event-type",
+                "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"} }, \"required\": [\"foo\"]}");
+        et.setCategory(EventCategory.BUSINESS);
+
+        final JSONObject event = new JSONObject("{ \"foo\": \"bar\" }");
+
+        Optional<ValidationError> error = EventValidation.forType(et).validate(event);
+
+        assertThat(error.get().getMessage(), equalTo("#: required key [metadata] not found"));
+    }
+
+    @Test
+    public void validationOfDataChangeEventRequiresExtraFields() {
+        final EventType et = buildEventType("some-event-type",
+                "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"} }, \"required\": [\"foo\"]}");
+        et.setCategory(EventCategory.DATA);
+
+        final JSONObject event = new JSONObject("{ \"data\": { \"foo\": \"bar\" } }");
+
+        Optional<ValidationError> error = EventValidation.forType(et).validate(event);
+
+        assertThat(error.get().getMessage(), equalTo("#: 3 schema violations found\n#: required key [metadata] not found\n#: required key [data_op] not found\n#: required key [data_type] not found"));
+    }
+
+    @Test
+    public void validationOfDataChangeEventShouldNotAllowAdditionalFieldsAtTheRootLevelObject() {
+        final EventType et = buildEventType("some-event-type",
+                "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"} }, \"required\": [\"foo\"]}");
+        et.setCategory(EventCategory.DATA);
+
+        final JSONObject event = new JSONObject("{ \"data\": { \"foo\": \"bar\" }, \"data_op\": \"C\", \"data_type\": \"some-event-type\", \"metadata\": {}, \"foo\": 1 }");
+
+        Optional<ValidationError> error = EventValidation.forType(et).validate(event);
+
+        assertThat(error.get().getMessage(), equalTo("#: extraneous key [foo] is not permitted"));
     }
 }

--- a/src/test/java/de/zalando/aruha/nakadi/validation/JSONSchemaValidationTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/validation/JSONSchemaValidationTest.java
@@ -32,7 +32,7 @@ public class JSONSchemaValidationTest {
         vsc2.setStrategyName(FieldNameMustBeSet.NAME);
         et.getValidationStrategies().add(vsc2);
 
-        final EventTypeValidator validator = EventValidation.forType(et).withConfiguration(vsc1).withConfiguration(vsc2);
+        final EventTypeValidator validator = new EventTypeValidator(et).withConfiguration(vsc1).withConfiguration(vsc2);
 
         final JSONObject validEvent = new JSONObject(
                 "{\"foo\": \"bar\", \"bar\": {\"foo\": \"baz\", \"bar\": \"baz\"}, \"extra\": \"i should be no problem\", \"name\": \"12345\"}");
@@ -61,7 +61,7 @@ public class JSONSchemaValidationTest {
                 "{\"overrides\": [{\"qualifier\": {\"field\": \"event-type\", \"match\" : \"D\"}, \"ignoredProperties\": [\"field-that-will-not-be-found\"]}]}"));
         et.getValidationStrategies().add(vsc1);
 
-        final EventTypeValidator validator = EventValidation.forType(et).withConfiguration(vsc1);
+        final EventTypeValidator validator = new EventTypeValidator(et).withConfiguration(vsc1);
 
         final JSONObject event = new JSONObject(
                 "{\"event-type\" : \"X\", \"extra\": \"i should be no problem\", \"name\": \"12345\", \"field-that-will-not-be-found\": {\"val\": \"i must be present since the matcher will not succeed\"}}");
@@ -85,7 +85,7 @@ public class JSONSchemaValidationTest {
                 "{\"overrides\": [{\"qualifier\": {\"field\": \"event-type\", \"match\" : \"D\"}, \"ignoredProperties\": [\"field-that-will-not-be-found\"]}]}"));
         et.getValidationStrategies().add(vsc1);
 
-        final EventTypeValidator validator = EventValidation.forType(et).withConfiguration(vsc1);
+        final EventTypeValidator validator = new EventTypeValidator(et).withConfiguration(vsc1);
 
         final JSONObject event = new JSONObject(
                 "{\"event-type\" : \"X\", \"field-that-will-not-be-found\": \"some useless value\", \"extra\": \"i should be no problem\", \"name\": \"12345\"}");

--- a/src/test/resources/sample-event-type-update.json
+++ b/src/test/resources/sample-event-type-update.json
@@ -1,7 +1,7 @@
 {
   "name": "NAME_PLACEHOLDER",
   "owning_application": "my-app",
-  "category": "business",
+  "category": "undefined",
   "schema": {
     "type": "json_schema",
     "schema": "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}}, \"required\": [\"foo\"]}"

--- a/src/test/resources/sample-event-type.json
+++ b/src/test/resources/sample-event-type.json
@@ -1,7 +1,7 @@
 {
   "name": "NAME_PLACEHOLDER",
   "owning_application": "article-producer",
-  "category": "data",
+  "category": "undefined",
   "schema": {
     "type": "json_schema",
     "schema": "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}}, \"required\": [\"foo\"]}"


### PR DESCRIPTION
This PR adds the idea of an effective schema. An effective schema is an schema that is aware of categories.

If the event type is of business category, then we should expect it to have "metadata" in the root of the every event.

If from data category, then we should expect to find `data_op`, `data_type` and `data` at the root. The later should contain the original `schema` as a value.

Do you think we should be strict about what fields are allowed at the root object of a data event?

If so, I could add an `additionalProperties: false` to it.