### PR TITLE
Aruha 154 hotfix datetime validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ dependencies {
     compile 'org.apache.curator:curator-recipes:2.9.1'
 
     // json
-    compile 'org.everit.json:org.everit.json.schema:1.1.0'
+    compile 'org.everit.json:org.everit.json.schema:1.2.0'
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-json-org:2.4.0'
 
     // scala dependencies

--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ dependencies {
     compile 'org.apache.curator:curator-recipes:2.9.1'
 
     // json
-    compile 'org.everit.json:org.everit.json.schema:1.2.0'
+    compile 'org.everit.json:org.everit.json.schema:1.1.0'
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-json-org:2.4.0'
 
     // scala dependencies

--- a/src/main/java/de/zalando/aruha/nakadi/config/RepositoriesConfig.java
+++ b/src/main/java/de/zalando/aruha/nakadi/config/RepositoriesConfig.java
@@ -7,6 +7,7 @@ import de.zalando.aruha.nakadi.repository.db.EventTypeDbRepository;
 import de.zalando.aruha.nakadi.repository.kafka.KafkaConfig;
 import de.zalando.aruha.nakadi.repository.zookeeper.ZookeeperConfig;
 import de.zalando.aruha.nakadi.validation.EventBodyMustRespectSchema;
+import de.zalando.aruha.nakadi.validation.EventMetadataValidationStrategy;
 import de.zalando.aruha.nakadi.validation.ValidationStrategy;
 import org.apache.curator.framework.CuratorFramework;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,6 +41,7 @@ public class RepositoriesConfig {
         final EventTypeCache cache = new EventTypeCache(dbRepo(), client);
 
         ValidationStrategy.register(EventBodyMustRespectSchema.NAME, new EventBodyMustRespectSchema());
+        ValidationStrategy.register(EventMetadataValidationStrategy.NAME, new EventMetadataValidationStrategy());
 
         return new EventTypeCache(dbRepo(), client);
     }

--- a/src/main/java/de/zalando/aruha/nakadi/validation/EventMetadataValidationStrategy.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/EventMetadataValidationStrategy.java
@@ -1,0 +1,13 @@
+package de.zalando.aruha.nakadi.validation;
+
+import de.zalando.aruha.nakadi.domain.EventType;
+import de.zalando.aruha.nakadi.domain.ValidationStrategyConfiguration;
+
+public class EventMetadataValidationStrategy extends ValidationStrategy {
+    public static final String NAME = "metadata-validation";
+
+    @Override
+    public EventValidator materialize(final EventType eventType, final ValidationStrategyConfiguration vsc) {
+        return new MetadataValidator();
+    }
+}

--- a/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
@@ -1,5 +1,6 @@
 package de.zalando.aruha.nakadi.validation;
 
+import de.zalando.aruha.nakadi.domain.EventCategory;
 import de.zalando.aruha.nakadi.domain.EventType;
 import de.zalando.aruha.nakadi.domain.ValidationStrategyConfiguration;
 import org.json.JSONArray;
@@ -18,6 +19,12 @@ public class EventValidation {
             final ValidationStrategyConfiguration vsc = new ValidationStrategyConfiguration();
             vsc.setStrategyName(EventBodyMustRespectSchema.NAME);
             etv.withConfiguration(vsc);
+        }
+
+        if (eventType.getCategory() == EventCategory.BUSINESS || eventType.getCategory() == EventCategory.DATA) {
+            final ValidationStrategyConfiguration metadataConf = new ValidationStrategyConfiguration();
+            metadataConf.setStrategyName(EventMetadataValidationStrategy.NAME);
+            etv.withConfiguration(metadataConf);
         }
 
         return etv;
@@ -71,8 +78,7 @@ public class EventValidation {
                 .put("enum", Arrays.asList(new String[] { eventType.getName() }));
         final JSONObject string = new JSONObject().put("type", "string");
         final JSONObject dateTime = new JSONObject()
-                .put("type", "string")
-                .put("format", "date-time");
+                .put("type", "string");
 
         metadataProperties.put("eid", uuid);
         metadataProperties.put("event_type", eventTypeString);

--- a/src/main/java/de/zalando/aruha/nakadi/validation/MetadataValidator.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/MetadataValidator.java
@@ -1,0 +1,42 @@
+package de.zalando.aruha.nakadi.validation;
+
+import org.json.JSONObject;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Optional;
+
+public class MetadataValidator implements EventValidator {
+    private static final String DATETIME_FORMAT_STRING = "yyyy-MM-dd'T'HH:mm:ssXXX";
+    private static final String DATETIME_FORMAT_STRING_SECFRAC = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+
+    @Override
+    public Optional<ValidationError> accepts(final JSONObject event) {
+        return Optional
+                .ofNullable(event.optJSONObject("metadata"))
+                .map(metadata -> metadata.optString("occurred_at"))
+                .flatMap(occurredAt -> checkDateTime(occurredAt));
+    }
+
+    private Optional<ValidationError> checkDateTime(final String occurredAt) {
+        try {
+            final DateFormat format = new SimpleDateFormat(DATETIME_FORMAT_STRING);
+            format.setLenient(false);
+            format.parse(occurredAt);
+
+            return Optional.empty();
+        } catch (ParseException e) {
+            try {
+                final DateFormat formatWithSecfrac = new SimpleDateFormat(DATETIME_FORMAT_STRING_SECFRAC);
+                formatWithSecfrac.setLenient(false);
+                Date date = formatWithSecfrac.parse(occurredAt);
+
+                return Optional.empty();
+            } catch (ParseException e1) {
+                return Optional.of(new ValidationError("occurred_at must be a valid date-time"));
+            }
+        }
+    }
+}

--- a/src/main/java/de/zalando/aruha/nakadi/validation/MetadataValidator.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/MetadataValidator.java
@@ -1,17 +1,12 @@
 package de.zalando.aruha.nakadi.validation;
 
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
 import org.json.JSONObject;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.Optional;
 
 public class MetadataValidator implements EventValidator {
-    private static final String DATETIME_FORMAT_STRING = "yyyy-MM-dd'T'HH:mm:ssXXX";
-    private static final String DATETIME_FORMAT_STRING_SECFRAC = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
-
     @Override
     public Optional<ValidationError> accepts(final JSONObject event) {
         return Optional
@@ -22,21 +17,12 @@ public class MetadataValidator implements EventValidator {
 
     private Optional<ValidationError> checkDateTime(final String occurredAt) {
         try {
-            final DateFormat format = new SimpleDateFormat(DATETIME_FORMAT_STRING);
-            format.setLenient(false);
-            format.parse(occurredAt);
+            DateTimeFormatter dateFormatter = ISODateTimeFormat.dateTimeParser();
+            dateFormatter.parseDateTime(occurredAt);
 
             return Optional.empty();
-        } catch (ParseException e) {
-            try {
-                final DateFormat formatWithSecfrac = new SimpleDateFormat(DATETIME_FORMAT_STRING_SECFRAC);
-                formatWithSecfrac.setLenient(false);
-                Date date = formatWithSecfrac.parse(occurredAt);
-
-                return Optional.empty();
-            } catch (ParseException e1) {
-                return Optional.of(new ValidationError("occurred_at must be a valid date-time"));
-            }
+        } catch (IllegalArgumentException e) {
+            return Optional.of(new ValidationError("occurred_at must be a valid date-time"));
         }
     }
 }

--- a/src/test/java/de/zalando/aruha/nakadi/validation/JSONSchemaValidationTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/validation/JSONSchemaValidationTest.java
@@ -189,6 +189,32 @@ public class JSONSchemaValidationTest {
     }
 
     @Test
+    public void requireMetadataOccurredAtToBeFormattedAsDateTimeWithMilliseconds() {
+        final EventType et = buildEventType("some-event-type", basicSchema());
+        et.setCategory(EventCategory.BUSINESS);
+
+        final JSONObject event = businessEvent();
+        event.getJSONObject("metadata").put("occurred_at", "1996-10-15T16:39:57.1245678+07:00");
+
+        Optional<ValidationError> error = EventValidation.forType(et).validate(event);
+
+        assertThat(error, isAbsent());
+    }
+
+    @Test
+    public void acceptsDateTimeZoneWithoutColonSeparation() {
+        final EventType et = buildEventType("some-event-type", basicSchema());
+        et.setCategory(EventCategory.BUSINESS);
+
+        final JSONObject event = businessEvent();
+        event.getJSONObject("metadata").put("occurred_at", "1996-10-15T16:39:57+0800");
+
+        Optional<ValidationError> error = EventValidation.forType(et).validate(event);
+
+        assertThat(error, isAbsent());
+    }
+
+    @Test
     public void requireEidToBeFormattedAsUUID() {
         final EventType et = buildEventType("some-event-type", basicSchema());
         et.setCategory(EventCategory.BUSINESS);

--- a/src/test/java/de/zalando/aruha/nakadi/validation/JSONSchemaValidationTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/validation/JSONSchemaValidationTest.java
@@ -19,6 +19,7 @@ public class JSONSchemaValidationTest {
 
     static {
         ValidationStrategy.register(EventBodyMustRespectSchema.NAME, new EventBodyMustRespectSchema());
+        ValidationStrategy.register(EventMetadataValidationStrategy.NAME, new EventMetadataValidationStrategy());
         ValidationStrategy.register(FieldNameMustBeSet.NAME, new FieldNameMustBeSet());
     }
 


### PR DESCRIPTION
The current validation rejects DateTimes with variable number of
millisecond digits (it's accepts only zero or 3 digits milliseconds strings).

It's better to use Joda validation since it handles such scenarios,
even though it accepts timezones without ":" which should be
invalid by the RFC 3339.

But it's better to accept such small variation than reject valid dates.

Fixes #185