### PR TITLE
aruha-131 validate partition strategy on update

### DIFF
--- a/src/main/java/de/zalando/aruha/nakadi/controller/EventTypeController.java
+++ b/src/main/java/de/zalando/aruha/nakadi/controller/EventTypeController.java
@@ -2,7 +2,6 @@ package de.zalando.aruha.nakadi.controller;
 
 import de.zalando.aruha.nakadi.domain.EventCategory;
 import de.zalando.aruha.nakadi.domain.EventType;
-import de.zalando.aruha.nakadi.domain.PartitionStrategyDescriptor;
 import de.zalando.aruha.nakadi.exceptions.DuplicatedEventTypeNameException;
 import de.zalando.aruha.nakadi.exceptions.InternalNakadiException;
 import de.zalando.aruha.nakadi.exceptions.InvalidEventTypeException;
@@ -35,9 +34,6 @@ import org.springframework.web.context.request.NativeWebRequest;
 import javax.validation.Valid;
 import java.util.List;
 
-import static de.zalando.aruha.nakadi.domain.EventCategory.UNDEFINED;
-import static de.zalando.aruha.nakadi.partitioning.PartitionStrategy.HASH_STRATEGY;
-import static de.zalando.aruha.nakadi.partitioning.PartitionStrategy.USER_DEFINED_STRATEGY;
 import static org.springframework.http.ResponseEntity.status;
 import static org.zalando.problem.spring.web.advice.Responses.create;
 
@@ -76,7 +72,7 @@ public class EventTypeController {
 
         try {
             validateSchema(eventType);
-            validatePartitionStrategy(eventType);
+            partitionResolver.validate(eventType);
             eventTypeRepository.saveEventType(eventType);
             topicRepository.createTopic(eventType.getName());
             return status(HttpStatus.CREATED).build();
@@ -130,6 +126,7 @@ public class EventTypeController {
 
         try {
             validateUpdate(name, eventType);
+            partitionResolver.validate(eventType);
             eventTypeRepository.update(eventType);
             return status(HttpStatus.OK).build();
         } catch (final InvalidEventTypeException e) {
@@ -154,25 +151,6 @@ public class EventTypeController {
         } catch (final InternalNakadiException e) {
             LOG.error("Problem loading event type " + name, e);
             return create(e.asProblem(), nativeWebRequest);
-        }
-    }
-
-    private void validatePartitionStrategy(final EventType eventType) throws NoSuchPartitionStrategyException,
-            InvalidEventTypeException {
-        final PartitionStrategyDescriptor partitionStrategy = eventType.getPartitionStrategy();
-        if (!partitionResolver.strategyExists(partitionStrategy.getName())) {
-            throw new NoSuchPartitionStrategyException("partition strategy does not exist: " +
-                    partitionStrategy.getName());
-        }
-        else if (HASH_STRATEGY.equals(partitionStrategy.getName()) &&
-                eventType.getPartitionKeyFields().isEmpty()) {
-            throw new InvalidEventTypeException("partition_key_fields field should be set for " +
-                    "partition strategy 'hash'");
-        }
-        else if (USER_DEFINED_STRATEGY.equals(partitionStrategy.getName()) &&
-                UNDEFINED.equals(eventType.getCategory())) {
-            throw new InvalidEventTypeException("'user_defined' partition strategy can't be used " +
-                    "for EventType of category 'undefined'");
         }
     }
 
@@ -206,7 +184,6 @@ public class EventTypeController {
 
         validateName(name, eventType);
         validateSchemaChange(eventType, existingEventType);
-        validatePartitionStrategy(eventType);
     }
 
     private void validateName(final String name, final EventType eventType) throws InvalidEventTypeException {

--- a/src/main/java/de/zalando/aruha/nakadi/controller/EventTypeController.java
+++ b/src/main/java/de/zalando/aruha/nakadi/controller/EventTypeController.java
@@ -200,11 +200,13 @@ public class EventTypeController {
                 && schemaAsJson.getJSONObject("properties").has(field);
     }
 
-    private void validateUpdate(final String name, final EventType eventType) throws NoSuchEventTypeException, InternalNakadiException, InvalidEventTypeException {
+    private void validateUpdate(final String name, final EventType eventType) throws NoSuchEventTypeException,
+            InternalNakadiException, InvalidEventTypeException, NoSuchPartitionStrategyException {
         final EventType existingEventType = eventTypeRepository.findByName(name);
 
         validateName(name, eventType);
         validateSchemaChange(eventType, existingEventType);
+        validatePartitionStrategy(eventType);
     }
 
     private void validateName(final String name, final EventType eventType) throws InvalidEventTypeException {

--- a/src/main/java/de/zalando/aruha/nakadi/partitioning/PartitionResolver.java
+++ b/src/main/java/de/zalando/aruha/nakadi/partitioning/PartitionResolver.java
@@ -3,6 +3,8 @@ package de.zalando.aruha.nakadi.partitioning;
 import com.google.common.collect.ImmutableMap;
 import de.zalando.aruha.nakadi.domain.EventType;
 import de.zalando.aruha.nakadi.domain.PartitionStrategyDescriptor;
+import de.zalando.aruha.nakadi.exceptions.InvalidEventTypeException;
+import de.zalando.aruha.nakadi.exceptions.NoSuchPartitionStrategyException;
 import de.zalando.aruha.nakadi.exceptions.PartitioningException;
 import de.zalando.aruha.nakadi.repository.TopicRepository;
 import org.json.JSONObject;
@@ -11,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import static de.zalando.aruha.nakadi.domain.EventCategory.UNDEFINED;
 import static de.zalando.aruha.nakadi.partitioning.PartitionStrategy.HASH_STRATEGY;
 import static de.zalando.aruha.nakadi.partitioning.PartitionStrategy.RANDOM_STRATEGY;
 import static de.zalando.aruha.nakadi.partitioning.PartitionStrategy.USER_DEFINED_STRATEGY;
@@ -27,6 +30,23 @@ public class PartitionResolver {
 
     public PartitionResolver(final TopicRepository topicRepository) {
         this.topicRepository = topicRepository;
+    }
+
+    public void validate(final EventType eventType) throws NoSuchPartitionStrategyException, InvalidEventTypeException {
+        final PartitionStrategyDescriptor partitionStrategy = eventType.getPartitionStrategy();
+
+        if (!this.strategyExists(partitionStrategy.getName())) {
+            throw new NoSuchPartitionStrategyException("partition strategy does not exist: " +
+                    partitionStrategy.getName());
+        } else if (HASH_STRATEGY.equals(partitionStrategy.getName()) &&
+                   eventType.getPartitionKeyFields().isEmpty()) {
+            throw new InvalidEventTypeException("partition_key_fields field should be set for " +
+                    "partition strategy 'hash'");
+        } else if (USER_DEFINED_STRATEGY.equals(partitionStrategy.getName()) &&
+                   UNDEFINED.equals(eventType.getCategory())) {
+            throw new InvalidEventTypeException("'user_defined' partition strategy can't be used " +
+                    "for EventType of category 'undefined'");
+        }
     }
 
     public boolean strategyExists(final String strategyName) {

--- a/src/test/java/de/zalando/aruha/nakadi/controller/EventTypeControllerTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/controller/EventTypeControllerTest.java
@@ -6,7 +6,6 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import de.zalando.aruha.nakadi.config.JsonConfig;
 import de.zalando.aruha.nakadi.domain.EventType;
-import de.zalando.aruha.nakadi.domain.PartitionStrategyDescriptor;
 import de.zalando.aruha.nakadi.exceptions.DuplicatedEventTypeNameException;
 import de.zalando.aruha.nakadi.exceptions.InternalNakadiException;
 import de.zalando.aruha.nakadi.exceptions.InvalidEventTypeException;
@@ -38,10 +37,6 @@ import javax.ws.rs.core.Response;
 import java.util.Arrays;
 
 import static de.zalando.aruha.nakadi.domain.EventCategory.BUSINESS;
-import static de.zalando.aruha.nakadi.domain.EventCategory.UNDEFINED;
-import static de.zalando.aruha.nakadi.service.StrategiesRegistry.HASH_PARTITION_STRATEGY;
-import static de.zalando.aruha.nakadi.service.StrategiesRegistry.RANDOM_PARTITION_STRATEGY;
-import static de.zalando.aruha.nakadi.service.StrategiesRegistry.USER_DEFINED_PARTITION_STRATEGY;
 import static de.zalando.aruha.nakadi.utils.TestUtils.buildDefaultEventType;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.mockito.Matchers.any;
@@ -64,12 +59,12 @@ public class EventTypeControllerTest {
 
     private final EventTypeRepository eventTypeRepository = mock(EventTypeRepository.class);
     private final TopicRepository topicRepository = mock(TopicRepository.class);
-
+    private final PartitionResolver partitionResolver = mock(PartitionResolver.class);
     private final ObjectMapper objectMapper = new JsonConfig().jacksonObjectMapper();
     private final MockMvc mockMvc;
 
     public EventTypeControllerTest() throws Exception {
-        final PartitionResolver partitionResolver = new PartitionResolver(topicRepository);
+
         final EventTypeController controller = new EventTypeController(eventTypeRepository, topicRepository,
                 partitionResolver);
 
@@ -146,70 +141,33 @@ public class EventTypeControllerTest {
     }
 
     @Test
-    public void whenPostWithUnknownPartitionStrategyThenReturn422() throws Exception {
+    public void whenPOSTWithInvalidPartitionStrategyThen422() throws Exception {
         final EventType eventType = buildDefaultEventType();
-        final PartitionStrategyDescriptor strategy = new PartitionStrategyDescriptor("unknown_strategy", null);
-        eventType.setPartitionStrategy(strategy);
 
-        final Problem expectedProblem = Problem.valueOf(MoreStatus.UNPROCESSABLE_ENTITY,
-                "partition strategy does not exist: unknown_strategy");
+        Mockito
+                .doThrow(InvalidEventTypeException.class)
+                .when(partitionResolver)
+                .validate(any());
 
         postEventType(eventType)
                 .andExpect(status().isUnprocessableEntity())
-                .andExpect(content().contentType("application/problem+json"))
-                .andExpect(content().string(matchesProblem(expectedProblem)));
+                .andExpect(content().contentType("application/problem+json"));
     }
 
     @Test
-    public void whenPostWithHashPartitionStrategyAndWithoutPartitionKeysThenReturn422() throws Exception {
+    public void whenPUTWithInvalidPartitionStrategyThen422() throws Exception {
         final EventType eventType = buildDefaultEventType();
-        eventType.setPartitionStrategy(HASH_PARTITION_STRATEGY);
 
-        final Problem expectedProblem = Problem.valueOf(MoreStatus.UNPROCESSABLE_ENTITY,
-                "partition_key_fields field should be set for partition strategy 'hash'");
+        Mockito.doReturn(eventType).when(eventTypeRepository).findByName(any());
 
-        postEventType(eventType)
+        Mockito
+                .doThrow(InvalidEventTypeException.class)
+                .when(partitionResolver)
+                .validate(any());
+
+        putEventType(eventType, eventType.getName())
                 .andExpect(status().isUnprocessableEntity())
-                .andExpect(content().contentType("application/problem+json"))
-                .andExpect(content().string(matchesProblem(expectedProblem)));
-    }
-
-    @Test
-    public void whenPostWithUserDefinedPartitionStrategyForUndefinedCategoryThenReturn422() throws Exception {
-        final EventType eventType = buildDefaultEventType();
-        eventType.setCategory(UNDEFINED);
-
-        eventType.setPartitionStrategy(USER_DEFINED_PARTITION_STRATEGY);
-
-        final Problem expectedProblem = Problem.valueOf(MoreStatus.UNPROCESSABLE_ENTITY,
-                "'user_defined' partition strategy can't be used for EventType of category 'undefined'");
-
-        postEventType(eventType)
-                .andExpect(status().isUnprocessableEntity())
-                .andExpect(content().contentType("application/problem+json"))
-                .andExpect(content().string(matchesProblem(expectedProblem)));
-    }
-
-    @Test
-    public void whenPostWithNullPartitionStrategyNameThenReturn422() throws Exception {
-        final EventType eventType = buildDefaultEventType();
-        final PartitionStrategyDescriptor strategy = new PartitionStrategyDescriptor(null, null);
-        eventType.setPartitionStrategy(strategy);
-
-        final Problem expectedProblem = invalidProblem("partition_strategy.name", "may not be null");
-
-        postEventType(eventType)
-                .andExpect(status().isUnprocessableEntity())
-                .andExpect(content().string(matchesProblem(expectedProblem)));
-    }
-
-    @Test
-    public void whenPostWithKnownPartitionStrategyThenReturn201() throws Exception {
-        final EventType eventType = buildDefaultEventType();
-        eventType.setPartitionStrategy(RANDOM_PARTITION_STRATEGY);
-        postEventType(eventType)
-                .andExpect(status().isCreated())
-                .andExpect(content().string(""));
+                .andExpect(content().contentType("application/problem+json"));
     }
 
     @Test


### PR DESCRIPTION
The partition strategy was not being validated on the update. So would
be possible to do stuff with PUT that is not possible on the POST. For
example, defining hash partition strategy without a
patition_key_fields. But this is not possible on POST.

This could cause 500 when publishing events to an event type with
inconsistent partition strategy data.