### PR TITLE
aruha-136 Expose effective schema

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -394,7 +394,7 @@ paths:
           schema:
             $ref: '#/definitions/Problem'
 
-  /event-types/{name}/effective_schema:
+  /event-types/{name}/effective-schema:
     get:
       tags:
         - schema-registry-api

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -141,6 +141,8 @@ paths:
     get:
       tags:
         - schema-registry-api
+      security:
+        - oauth2: ['uid']
       description: Returns a list of all registered `EventType`s
       parameters:
         - name: X-Flow-Id
@@ -389,6 +391,46 @@ paths:
             $ref: '#/definitions/Problem'
         '503':
           description: Service (temporarily) unavailable
+          schema:
+            $ref: '#/definitions/Problem'
+
+  /event-types/{name}/effective_schema:
+    get:
+      tags:
+        - schema-registry-api
+      security:
+        - oauth2: ['uid']
+      description: |
+        When publishing events whose `EventType` category is either "business" or "data", additional fields are required
+        other than those described in the schema.
+
+        This endpoint exposes this effective schema, e.g. the schema used to validate events in fact.
+      parameters:
+        - name: name
+          in: path
+          description: Name of the EventType to update.
+          type: string
+          required: true
+        - name: X-Flow-Id
+          in: header
+          description: |
+            The flow id of the request, which is written into the logs and passed to called services. Helpful
+            for operational troubleshooting and log analysis.
+          type: string
+          format: flow-id
+      responses:
+        '200':
+          description: Ok
+        '401':
+          description: Client is not authenticated
+          schema:
+            $ref: '#/definitions/Problem'
+        '404':
+          description: EventType not found.
+          schema:
+              $ref: '#/definitions/Problem'
+        '500':
+          description: Server error
           schema:
             $ref: '#/definitions/Problem'
 

--- a/src/main/java/de/zalando/aruha/nakadi/controller/EventTypeController.java
+++ b/src/main/java/de/zalando/aruha/nakadi/controller/EventTypeController.java
@@ -163,7 +163,7 @@ public class EventTypeController {
         }
     }
 
-    @RequestMapping(value = "/{name}/effective_schema", method = RequestMethod.GET)
+    @RequestMapping(value = "/{name}/effective-schema", method = RequestMethod.GET)
     public ResponseEntity<?> exposeEventTypeEffectiveSchema(@PathVariable final String name, final NativeWebRequest nativeWebRequest) {
         try {
             final EventType eventType = eventTypeRepository.findByName(name);

--- a/src/test/java/de/zalando/aruha/nakadi/controller/EventTypeControllerTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/controller/EventTypeControllerTest.java
@@ -504,7 +504,7 @@ public class EventTypeControllerTest {
 
         when(eventTypeRepository.findByName(eventType.getName())).thenReturn(eventType);
 
-        final MockHttpServletRequestBuilder requestBuilder = get("/event-types/" + eventType.getName() + "/effective_schema").accept(
+        final MockHttpServletRequestBuilder requestBuilder = get("/event-types/" + eventType.getName() + "/effective-schema").accept(
                 APPLICATION_JSON);
 
         mockMvc.perform(requestBuilder).andExpect(status().is(200))
@@ -520,7 +520,7 @@ public class EventTypeControllerTest {
 
         when(eventTypeRepository.findByName(eventType.getName())).thenReturn(eventType);
 
-        final MockHttpServletRequestBuilder requestBuilder = get("/event-types/" + eventType.getName() + "/effective_schema").accept(
+        final MockHttpServletRequestBuilder requestBuilder = get("/event-types/" + eventType.getName() + "/effective-schema").accept(
                 APPLICATION_JSON);
 
         mockMvc.perform(requestBuilder).andExpect(status().is(200))
@@ -536,7 +536,7 @@ public class EventTypeControllerTest {
         Mockito.doThrow(new NoSuchEventTypeException("dummy message")).when(eventTypeRepository).findByName(
                 eventTypeName);
 
-        final MockHttpServletRequestBuilder requestBuilder = get("/event-types/" + eventTypeName + "/effective_schema").
+        final MockHttpServletRequestBuilder requestBuilder = get("/event-types/" + eventTypeName + "/effective-schema").
                 accept(APPLICATION_JSON);
 
         mockMvc.perform(requestBuilder)

--- a/src/test/java/de/zalando/aruha/nakadi/utils/TestUtils.java
+++ b/src/test/java/de/zalando/aruha/nakadi/utils/TestUtils.java
@@ -89,6 +89,10 @@ public class TestUtils {
         return IOUtils.toString(clazz.getResourceAsStream(resourceName));
     }
 
+    public static String getStringFromFile(final String resourceName) throws IOException {
+        return Resources.toString(Resources.getResource(resourceName), Charsets.UTF_8);
+    }
+
     public static EventType buildEventType(final String name, final JSONObject schema) {
         final EventType et = new EventType();
         et.setName(name);

--- a/src/test/resources/sample-business-event-type-effective-schema.json
+++ b/src/test/resources/sample-business-event-type-effective-schema.json
@@ -1,0 +1,40 @@
+{
+  "type": "object",
+  "properties": {
+    "foo": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "eid": {
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+        },
+        "event_type": {
+          "type": "string",
+          "enum": ["NAME_PLACEHOLDER"]
+        },
+        "occurred_at": {
+          "type": "string"
+        },
+        "parent_eids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+          }
+        },
+        "flow_id": {
+          "type": "string"
+        },
+        "partition": {
+          "type": "string"
+        }
+      },
+      "required": ["eid", "occurred_at"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["foo", "metadata"]
+}

--- a/src/test/resources/sample-business-event-type.json
+++ b/src/test/resources/sample-business-event-type.json
@@ -1,0 +1,9 @@
+{
+  "name": "NAME_PLACEHOLDER",
+  "owning_application": "article-producer",
+  "category": "business",
+  "schema": {
+    "type": "json_schema",
+    "schema": "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}}, \"required\": [\"foo\"]}"
+  }
+}

--- a/src/test/resources/sample-datachange-event-type-effective-schema.json
+++ b/src/test/resources/sample-datachange-event-type-effective-schema.json
@@ -1,0 +1,53 @@
+{
+  "type": "object",
+  "properties": {
+    "data_type": {
+      "type": "string"
+    },
+    "data_op": {
+      "type": "string",
+      "enum": ["C", "U", "D", "S"]
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "required": ["foo"]
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "eid": {
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+        },
+        "event_type": {
+          "type": "string",
+          "enum": ["NAME_PLACEHOLDER"]
+        },
+        "occurred_at": {
+          "type": "string"
+        },
+        "parent_eids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+          }
+        },
+        "flow_id": {
+          "type": "string"
+        },
+        "partition": {
+          "type": "string"
+        }
+      },
+      "required": ["eid", "occurred_at"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["metadata", "data_type", "data_op", "data"]
+}

--- a/src/test/resources/sample-datachange-event-type.json
+++ b/src/test/resources/sample-datachange-event-type.json
@@ -1,0 +1,9 @@
+{
+  "name": "NAME_PLACEHOLDER",
+  "owning_application": "article-producer",
+  "category": "data",
+  "schema": {
+    "type": "json_schema",
+    "schema": "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}}, \"required\": [\"foo\"]}"
+  }
+}


### PR DESCRIPTION
When publishing events whose `EventType` category is either "business"
or "data", additional fields are required other than those described in
the schema.

This endpoint exposes this effective schema, e.g. the schema used to
validate events in fact.