### PR TITLE
aruha-184 fix schema doc

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1222,8 +1222,11 @@ definitions:
     properties:
       type:
         type: string
-        example: 'json-schema'
-        description: The type of schema definition (avro, json-schema, etc).
+        enum:
+          - JSON_SCHEMA
+        description: |
+          The type of schema definition. Currently only JSON_SCHEMA v4 is supported, but in the future there
+          could be others.
       schema:
         type: string
         description: |

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1177,8 +1177,7 @@ definitions:
         allOf:
           - $ref: '#/definitions/EventTypeSchema'
         description: |
-          The schema for this EventType. This is expected to be a json schema in yaml format (other formats
-          might be added in the future).
+          The schema for this EventType. Submitted events will be validated against it.
 
       data_key_fields:
         type: array


### PR DESCRIPTION
The format of the serialized string should follow the specified
"schema.type", as stated in the EventTypeSchema object definition.