### PR TITLE
aruha-112 don't display null detail

### DIFF
--- a/src/main/java/de/zalando/aruha/nakadi/domain/BatchItemResponse.java
+++ b/src/main/java/de/zalando/aruha/nakadi/domain/BatchItemResponse.java
@@ -3,7 +3,7 @@ package de.zalando.aruha.nakadi.domain;
 public class BatchItemResponse {
     private EventPublishingStatus publishingStatus = EventPublishingStatus.ABORTED;
     private EventPublishingStep step = EventPublishingStep.NONE;
-    private String detail;
+    private String detail = "";
 
     public EventPublishingStatus getPublishingStatus() {
         return publishingStatus;

--- a/src/test/java/de/zalando/aruha/nakadi/service/EventPublisherTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/service/EventPublisherTest.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 import static de.zalando.aruha.nakadi.utils.TestUtils.buildDefaultEventType;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -89,7 +89,7 @@ public class EventPublisherTest {
         final BatchItemResponse second = result.getResponses().get(1);
         assertThat(second.getPublishingStatus(), equalTo(EventPublishingStatus.ABORTED));
         assertThat(second.getStep(), equalTo(EventPublishingStep.NONE));
-        assertThat(second.getDetail(), is(nullValue()));
+        assertThat(second.getDetail(), is(isEmptyString()));
 
         verify(cache, times(1)).getValidator(any());
     }
@@ -129,7 +129,7 @@ public class EventPublisherTest {
         final BatchItemResponse second = result.getResponses().get(1);
         assertThat(second.getPublishingStatus(), equalTo(EventPublishingStatus.ABORTED));
         assertThat(second.getStep(), equalTo(EventPublishingStep.VALIDATING));
-        assertThat(second.getDetail(), is(nullValue()));
+        assertThat(second.getDetail(), is(isEmptyString()));
 
         verify(cache, times(2)).getValidator(any());
         verify(partitionResolver, times(1)).resolvePartition(any(), any());


### PR DESCRIPTION
Display `detail: null` could confuse users. Display empty string
instead.