### PR TITLE
aruha-175 Improved error message for invalid offset streaming

### DIFF
--- a/src/acceptance-test/java/de/zalando/aruha/nakadi/webservice/EventStreamReadingAT.java
+++ b/src/acceptance-test/java/de/zalando/aruha/nakadi/webservice/EventStreamReadingAT.java
@@ -37,7 +37,7 @@ public class EventStreamReadingAT extends BaseAT {
     private static final String STREAM_ENDPOINT = createStreamEndpointUrl(TEST_TOPIC);
     private static final String SEPARATOR = "\n";
 
-    private ObjectMapper jsonMapper = new ObjectMapper();
+    private final ObjectMapper jsonMapper = new ObjectMapper();
     private KafkaTestHelper kafkaHelper;
     private String xNakadiCursors;
     private List<Cursor> initialCursors;

--- a/src/acceptance-test/java/de/zalando/aruha/nakadi/webservice/EventStreamReadingAT.java
+++ b/src/acceptance-test/java/de/zalando/aruha/nakadi/webservice/EventStreamReadingAT.java
@@ -287,7 +287,7 @@ public class EventStreamReadingAT extends BaseAT {
                 .then()
                 .statusCode(HttpStatus.PRECONDITION_FAILED.value())
                 .and()
-                .body("detail", equalTo("cursors are not valid"));
+                .body("detail", equalTo("non existing partition very_wrong_partition"));
     }
 
     private static String createStreamEndpointUrl(final String eventType) {

--- a/src/acceptance-test/java/de/zalando/aruha/nakadi/webservice/EventStreamReadingAT.java
+++ b/src/acceptance-test/java/de/zalando/aruha/nakadi/webservice/EventStreamReadingAT.java
@@ -237,6 +237,8 @@ public class EventStreamReadingAT extends BaseAT {
                 .then()
                 .statusCode(HttpStatus.NOT_FOUND.value())
                 .and()
+                .contentType(equalTo("application/problem+json;charset=UTF-8"))
+                .and()
                 .body("detail", equalTo("topic not found"));
     }
 
@@ -249,6 +251,8 @@ public class EventStreamReadingAT extends BaseAT {
                 .get(STREAM_ENDPOINT)
                 .then()
                 .statusCode(HttpStatus.UNPROCESSABLE_ENTITY.value())
+                .and()
+                .contentType(equalTo("application/problem+json;charset=UTF-8"))
                 .and()
                 .body("detail", equalTo("stream_limit can't be lower than batch_limit"));
     }
@@ -263,6 +267,8 @@ public class EventStreamReadingAT extends BaseAT {
                 .then()
                 .statusCode(HttpStatus.UNPROCESSABLE_ENTITY.value())
                 .and()
+                .contentType(equalTo("application/problem+json;charset=UTF-8"))
+                .and()
                 .body("detail", equalTo("stream_timeout can't be lower than batch_flush_timeout"));
     }
 
@@ -275,6 +281,8 @@ public class EventStreamReadingAT extends BaseAT {
                 .then()
                 .statusCode(HttpStatus.BAD_REQUEST.value())
                 .and()
+                .contentType(equalTo("application/problem+json;charset=UTF-8"))
+                .and()
                 .body("detail", equalTo("incorrect syntax of X-nakadi-cursors header"));
     }
 
@@ -286,6 +294,8 @@ public class EventStreamReadingAT extends BaseAT {
                 .get(STREAM_ENDPOINT)
                 .then()
                 .statusCode(HttpStatus.PRECONDITION_FAILED.value())
+                .and()
+                .contentType(equalTo("application/problem+json;charset=UTF-8"))
                 .and()
                 .body("detail", equalTo("non existing partition very_wrong_partition"));
     }

--- a/src/main/java/de/zalando/aruha/nakadi/controller/EventStreamController.java
+++ b/src/main/java/de/zalando/aruha/nakadi/controller/EventStreamController.java
@@ -180,7 +180,7 @@ public class EventStreamController {
             case EMPTY_PARTITION:
                 return "partition " + cursor.getPartition() + " is empty";
             case UNAVAILABLE:
-                return "offset " + cursor.getOffset() + " for partition " + cursor.getPartition() + " unavailable";
+                return "offset " + cursor.getOffset() + " for partition " + cursor.getPartition() + " is unavailable";
             default:
                 return "invalid offset " + cursor.getOffset() + " for partition " + cursor.getPartition();
         }

--- a/src/main/java/de/zalando/aruha/nakadi/controller/EventStreamController.java
+++ b/src/main/java/de/zalando/aruha/nakadi/controller/EventStreamController.java
@@ -189,6 +189,7 @@ public class EventStreamController {
     private void writeProblemResponse(final HttpServletResponse response, final OutputStream outputStream,
                                       final Response.StatusType statusCode, final String message) throws IOException {
         response.setStatus(statusCode.getStatusCode());
+        response.setContentType("application/json+problem");
         jsonMapper.writer().writeValue(outputStream, Problem.valueOf(statusCode, message));
     }
 }

--- a/src/main/java/de/zalando/aruha/nakadi/controller/EventStreamController.java
+++ b/src/main/java/de/zalando/aruha/nakadi/controller/EventStreamController.java
@@ -189,7 +189,7 @@ public class EventStreamController {
     private void writeProblemResponse(final HttpServletResponse response, final OutputStream outputStream,
                                       final Response.StatusType statusCode, final String message) throws IOException {
         response.setStatus(statusCode.getStatusCode());
-        response.setContentType("application/json+problem");
+        response.setContentType("application/problem+json");
         jsonMapper.writer().writeValue(outputStream, Problem.valueOf(statusCode, message));
     }
 }

--- a/src/main/java/de/zalando/aruha/nakadi/controller/EventStreamController.java
+++ b/src/main/java/de/zalando/aruha/nakadi/controller/EventStreamController.java
@@ -6,6 +6,8 @@ import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.zalando.aruha.nakadi.domain.Cursor;
+import de.zalando.aruha.nakadi.domain.CursorError;
+import de.zalando.aruha.nakadi.exceptions.InvalidCursorException;
 import de.zalando.aruha.nakadi.exceptions.NakadiException;
 import de.zalando.aruha.nakadi.repository.EventConsumer;
 import de.zalando.aruha.nakadi.repository.TopicRepository;
@@ -33,7 +35,6 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static de.zalando.aruha.nakadi.metrics.MetricUtils.metricNameFor;
@@ -120,15 +121,6 @@ public class EventStreamController {
                     }
                 }
 
-                // check that offsets are not out of bounds and partitions exist
-                if (cursors != null) {
-                    final Optional<String> errorMessage = topicRepository.validateCursors(topic, cursors);
-                    if (errorMessage.isPresent()) {
-                        writeProblemResponse(response, outputStream, PRECONDITION_FAILED, errorMessage.get());
-                        return;
-                    }
-                }
-
                 // if no cursors provided - read from the newest available events
                 if (cursors == null) {
                     cursors = topicRepository
@@ -150,7 +142,7 @@ public class EventStreamController {
                 response.setStatus(HttpStatus.OK.value());
                 response.setContentType("text/plain"); // TODO: must be aligned with API
 
-                eventConsumer = topicRepository.createEventConsumer(topic, streamConfig.getCursors());
+                eventConsumer = topicRepository.createEventConsumer(topic, cursors);
                 final EventStream eventStream = eventStreamFactory.createEventStream(eventConsumer, outputStream,
                         streamConfig);
                 eventStream.streamEvents();
@@ -158,6 +150,10 @@ public class EventStreamController {
             catch (final NakadiException e) {
                 LOG.error("Error while trying to stream events. Respond with SERVICE_UNAVAILABLE.", e);
                 writeProblemResponse(response, outputStream, SERVICE_UNAVAILABLE, e.getProblemMessage());
+            }
+            catch (final InvalidCursorException e) {
+                final String errorMessage = invalidCursorMessage(e.getError(), e.getCursor());
+                writeProblemResponse(response, outputStream, PRECONDITION_FAILED, errorMessage);
             }
             catch (final Exception e) {
                 LOG.error("Error while trying to stream events. Respond with INTERNAL_SERVER_ERROR.", e);
@@ -177,11 +173,22 @@ public class EventStreamController {
         };
     }
 
+    private String invalidCursorMessage(final CursorError error, final Cursor cursor) {
+        switch (error) {
+            case PARTITION_NOT_FOUND:
+                return "non existing partition " + cursor.getPartition();
+            case EMPTY_PARTITION:
+                return "partition " + cursor.getPartition() + " is empty";
+            case UNAVAILABLE:
+                return "offset " + cursor.getOffset() + " for partition " + cursor.getPartition() + " unavailable";
+            default:
+                return "invalid offset " + cursor.getOffset() + " for partition " + cursor.getPartition();
+        }
+    }
+
     private void writeProblemResponse(final HttpServletResponse response, final OutputStream outputStream,
                                       final Response.StatusType statusCode, final String message) throws IOException {
         response.setStatus(statusCode.getStatusCode());
         jsonMapper.writer().writeValue(outputStream, Problem.valueOf(statusCode, message));
     }
-
-
 }

--- a/src/main/java/de/zalando/aruha/nakadi/domain/CursorError.java
+++ b/src/main/java/de/zalando/aruha/nakadi/domain/CursorError.java
@@ -1,0 +1,5 @@
+package de.zalando.aruha.nakadi.domain;
+
+public enum CursorError {
+    PARTITION_NOT_FOUND, EMPTY_PARTITION, UNAVAILABLE, INVALID_FORMAT
+}

--- a/src/main/java/de/zalando/aruha/nakadi/exceptions/InvalidCursorException.java
+++ b/src/main/java/de/zalando/aruha/nakadi/exceptions/InvalidCursorException.java
@@ -1,0 +1,23 @@
+package de.zalando.aruha.nakadi.exceptions;
+
+import de.zalando.aruha.nakadi.domain.Cursor;
+import de.zalando.aruha.nakadi.domain.CursorError;
+
+public class InvalidCursorException extends Exception {
+    private final CursorError error;
+    private final Cursor cursor;
+
+    public InvalidCursorException(final CursorError error, final Cursor cursor) {
+        super();
+        this.error = error;
+        this.cursor = cursor;
+    }
+
+    public CursorError getError() {
+        return error;
+    }
+
+    public Cursor getCursor() {
+        return cursor;
+    }
+}

--- a/src/main/java/de/zalando/aruha/nakadi/repository/TopicRepository.java
+++ b/src/main/java/de/zalando/aruha/nakadi/repository/TopicRepository.java
@@ -8,10 +8,13 @@ import de.zalando.aruha.nakadi.domain.TopicPartition;
 import de.zalando.aruha.nakadi.exceptions.DuplicatedEventTypeNameException;
 import de.zalando.aruha.nakadi.exceptions.EventPublishingException;
 import de.zalando.aruha.nakadi.exceptions.NakadiException;
+import de.zalando.aruha.nakadi.exceptions.ServiceUnavailableException;
 import de.zalando.aruha.nakadi.exceptions.TopicCreationException;
 import de.zalando.aruha.nakadi.exceptions.TopicDeletionException;
+
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Manages access to topic information.
@@ -30,8 +33,6 @@ public interface TopicRepository {
 
     boolean partitionExists(String topic, String partition) throws NakadiException;
 
-    boolean areCursorsValid(String topic, List<Cursor> cursors) throws NakadiException;
-
     void syncPostBatch(String topicId, List<BatchItem> batch) throws EventPublishingException;
 
     List<TopicPartition> listPartitions(String topicId) throws NakadiException;
@@ -41,4 +42,6 @@ public interface TopicRepository {
     TopicPartition getPartition(String topicId, String partition) throws NakadiException;
 
     EventConsumer createEventConsumer(String topic, Map<String, String> cursors) throws NakadiException;
+
+    Optional<String> validateCursors(String topic, List<Cursor> cursors) throws ServiceUnavailableException;
 }

--- a/src/main/java/de/zalando/aruha/nakadi/repository/TopicRepository.java
+++ b/src/main/java/de/zalando/aruha/nakadi/repository/TopicRepository.java
@@ -7,14 +7,13 @@ import de.zalando.aruha.nakadi.domain.Topic;
 import de.zalando.aruha.nakadi.domain.TopicPartition;
 import de.zalando.aruha.nakadi.exceptions.DuplicatedEventTypeNameException;
 import de.zalando.aruha.nakadi.exceptions.EventPublishingException;
+import de.zalando.aruha.nakadi.exceptions.InvalidCursorException;
 import de.zalando.aruha.nakadi.exceptions.NakadiException;
 import de.zalando.aruha.nakadi.exceptions.ServiceUnavailableException;
 import de.zalando.aruha.nakadi.exceptions.TopicCreationException;
 import de.zalando.aruha.nakadi.exceptions.TopicDeletionException;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 /**
  * Manages access to topic information.
@@ -41,7 +40,5 @@ public interface TopicRepository {
 
     TopicPartition getPartition(String topicId, String partition) throws NakadiException;
 
-    EventConsumer createEventConsumer(String topic, Map<String, String> cursors) throws NakadiException;
-
-    Optional<String> validateCursors(String topic, List<Cursor> cursors) throws ServiceUnavailableException;
+    EventConsumer createEventConsumer(String topic, List<Cursor> cursors) throws NakadiException, InvalidCursorException;
 }

--- a/src/test/java/de/zalando/aruha/nakadi/controller/EventStreamControllerTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/controller/EventStreamControllerTest.java
@@ -219,8 +219,6 @@ public class EventStreamControllerTest {
     public void whenNormalCaseThenParametersArePassedToConfigAndStreamStarted() throws Exception {
         final EventConsumer eventConsumerMock = mock(EventConsumer.class);
         when(topicRepositoryMock.topicExists(eq(TEST_EVENT_TYPE))).thenReturn(true);
-//        when(topicRepositoryMock.validateCursors(eq(TEST_EVENT_TYPE), eq(ImmutableList.of(new Cursor("0", "0")))))
-//                .thenReturn(Optional.empty());
         when(topicRepositoryMock.createEventConsumer(eq(TEST_EVENT_TYPE), eq(ImmutableList.of(new Cursor("0", "0")))))
                 .thenReturn(eventConsumerMock);
 

--- a/src/test/java/de/zalando/aruha/nakadi/controller/EventStreamControllerTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/controller/EventStreamControllerTest.java
@@ -185,7 +185,7 @@ public class EventStreamControllerTest {
         final StreamingResponseBody responseBody = controller.streamEvents(TEST_EVENT_TYPE, 0, 0, 0, 0, 0,
                 "[{\"partition\":\"0\",\"offset\":\"0\"}]", requestMock, responseMock);
 
-        final Problem expectedProblem = Problem.valueOf(PRECONDITION_FAILED, "offset 0 for partition 0 unavailable");
+        final Problem expectedProblem = Problem.valueOf(PRECONDITION_FAILED, "offset 0 for partition 0 is unavailable");
         assertThat(responseToString(responseBody), jsonHelper.matchesObject(expectedProblem));
     }
 


### PR DESCRIPTION
Some users were confused when the provided offsets were resulting in
error. So instead of providing a boolean answer we now display more
detailed reasons for:

1. out of bounds offset
2. invalid offset value (nonnumerical nor "BEGIN")
3. empty partition
4. inexistent partition.

Also fixes #158 