### PR TITLE
aruha-151 fix definitions on data change events

### DIFF
--- a/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
@@ -45,6 +45,8 @@ public class EventValidation {
 
         addMetadata(wrapper, eventType);
 
+        moveDefinitionsToRoot(wrapper, schema);
+
         final JSONObject properties = wrapper.getJSONObject("properties");
 
         properties.put("data_type", new JSONObject().put("type", "string"));
@@ -57,6 +59,14 @@ public class EventValidation {
         addToRequired(wrapper, new String[]{ "data_type", "data_op", "data" });
 
         return wrapper;
+    }
+
+    private static void moveDefinitionsToRoot(final JSONObject wrapper, final JSONObject schema) {
+        final Object definitions = schema.remove("definitions");
+
+        if (definitions != null) {
+            wrapper.put("definitions", definitions);
+        }
     }
 
     private static JSONObject addMetadata(final JSONObject schema, final EventType eventType) {

--- a/src/test/java/de/zalando/aruha/nakadi/utils/TestUtils.java
+++ b/src/test/java/de/zalando/aruha/nakadi/utils/TestUtils.java
@@ -107,6 +107,10 @@ public class TestUtils {
         return buildEventType(randomValidEventTypeName(), new JSONObject("{ \"price\": 1000 }"));
     }
 
+    public static String readFile(final String filename) throws IOException {
+        return Resources.toString(Resources.getResource(filename), Charsets.UTF_8);
+    }
+
     public static JSONObject buildBusinessEvent() throws IOException {
         final String json = Resources.toString(Resources.getResource("sample-business-event.json"), Charsets.UTF_8);
         return new JSONObject(json);

--- a/src/test/java/de/zalando/aruha/nakadi/validation/JSONSchemaValidationTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/validation/JSONSchemaValidationTest.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import static de.zalando.aruha.nakadi.utils.IsOptional.isAbsent;
 import static de.zalando.aruha.nakadi.utils.IsOptional.isPresent;
 import static de.zalando.aruha.nakadi.utils.TestUtils.buildEventType;
+import static de.zalando.aruha.nakadi.utils.TestUtils.readFile;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -225,6 +226,18 @@ public class JSONSchemaValidationTest {
         Optional<ValidationError> error = EventValidation.forType(et).validate(event);
 
         assertThat(error.get().getMessage(), equalTo("#/metadata/eid: string [x] does not match pattern ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"));
+    }
+
+    @Test
+    public void acceptsDefinitionsOnDataChangeEvents() throws Exception {
+        final JSONObject schema = new JSONObject(readFile("product-json-schema.json"));
+        final EventType et = buildEventType("some-event-type", schema);
+        et.setCategory(EventCategory.DATA);
+        final JSONObject event = new JSONObject(readFile("product-event.json"));
+
+        final Optional<ValidationError> error = EventValidation.forType(et).validate(event);
+
+        assertThat(error, isAbsent());
     }
 
     private JSONObject basicSchema() {

--- a/src/test/resources/product-event.json
+++ b/src/test/resources/product-event.json
@@ -1,0 +1,33 @@
+{
+  "metadata": {
+    "eid": "12341234-1234-1324-1324-123412341234",
+    "occurred_at": "1992-08-03T10:00:00Z"
+  },
+  "data_type": "some-event-type",
+  "data_op": "C",
+  "data": {
+    "owner_id": "sometenantid",
+    "event_timestamp": "2016-05-10T16:43:24.672Z",
+    "product_status": "active",
+    "event_type": "create",
+    "product_id": "C2FDA95C-CB3B-4EA2-9386-500E9227521D",
+    "product": {
+      "attributes": [
+        {
+          "type": {
+            "id": "4172595c-591c-4cd3-9048-d103eb5e45fc"
+          },
+          "values": [
+            {
+              "attribute": {
+                "id": "c53c6c42-ab04-49ed-8e44-0ff7ee9d519b"
+              },
+              "discrim": "ref"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+

--- a/src/test/resources/product-json-schema.json
+++ b/src/test/resources/product-json-schema.json
@@ -1,0 +1,238 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "event_type",
+    "owner_id",
+    "product_id",
+    "product_status",
+    "event_timestamp"
+  ],
+  "properties": {
+    "product_id": {
+      "type": "string"
+    },
+    "event_type": {
+      "enum": [
+        "create",
+        "update",
+        "delete"
+      ]
+    },
+    "owner_id": {
+      "type": "string"
+    },
+    "event_timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp of when this event was published. Each attempt to publish may result in a new timestamp"
+    },
+    "product_status": {
+      "enum": [
+        "active",
+        "inactive"
+      ]
+    },
+    "product": {
+      "$ref": "#/definitions/Product",
+      "description": "The product will be present for CREATE or UPDATE events"
+    }
+  },
+  "additional_properties": false,
+
+  "definitions": {
+
+    "Attribute": {
+      "type": "object",
+      "required": [
+        "type",
+        "values"
+      ],
+      "properties": {
+        "type": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+              "description": "This is a UUID value"
+            }
+          }
+        },
+        "values": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+
+    "Value": {
+      "type": "object",
+      "oneOf": [
+        { "$ref": "#/definitions/ReferenceValue" },
+        { "$ref": "#/definitions/BooleanValue" },
+        { "$ref": "#/definitions/StringValue" },
+        { "$ref": "#/definitions/LocalizedStringValue" },
+        { "$ref": "#/definitions/IntegerValue" },
+        { "$ref": "#/definitions/DecimalValue" },
+        { "$ref": "#/definitions/DatetimeValue" },
+        { "$ref": "#/definitions/StructuredValue" }
+      ]
+    },
+
+    "ReferenceValue": {
+      "type": "object",
+      "description": "A reference to an attribute, by ID, in the master-attributes service",
+      "required": [
+        "discrim",
+        "attribute"
+      ],
+      "properties": {
+        "discrim": { "enum": [ "ref" ] },
+        "attribute": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+              "description": "This is a UUID value"
+            }
+          }
+        }
+      }
+    },
+
+    "BooleanValue": {
+      "type": "object",
+      "required": [
+        "discrim",
+        "value"
+      ],
+      "properties": {
+        "discrim": { "enum": ["boolean"] },
+        "value": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+
+    "StringValue": {
+      "type": "object",
+      "required": [
+        "discrim",
+        "value"
+      ],
+      "properties": {
+        "discrim": { "enum": ["string"] },
+        "value": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+
+    "LocalizedStringValue": {
+      "type": "object",
+      "required": [
+        "discrim",
+        "id"
+      ],
+      "properties": {
+        "discrim": { "enum": [ "localized" ] },
+        "id": {
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+          "description": "The UUID ID of this text in the localized text service in SPP"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "IntegerValue": {
+      "type": "object",
+      "required": [
+        "discrim",
+        "value"
+      ],
+      "properties": {
+        "discrim": { "enum": [ "integer" ] },
+        "value": {
+          "type": "integer",
+          "minimum": -9223372036854775808,
+          "maximum": 9223372036854775807
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "DecimalValue": {
+      "type": "object",
+      "required": [
+        "discrim",
+        "value"
+      ],
+      "properties": {
+        "discrim": { "enum": [ "decimal" ] },
+        "value": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "DatetimeValue": {
+      "type": "object",
+      "required": [
+        "discrim",
+        "value"
+      ],
+      "properties": {
+        "discrim": { "enum": [ "datetime" ] },
+        "value": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "StructuredValue": {
+      "type": "object",
+      "required": [
+        "discrim",
+        "values"
+      ],
+      "properties": {
+        "discrim": { "enum": [ "struct" ] },
+        "values": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/Attribute"
+          }
+        }
+      }
+    },
+
+    "Product": {
+      "type": "object",
+      "required": [
+        "attributes"
+      ],
+      "properties": {
+        "attributes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Attribute"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Since we wrapping the original json schema inside a wrapper schema,
references to definitions in the root of the provided JSON were broken.

This commit fixes this issue by moving definitions to the root of the
wrapper json.

If there are other definitions at other levels of the provided json
schema, that would stil be an unsolved issue.