### PR TITLE
ARUHA-240: Remove data_key_fields from definition.

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1198,16 +1198,6 @@ definitions:
         description: |
           The schema for this EventType. Submitted events will be validated against it.
 
-      data_key_fields:
-        type: array
-        items:
-          type: string
-        description: |
-          Indicators of the path of the properties that constitute the primary key (identifier) of
-          the data within this Event.  If set MUST be a valid required field as defined in the
-          schema.  (TBD should be required? Is applicable only to both Business and DataChange
-          Events?)
-
       partition_key_fields:
         type: array
         items:


### PR DESCRIPTION
The `data_key_fields` isn't implemented in the code and setting it
stops event type creation. This removes the property from the API
definition for the moment; apart from breaking event type creation,
it's not a certainty the property will be used (there's a TBD in
the documentation).

For #272.