### PR TITLE
aruha-114 fix ambiguity when requiring eid

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -876,8 +876,8 @@ definitions:
             description: |
               Identifier of this Event.
 
-              Clients are allowed to generate this and this SHOULD be guaranteed to be unique from the
-              perspective of the producer. Consumers MIGHT use this value to assert uniqueness of reception
+              Clients MUST generate this and this SHOULD be guaranteed to be unique from the perspective of the
+              producer. Consumers MIGHT use this value to assert uniqueness of reception
               of the Event.
             type: string
             example: '105a76d8-db49-4144-ace7-e683e8f4ba46'


### PR DESCRIPTION
It was not clear enought if eid is a required metadata field or not.

The correct interpretation is the later: it is required.

Our usage of Kafka provides the safest persistence guarantee available,
which has "at least once" semantics.

> acks=all This means the leader will wait for the full set of in-sync
replicas to acknowledge the record. This guarantees that the record will
not be lost as long as at least one in-sync replica remains alive. This
is the strongest available guarantee.

On the other hand it means that we could reply with error when it would
be successfully published. That would happen in the very rare event of
timeout during replicas acknowledgement. See page 81, for example
http://www.slideshare.net/miguno/apache-kafka-08-basic-training-verisign

That said, it's really important to provide a way for consumers to
handle duplicates. That is one of the reasons why it's important to
provide an UUID.

Fixes #192 