### PR TITLE
aruha-185 fix enrichment api documentation

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1157,12 +1157,16 @@ definitions:
           upon reception (and after validation) of an Event and is only possible on fields that are not
           defined on the incoming Event.
 
+          For event types in categories 'business' or 'data' it's mandatory to use metadata_enrichment strategy. For
+          'undefined' event types it's not possible to use this strategy, since metadata field is not required.
+
           See documentation for the write operation for details on behaviour in case of unsuccessful
           enrichment.
         type: array
         items:
           type: string
-        default: ['metadata-enrichment']
+          enum:
+            - metadata_enrichment
 
       partition_strategy:
         description: |
@@ -1217,6 +1221,7 @@ definitions:
       - name
       - category
       - owning_application
+      - enrichment_strategies
       - schema
 
   EventTypeSchema:

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1166,7 +1166,7 @@ definitions:
         items:
           type: string
           enum:
-            - metadata_enrichment
+            - METADATA_ENRICHMENT
 
       partition_strategy:
         description: |

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1157,7 +1157,7 @@ definitions:
           upon reception (and after validation) of an Event and is only possible on fields that are not
           defined on the incoming Event.
 
-          For event types in categories 'business' or 'data' it's mandatory to use metadata_enrichment strategy. For
+          For event types in categories 'business' or 'data' it's mandatory to use METADATA_ENRICHMENT strategy. For
           'undefined' event types it's not possible to use this strategy, since metadata field is not required.
 
           See documentation for the write operation for details on behaviour in case of unsuccessful
@@ -1221,7 +1221,6 @@ definitions:
       - name
       - category
       - owning_application
-      - enrichment_strategies
       - schema
 
   EventTypeSchema:


### PR DESCRIPTION
Trying to create an event type without any specified enrichment strategy
result in:

```
Failed to create event type end2end_monitor.test_invoked, code: 422,
message: {u'status': 422, u'type': u'http://httpstatus.es/422',
u'detail': u'must define metadata enrichment strategy', u'title':
u'Unprocessable Entity'}
```

But according to specs default enrichment_strategies is `metadata-enrichment`.

So in this PR we made it clear that enrichment strategy is required, when it
should specify it and why.