### PR TITLE
aruha-113 add multi-status code 207

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -468,7 +468,9 @@ paths:
           required: true
       responses:
         '200':
-          description: Ok
+          description: All events in the batch have been successfully published.
+        '207':
+          description: At least one event has failed to be submitted.
           schema:
             type: array
             items:
@@ -487,10 +489,6 @@ paths:
               $ref: '#/definitions/Problem'
         '405':
           description: Not allowed.
-          schema:
-              $ref: '#/definitions/Problem'
-        '409':
-          description: Conflict.
           schema:
               $ref: '#/definitions/Problem'
         '500':

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -467,7 +467,7 @@ paths:
         '200':
           description: All events in the batch have been successfully published.
         '207':
-          description: At least one event has failed to be submitted.
+          description: At least one event has failed to be submitted. The batch might be partially submitted.
           schema:
             type: array
             items:
@@ -488,6 +488,12 @@ paths:
           description: Not allowed.
           schema:
               $ref: '#/definitions/Problem'
+        '422':
+          description: At least one event failed to be validated, enriched or partitioned. None were submitted.
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/BatchItemResponse'
         '500':
           description: Server error
           schema:

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -435,9 +435,6 @@ paths:
         1. The incoming Event's relative ordering is evaluated according to the rule on the
         `EventType`. Failure to evaluate the rule will **reject** the Event.
 
-        The response in successful operation is an array of same length as the input, including a
-        `BatchItemResponse` corresponding to each item's status.
-
         Given the batched nature of this operation, any violation on validation or failures on enrichment or
         partitioning will cause the whole batch to be rejected, i.e. none of its elements are pushed to the
         underlying broker.


### PR DESCRIPTION
In order to more precisely communicate partial success scenarios, we are
introducing 207 Multi-status code as a possible http response code.

In case all events have been published successfully, then we just return
200 with empty body, otherwise we provide detailed status information in
the form of an array of BatchItemResponse's.

We considered using 422 as a response answer but it just doesn't feel correct
since we could have a mix of successes and failures in the batch.