### PR TITLE
ARUHA-240: lower case some enums in the definition.

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1172,7 +1172,7 @@ definitions:
           fields that are not defined on the incoming Event.
 
           For event types in categories 'business' or 'data' it's mandatory to use
-          METADATA_ENRICHMENT strategy. For 'undefined' event types it's not possible to use this
+          metadata_enrichment strategy. For 'undefined' event types it's not possible to use this
           strategy, since metadata field is not required.
 
           See documentation for the write operation for details on behaviour in case of unsuccessful
@@ -1181,7 +1181,7 @@ definitions:
         items:
           type: string
           enum:
-            - METADATA_ENRICHMENT
+            - metadata_enrichment
 
       partition_strategy:
         description: |
@@ -1238,9 +1238,9 @@ definitions:
       type:
         type: string
         enum:
-          - JSON_SCHEMA
+          - json_schema
         description: |
-          The type of schema definition. Currently only JSON_SCHEMA v4 is supported, but in the
+          The type of schema definition. Currently only json_schema (JSON Schema v04) is supported, but in the
           future there could be others.
       schema:
         type: string


### PR DESCRIPTION
Follow up to 00448ed to lower case the metadata_enrichment and
json_schema enum values and align the code with the API
definition.

After this the only uppercase enums are the 4 letters used for the
`data_op` value (these match the implementation, which checks they
are uppercase when sent).