### PR TITLE
Replace partitioning_key_fields with partition_key_fields.

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1191,7 +1191,7 @@ definitions:
           If set MUST be a valid required field as defined in the schema.
           (TBD should be required? Is applicable only to both Business and DataChange Events?)
 
-      partitioning_key_fields:
+      partition_key_fields:
         type: array
         items:
           type: string


### PR DESCRIPTION
The server accepts partition_key_fields as the field name for event type creation and not the advertised field partitioning_key_fields.

Fixes #258