### PR TITLE
Fix field name of EventType

### DIFF
--- a/src/main/java/de/zalando/aruha/nakadi/controller/EventTypeController.java
+++ b/src/main/java/de/zalando/aruha/nakadi/controller/EventTypeController.java
@@ -80,7 +80,7 @@ public class EventTypeController {
             enrichment.validate(eventType);
             partitionResolver.validate(eventType);
             eventTypeRepository.saveEventType(eventType);
-            topicRepository.createTopic(eventType.getName(), eventType.getDefaultStatistic());
+            topicRepository.createTopic(eventType.getName(), eventType.getDefaultStatistics());
             return status(HttpStatus.CREATED).build();
         } catch (final InvalidEventTypeException | NoSuchPartitionStrategyException |
                 DuplicatedEventTypeNameException e) {
@@ -189,8 +189,8 @@ public class EventTypeController {
 
         validateName(name, eventType);
         validateSchemaChange(eventType, existingEventType);
-        eventType.setDefaultStatistic(
-                validateStatisticsUpdate(existingEventType.getDefaultStatistic(), eventType.getDefaultStatistic()));
+        eventType.setDefaultStatistics(
+                validateStatisticsUpdate(existingEventType.getDefaultStatistics(), eventType.getDefaultStatistics()));
     }
 
     private EventTypeStatistics validateStatisticsUpdate(final EventTypeStatistics existing, final EventTypeStatistics newStatistics) throws InvalidEventTypeException {

--- a/src/main/java/de/zalando/aruha/nakadi/domain/EventType.java
+++ b/src/main/java/de/zalando/aruha/nakadi/domain/EventType.java
@@ -44,7 +44,7 @@ public class EventType {
 
     @Valid
     @Nullable
-    private EventTypeStatistics defaultStatistic;
+    private EventTypeStatistics defaultStatistics;
 
     public String getName() { return name; }
 
@@ -86,12 +86,12 @@ public class EventType {
         this.schema = schema;
     }
 
-    public EventTypeStatistics getDefaultStatistic() {
-        return defaultStatistic;
+    public EventTypeStatistics getDefaultStatistics() {
+        return defaultStatistics;
     }
 
-    public void setDefaultStatistic(final EventTypeStatistics defaultStatistic) {
-        this.defaultStatistic = defaultStatistic;
+    public void setDefaultStatistics(final EventTypeStatistics defaultStatistics) {
+        this.defaultStatistics = defaultStatistics;
     }
 
     public List<String> getPartitionKeyFields() {

--- a/src/test/java/de/zalando/aruha/nakadi/controller/EventTypeControllerTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/controller/EventTypeControllerTest.java
@@ -294,7 +294,7 @@ public class EventTypeControllerTest {
         statistics.setMessagesPerMinute(1000);
         statistics.setReadParallelism(1);
         statistics.setWriteParallelism(2);
-        defaultEventType.setDefaultStatistic(statistics);
+        defaultEventType.setDefaultStatistics(statistics);
         postEventType(defaultEventType).andExpect(status().is2xxSuccessful());
         verify(topicRepository, times(1)).createTopic(eq(defaultEventType.getName()), eq(statistics));
     }


### PR DESCRIPTION
In the API it's called "default_statistics" but it was implemented as "default_statistic" (without an "s")

@v-stepanov @rcillo @antban @jkliff 