### PR TITLE
Return application/x-json-stream for an event stream.

### DIFF
--- a/src/main/java/de/zalando/aruha/nakadi/controller/EventStreamController.java
+++ b/src/main/java/de/zalando/aruha/nakadi/controller/EventStreamController.java
@@ -140,7 +140,7 @@ public class EventStreamController {
                         streamLimit, batchTimeout, streamTimeout, streamKeepAliveLimit);
 
                 response.setStatus(HttpStatus.OK.value());
-                response.setContentType("text/plain"); // TODO: must be aligned with API
+                response.setContentType("application/x-json-stream");
                 final EventStream eventStream = eventStreamFactory.createEventStream(eventConsumer, outputStream,
                         streamConfig);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ server:
   port: 8080
   compression:
     enabled: true
-#    mime-types: custom/mime-type,text/html,text/xml,text/plain
+    mime-types: text/plain,application/x-json-stream
 management:
   port: 7979
 logging:

--- a/src/test/java/de/zalando/aruha/nakadi/controller/EventStreamControllerTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/controller/EventStreamControllerTest.java
@@ -253,8 +253,9 @@ public class EventStreamControllerTest {
                 ));
 
         assertThat(statusCaptor.getValue(), equalTo(HttpStatus.OK.value()));
-        assertThat(contentTypeCaptor.getValue(), equalTo("text/plain"));
+        assertThat(contentTypeCaptor.getValue(), equalTo("application/x-json-stream"));
 
+        
         verify(topicRepositoryMock, times(1)).createEventConsumer(eq(TEST_EVENT_TYPE), eq(ImmutableList.of(new Cursor("0", "0"))));
         verify(eventStreamFactoryMock, times(1)).createEventStream(eq(eventConsumerMock), eq(outputStream),
                 eq(streamConfig));

--- a/src/test/java/de/zalando/aruha/nakadi/controller/EventStreamControllerTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/controller/EventStreamControllerTest.java
@@ -254,7 +254,6 @@ public class EventStreamControllerTest {
 
         assertThat(statusCaptor.getValue(), equalTo(HttpStatus.OK.value()));
         assertThat(contentTypeCaptor.getValue(), equalTo("application/x-json-stream"));
-
         
         verify(topicRepositoryMock, times(1)).createEventConsumer(eq(TEST_EVENT_TYPE), eq(ImmutableList.of(new Cursor("0", "0"))));
         verify(eventStreamFactoryMock, times(1)).createEventStream(eq(eventConsumerMock), eq(outputStream),


### PR DESCRIPTION
This changes the event stream response's content type from "text/plain" to "application/x-json-stream" to make it line up with the API definition. Possibly some discussion needed on the preferred content type for the stream before merging.

For #257