### PR TITLE
aruha-181 Set eid in the response when present

### DIFF
--- a/src/main/java/de/zalando/aruha/nakadi/domain/BatchItem.java
+++ b/src/main/java/de/zalando/aruha/nakadi/domain/BatchItem.java
@@ -15,7 +15,7 @@ public class BatchItem {
 
         Optional.
                 ofNullable(event.optJSONObject("metadata"))
-                .map(e -> e.optString("eid"))
+                .map(e -> e.optString("eid", null))
                 .ifPresent(this.response::setEid);
     }
 

--- a/src/main/java/de/zalando/aruha/nakadi/domain/BatchItem.java
+++ b/src/main/java/de/zalando/aruha/nakadi/domain/BatchItem.java
@@ -14,7 +14,7 @@ public class BatchItem {
         this.event = event;
 
         Optional.
-                of(event.optJSONObject("metadata"))
+                ofNullable(event.optJSONObject("metadata"))
                 .map(e -> e.optString("eid"))
                 .ifPresent(this.response::setEid);
     }

--- a/src/main/java/de/zalando/aruha/nakadi/domain/BatchItem.java
+++ b/src/main/java/de/zalando/aruha/nakadi/domain/BatchItem.java
@@ -2,8 +2,7 @@ package de.zalando.aruha.nakadi.domain;
 
 import org.json.JSONObject;
 
-import static de.zalando.aruha.nakadi.domain.EventPublishingStatus.FAILED;
-import static de.zalando.aruha.nakadi.domain.EventPublishingStatus.SUBMITTED;
+import java.util.Optional;
 
 public class BatchItem {
     private final BatchItemResponse response;
@@ -13,6 +12,11 @@ public class BatchItem {
     public BatchItem(final JSONObject event) {
         this.response = new BatchItemResponse();
         this.event = event;
+
+        Optional.
+                of(event.optJSONObject("metadata"))
+                .map(e -> e.optString("eid"))
+                .ifPresent(this.response::setEid);
     }
 
     public JSONObject getEvent() {

--- a/src/main/java/de/zalando/aruha/nakadi/domain/BatchItemResponse.java
+++ b/src/main/java/de/zalando/aruha/nakadi/domain/BatchItemResponse.java
@@ -4,12 +4,17 @@ public class BatchItemResponse {
     private EventPublishingStatus publishingStatus = EventPublishingStatus.ABORTED;
     private EventPublishingStep step = EventPublishingStep.NONE;
     private String detail = "";
+    private String eid = "";
+
+    public String getEid() { return eid; }
+
+    public void setEid(final String eid) { this.eid = eid; }
 
     public EventPublishingStatus getPublishingStatus() {
         return publishingStatus;
     }
 
-    public void setPublishingStatus(EventPublishingStatus publishingStatus) {
+    public void setPublishingStatus(final EventPublishingStatus publishingStatus) {
         this.publishingStatus = publishingStatus;
     }
 

--- a/src/test/java/de/zalando/aruha/nakadi/service/EventPublisherTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/service/EventPublisherTest.java
@@ -21,9 +21,11 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import static de.zalando.aruha.nakadi.utils.TestUtils.buildBusinessEvent;
 import static de.zalando.aruha.nakadi.utils.TestUtils.buildDefaultEventType;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -54,6 +56,20 @@ public class EventPublisherTest {
         final EventPublishResult result = publisher.publish(batch, eventType.getName());
 
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.SUBMITTED));
+        verify(topicRepository, times(1)).syncPostBatch(eq(eventType.getName()), any());
+    }
+
+    @Test
+    public void whenEventHasEidThenSetItInTheResponse() throws Exception {
+        final EventType eventType = buildDefaultEventType();
+        final JSONObject event = buildBusinessEvent();
+        final JSONArray batch = new JSONArray(Arrays.asList(event));
+
+        mockSuccessfulValidation(eventType, event);
+
+        final EventPublishResult result = publisher.publish(batch, eventType.getName());
+
+        assertThat(result.getResponses().get(0).getEid(), equalTo(event.getJSONObject("metadata").optString("eid")));
         verify(topicRepository, times(1)).syncPostBatch(eq(eventType.getName()), any());
     }
 


### PR DESCRIPTION
In order to make it easier for producers to correlate a response with an
event we are setting the eid as a property in the batch item response.