### PR TITLE
ARUHA-157 Update Kafka Broker List for KafkaProducer

### DIFF
--- a/src/acceptance-test/java/de/zalando/aruha/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/src/acceptance-test/java/de/zalando/aruha/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -1,40 +1,33 @@
 package de.zalando.aruha.nakadi.repository.kafka;
 
-import static org.echocat.jomon.runtime.concurrent.Retryer.executeWithRetry;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import static org.hamcrest.Matchers.arrayWithSize;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import de.zalando.aruha.nakadi.domain.BatchItem;
+import de.zalando.aruha.nakadi.domain.EventPublishingStatus;
+import de.zalando.aruha.nakadi.repository.zookeeper.ZooKeeperHolder;
+import de.zalando.aruha.nakadi.utils.TestUtils;
+import de.zalando.aruha.nakadi.webservice.BaseAT;
+import org.apache.curator.CuratorZookeeperClient;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.PartitionInfo;
+import org.echocat.jomon.runtime.concurrent.RetryForSpecifiedTimeStrategy;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import de.zalando.aruha.nakadi.domain.BatchItem;
-import de.zalando.aruha.nakadi.domain.EventPublishingStatus;
-import org.apache.curator.CuratorZookeeperClient;
-import org.apache.curator.framework.CuratorFramework;
-
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.common.PartitionInfo;
-
-import org.echocat.jomon.runtime.concurrent.RetryForSpecifiedTimeStrategy;
-
-import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
-
-import de.zalando.aruha.nakadi.repository.zookeeper.ZooKeeperHolder;
-import de.zalando.aruha.nakadi.utils.TestUtils;
-import de.zalando.aruha.nakadi.webservice.BaseAT;
-import org.mockito.Mockito;
+import static org.echocat.jomon.runtime.concurrent.Retryer.executeWithRetry;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class KafkaRepositoryAT extends BaseAT {
 
@@ -138,7 +131,7 @@ public class KafkaRepositoryAT extends BaseAT {
         Mockito
                 .doReturn(kafkaHelper.createProducer())
                 .when(factory)
-                .createProducer();
+                .getProducer();
 
         return new KafkaTopicRepository(zooKeeperHolder, factory, repositorySettings);
     }

--- a/src/main/java/de/zalando/aruha/nakadi/repository/kafka/KafkaConfig.java
+++ b/src/main/java/de/zalando/aruha/nakadi/repository/kafka/KafkaConfig.java
@@ -17,7 +17,7 @@ public class KafkaConfig {
 
     @Bean
     public KafkaLocationManager getKafkaLocationManager() {
-        return new KafkaLocationManager();
+        return new KafkaLocationManager(zookeeperConfig.zooKeeperHolder());
     }
 
     @Bean

--- a/src/main/java/de/zalando/aruha/nakadi/repository/kafka/KafkaFactory.java
+++ b/src/main/java/de/zalando/aruha/nakadi/repository/kafka/KafkaFactory.java
@@ -10,7 +10,7 @@ import java.util.Properties;
 
 class KafkaFactory implements KafkaPropertiesListener {
     private final KafkaLocationManager kafkaLocationManager;
-    private KafkaProducer<String, String> kafkaProducer;
+    private volatile KafkaProducer<String, String> kafkaProducer;
 
     public KafkaFactory(final KafkaLocationManager kafkaLocationManager) {
         this.kafkaLocationManager = kafkaLocationManager;

--- a/src/main/java/de/zalando/aruha/nakadi/repository/kafka/KafkaFactory.java
+++ b/src/main/java/de/zalando/aruha/nakadi/repository/kafka/KafkaFactory.java
@@ -18,7 +18,7 @@ class KafkaFactory implements KafkaPropertiesListener {
         kafkaLocationManager.registerPropertiesListener(this);
     }
 
-    public Producer<String, String> createProducer() {
+    public Producer<String, String> getProducer() {
         return kafkaProducer;
     }
 

--- a/src/main/java/de/zalando/aruha/nakadi/repository/kafka/KafkaFactory.java
+++ b/src/main/java/de/zalando/aruha/nakadi/repository/kafka/KafkaFactory.java
@@ -6,14 +6,16 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 
 import java.util.List;
+import java.util.Properties;
 
-class KafkaFactory {
+class KafkaFactory implements KafkaPropertiesListener {
     private final KafkaLocationManager kafkaLocationManager;
-    private final KafkaProducer<String, String> kafkaProducer;
+    private KafkaProducer<String, String> kafkaProducer;
 
     public KafkaFactory(final KafkaLocationManager kafkaLocationManager) {
         this.kafkaLocationManager = kafkaLocationManager;
         kafkaProducer = new KafkaProducer<>(kafkaLocationManager.getKafkaProperties());
+        kafkaLocationManager.registerPropertiesListener(this);
     }
 
     public Producer<String, String> createProducer() {
@@ -29,4 +31,8 @@ class KafkaFactory {
         return new NakadiKafkaConsumer(getConsumer(), topic, kafkaCursors, pollTimeout);
     }
 
+    @Override
+    public void updateProperties(final Properties kafkaProperties) {
+        kafkaProducer = new KafkaProducer<>(kafkaProperties);
+    }
 }

--- a/src/main/java/de/zalando/aruha/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/src/main/java/de/zalando/aruha/nakadi/repository/kafka/KafkaLocationManager.java
@@ -6,10 +6,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 
-import javax.annotation.PostConstruct;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -22,11 +20,15 @@ class KafkaLocationManager {
 
     private static final String _BROKERS_IDS_PATH = "/brokers/ids";
 
-    @Autowired
-    private ZooKeeperHolder zkFactory;
+    private final ZooKeeperHolder zkFactory;
 
     private volatile Properties kafkaProperties;
     private final List<KafkaPropertiesListener> kafkaPropertiesListeners = new LinkedList<>();
+
+    public KafkaLocationManager(final ZooKeeperHolder zkFactory) {
+        this.zkFactory = zkFactory;
+        init();
+    }
 
     public void registerPropertiesListener(final KafkaPropertiesListener listener) {
         kafkaPropertiesListeners.add(listener);
@@ -89,7 +91,6 @@ class KafkaLocationManager {
         return props;
     }
 
-    @PostConstruct
     private void init() {
         kafkaProperties = buildKafkaProperties(fetchBrokers());
     }

--- a/src/main/java/de/zalando/aruha/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/src/main/java/de/zalando/aruha/nakadi/repository/kafka/KafkaLocationManager.java
@@ -97,11 +97,16 @@ class KafkaLocationManager {
     @Scheduled(fixedDelay = 30000)
     private void updateBrokers() {
         if (kafkaProperties != null) {
+            final Properties oldProperties = getKafkaProperties();
+
             final List<Broker> brokers = fetchBrokers();
             if (!brokers.isEmpty()) {
-                kafkaProperties.setProperty("bootstrap.servers", buildBootstrapServers(brokers));
+                this.kafkaProperties.setProperty("bootstrap.servers", buildBootstrapServers(brokers));
             }
-            notifyPropertiesListeners();
+
+            if (!oldProperties.getProperty("bootstrap.servers").equals(kafkaProperties.getProperty("bootstrap.servers"))) {
+                notifyPropertiesListeners();
+            }
         }
     }
 

--- a/src/main/java/de/zalando/aruha/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/src/main/java/de/zalando/aruha/nakadi/repository/kafka/KafkaLocationManager.java
@@ -12,6 +12,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import javax.annotation.PostConstruct;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 
@@ -25,6 +26,11 @@ class KafkaLocationManager {
     private ZooKeeperHolder zkFactory;
 
     private Properties kafkaProperties;
+    private final List<KafkaPropertiesListener> kafkaPropertiesListeners = new LinkedList<>();
+
+    public void registerPropertiesListener(final KafkaPropertiesListener listener) {
+        kafkaPropertiesListeners.add(listener);
+    }
 
     static class Broker {
         final String host;
@@ -95,7 +101,12 @@ class KafkaLocationManager {
             if (!brokers.isEmpty()) {
                 kafkaProperties.setProperty("bootstrap.servers", buildBootstrapServers(brokers));
             }
+            notifyPropertiesListeners();
         }
+    }
+
+    private void notifyPropertiesListeners() {
+        kafkaPropertiesListeners.stream().forEach(listener -> listener.updateProperties(getKafkaProperties()));
     }
 
     public Properties getKafkaProperties() {

--- a/src/main/java/de/zalando/aruha/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/src/main/java/de/zalando/aruha/nakadi/repository/kafka/KafkaLocationManager.java
@@ -23,7 +23,7 @@ class KafkaLocationManager {
     private static final String _BROKERS_IDS_PATH = "/brokers/ids";
 
     @Autowired
-    private ZooKeeperHolder zkFactory;
+    private volatile ZooKeeperHolder zkFactory;
 
     private Properties kafkaProperties;
     private final List<KafkaPropertiesListener> kafkaPropertiesListeners = new LinkedList<>();

--- a/src/main/java/de/zalando/aruha/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/src/main/java/de/zalando/aruha/nakadi/repository/kafka/KafkaLocationManager.java
@@ -23,9 +23,9 @@ class KafkaLocationManager {
     private static final String _BROKERS_IDS_PATH = "/brokers/ids";
 
     @Autowired
-    private volatile ZooKeeperHolder zkFactory;
+    private ZooKeeperHolder zkFactory;
 
-    private Properties kafkaProperties;
+    private volatile Properties kafkaProperties;
     private final List<KafkaPropertiesListener> kafkaPropertiesListeners = new LinkedList<>();
 
     public void registerPropertiesListener(final KafkaPropertiesListener listener) {

--- a/src/main/java/de/zalando/aruha/nakadi/repository/kafka/KafkaPropertiesListener.java
+++ b/src/main/java/de/zalando/aruha/nakadi/repository/kafka/KafkaPropertiesListener.java
@@ -1,0 +1,7 @@
+package de.zalando.aruha.nakadi.repository.kafka;
+
+import java.util.Properties;
+
+public interface KafkaPropertiesListener {
+    void updateProperties(final Properties kafkaProperties);
+}

--- a/src/test/java/de/zalando/aruha/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -312,7 +312,7 @@ public class KafkaTopicRepositoryTest {
         final KafkaFactory kafkaFactory = mock(KafkaFactory.class);
 
         when(kafkaFactory.getConsumer()).thenReturn(consumer);
-        when(kafkaFactory.createProducer()).thenReturn(kafkaProducer);
+        when(kafkaFactory.getProducer()).thenReturn(kafkaProducer);
 
         return kafkaFactory;
     }


### PR DESCRIPTION
When the Kafka brokers change, create a new producer to take new brokers into account and remove old ones.

Fixes #188 