### PR TITLE
Match BatchItemResponse enum casing with API spec.

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1286,36 +1286,36 @@ definitions:
       publishing_status:
         type: string
         enum:
-          - SUBMITTED
-          - FAILED
-          - ABORTED
+          - submitted
+          - failed
+          - aborted
         description: |
           Indicator of the submission of the Event within a Batch.
-          - SUBMITTED indicates successful submission, including commit on he underlying broker.
-          - FAILED indicates the message submission was not possible and can be resubmitted if so desired.
-          - ABORTED indicates that the submission of this item was not attempted any further due to a failure
+          - "submitted" indicates successful submission, including commit on he underlying broker.
+          - "failed" indicates the message submission was not possible and can be resubmitted if so desired.
+          - "aborted" indicates that the submission of this item was not attempted any further due to a failure
             on another item in the batch.
       step:
         type: string
         enum:
-          - NONE
-          - VALIDATING
-          - ENRICHING
-          - PARTITIONING
-          - PUBLISHING
+          - none
+          - validating
+          - enriching
+          - partitioning
+          - publishing
         description: |
-          Indicator of the step in the pulbishing process this Event reached.
+          Indicator of the step in the publishing process this Event reached.
 
-          In Items that FAILED means the step of the failure.
+          In Items that "failed" means the step of the failure.
 
-          - NONE indicates that nothing was yet attempted for the publishing of this Event. Should be present
+          - "none" indicates that nothing was yet attempted for the publishing of this Event. Should be present
             only in the case of aborting the publishing during the validation of another (previous) Event.
-          - VALIDATING, ENRICHING, PARTITIONING and PUBLISHING indicate all the corresponding steps of the
+          - "validating", "enriching", "partitioning" and "publishing" indicate all the corresponding steps of the
             publishing process.
       detail:
         type: string
         description: |
-          Human readable information about the failure on this item. Items that are not SUBMITTED should have
+          Human readable information about the failure on this item. Items that are not "submitted" should have
           a description.
     required:
       - publishing_status

--- a/src/test/java/de/zalando/aruha/nakadi/domain/BatchItemResponseTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/domain/BatchItemResponseTest.java
@@ -1,0 +1,45 @@
+package de.zalando.aruha.nakadi.domain;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.zalando.aruha.nakadi.config.JsonConfig;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+
+public class BatchItemResponseTest {
+
+    private ObjectMapper mapper;
+
+    @Before
+    public void setUp() {
+        mapper = (new JsonConfig()).jacksonObjectMapper();
+    }
+
+    @Test
+    public void testEnumsHaveLowerCaseSerialization() throws Exception {
+
+        String detail = "detail";
+        String eid = UUID.randomUUID().toString();
+        TypeReference<Map<String, String>> typeRef = new TypeReference<Map<String, String>>() {
+        };
+        for (EventPublishingStatus status : EventPublishingStatus.values()) {
+            for (EventPublishingStep step : EventPublishingStep.values()) {
+                BatchItemResponse bir = new BatchItemResponse();
+                bir.setStep(step);
+                bir.setPublishingStatus(status);
+                bir.setDetail(detail);
+                bir.setEid(eid);
+                String json = mapper.writeValueAsString(bir);
+                Map<String, String> jsonMap = mapper.readValue(json, typeRef);
+                assertEquals(status.name().toLowerCase(), jsonMap.get("publishing_status"));
+                assertEquals(step.name().toLowerCase(), jsonMap.get("step"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
For #259. This changes the definition to declare lowercase strings for those fields and adds a test case to verify the JSON configuration is serializing lowercase values.
