### PR TITLE
ARUHA-242: Remove validation_strategies from the API yaml.

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -185,13 +185,9 @@ paths:
         of a Topic. If so desired, clients can interact directly with the topic using the low level
         API (for existing restrictions see the corresponding methods on the topic-api).
 
-        The fields validation-strategies, enrichment-strategies and partition-resolution-strategy
+        The fields enrichment-strategies and partition-resolution-strategy
         have all an effect on the incoming Event of this EventType. For its impacts on the reception
         of events please consult the Event submission API methods.
-
-        * Validation strategies define an array of validation stategies to be evaluated on reception
-        of an `Event` of this `EventType`. Details of usage can be found in an external document
-        (TBD link to document).
 
         * TBD Enrichment strategy
 
@@ -207,7 +203,7 @@ paths:
         * Using `EventTypeSchema.type` other than json-schema or passing a `EventTypeSchema.schema`
         that is invalid with respect to the schema's type. Rejects with 422 Unprocessable entity.
 
-        * Referring any of Validation, Enrichment or Partition strategies that does not exist or
+        * Referring any Enrichment or Partition strategies that do not exist or
         whose parametrization is deemed invalid. Rejects with 422 Unprocessable entity.
 
         Nakadi MIGHT impose necessary schema, validation and enrichment minimal configurations that
@@ -317,7 +313,7 @@ paths:
         - name: X-Flow-Id
           in: header
           description: |
-          The flow id of the request, which is written into the logs and passed to called
+            The flow id of the request, which is written into the logs and passed to called
             services. Helpful for operational troubleshooting and log analysis.
           type: string
           format: flow-id
@@ -407,7 +403,7 @@ paths:
         validation, enrichment and partition. The steps performed on reception of incoming message
         are:
 
-        1. Every validation rule specified in the `EventType` will be checked in order against the
+        1. Every validation rule specified for the `EventType` will be checked in order against the
         incoming Events. Validation rules are evaluated in the order they are defined and the Event
         is **rejected** in the first case of failure. If the offending validation rule provides
         information about the violation it will be included in the `BatchItemResponse`.  If the
@@ -455,7 +451,7 @@ paths:
           description: All events in the batch have been successfully published.
         '207':
           description: |
-          At least one event has failed to be submitted. The batch might be partially submitted.
+            At least one event has failed to be submitted. The batch might be partially submitted.
           schema:
             type: array
             items:
@@ -738,31 +734,6 @@ paths:
           description: Not found
           schema:
             $ref: '#/definitions/Problem'
-        '500':
-          description: Server error
-          schema:
-            $ref: '#/definitions/Problem'
-        '503':
-          description: Service (temporarily) unavailable
-          schema:
-            $ref: '#/definitions/Problem'
-
-  '/registry/validation-strategies':
-    get:
-      tags:
-        - schema-registry-api
-      description: |
-        Lists all of the validation strategies supported by this installation of Nakadi.
-
-        If the EventType creation is to have special validations (besides the default), one can
-        consult over this method the available possibilities.
-      responses:
-        '200':
-          description: Returns a list of all validation strategies known to Nakadi
-          schema:
-            type: array
-            items:
-              type: string
         '500':
           description: Server error
           schema:
@@ -1133,12 +1104,11 @@ definitions:
           Defines the category of this EventType.
 
           The value set will influence, if not set otherwise, the default set of
-          validation-strategies, enrichment-strategies, and the effective schema for validation in
+          validations, enrichment-strategies, and the effective schema for validation in
           the following way:
 
           - `undefined`: No predefined changes apply. The effective schema for the validation is
-            exactly the same as the `EventTypeSchema`.  Default validation_strategy for this
-            `EventType` is `['schema-validation']`.
+            exactly the same as the `EventTypeSchema`.
 
           - `data`: Events of this category will be DataChangeEvents. The effective schema during
             the validation contains `metadata`, and adds fields `data_op` and `data_type`. The
@@ -1147,23 +1117,7 @@ definitions:
           - `business`: Events of this category will be BusinessEvents. The effective schema for
             validation contains `metadata` and any additionally defined properties passed in the
             `EventTypeSchema` directly on top level of the Event. If name conflicts arise, creation
-            of this EventType will be rejected.  Default validation_strategy for this `EventType` is
-            `['schema-validation']`.
-
-      validation_strategies:
-        description: |
-          Determines the validation that has to be executed upon reception of Events of this
-          type. Events are rejected if any of the rules fail (see details of Problem response on the
-          Event publishing methods).
-
-          Rule evaluation order is the same as in this array.
-
-          If not explicitly set, default value will respect the definition of the
-          `EventType.category`.
-        type: array
-        items:
-          type: string
-        default: ['schema-validation']
+            of this EventType will be rejected. 
 
       enrichment_strategies:
         description: |


### PR DESCRIPTION
This removes the `validation_strategies` property from event
type, and the corresponding registry path to see validations
available in the installation. These features are not
implemented yet by the server, and they can be added back
when they're available.

For #287