### PR TITLE
aruha-112 improve readme with batch example

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,16 @@ curl --request GET \
      http://localhost:8080/event-types/order.ORDER_RECEIVED/partitions/0
 ```
 
-### Publish event
+### Publish events
 
 ```sh
 curl --request POST \
      --header "Content-Type:application/json" \
      http://localhost:8080/event-types/order.ORDER_RECEIVED/events \
-     -d '{ "order_number": "ORDER_ONE", "metadata": { "eid": "39ac3332-eb00-11e5-91fe-1c6f65464fc6", "occurred_at": "2016-03-15T23:47:15+01:00" } }'
+     -d '[
+       { "order_number": "ORDER_ONE", "metadata": { "eid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "occurred_at": "2016-03-15T23:47:15+01:00" } },
+       { "order_number": "ORDER_TWO", "metadata": { "eid": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "occurred_at": "2016-03-15T23:47:16+01:00" } }
+     ]'
 ```
 
 ### Receive event stream


### PR DESCRIPTION
A change to the README was required to keep up to date with the new
bulk event publishing API.