### PR TITLE
aruha-243 change default value of stream_timeout

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -590,7 +590,7 @@ paths:
           in: query
           description: |
             Maximum time in seconds a stream will live before being interrupted.
-            If 0 or unspecified will stream indefinitely.
+            If value is zero, streams indefinitely.
 
             If this timeout is reached, any pending messages (in the sense of `stream_limit`) will
             be flushed to the client.
@@ -599,7 +599,7 @@ paths:
           type: number
           format: int32
           required: false
-          default: 0
+          default: 60
         - name: stream_keep_alive_limit
           in: query
           description: |

--- a/src/main/java/de/zalando/aruha/nakadi/controller/EventStreamController.java
+++ b/src/main/java/de/zalando/aruha/nakadi/controller/EventStreamController.java
@@ -69,7 +69,7 @@ public class EventStreamController {
             @RequestParam(value = "batch_limit", required = false, defaultValue = "1") final int batchLimit,
             @RequestParam(value = "stream_limit", required = false, defaultValue = "0") final int streamLimit,
             @RequestParam(value = "batch_flush_timeout", required = false, defaultValue = "30") final int batchTimeout,
-            @RequestParam(value = "stream_timeout", required = false, defaultValue = "0") final int streamTimeout,
+            @RequestParam(value = "stream_timeout", required = false, defaultValue = "60") final int streamTimeout,
             @RequestParam(value = "stream_keep_alive_limit", required = false, defaultValue = "0") final int streamKeepAliveLimit,
             @Nullable @RequestHeader(name = "X-nakadi-cursors", required = false) final String cursorsStr,
             final NativeWebRequest request, final HttpServletResponse response) throws IOException {

--- a/src/test/java/de/zalando/aruha/nakadi/controller/EventStreamControllerTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/controller/EventStreamControllerTest.java
@@ -120,7 +120,7 @@ public class EventStreamControllerTest {
                 .withCursors(ImmutableMap.of("0", "0"))
                 .withStreamKeepAliveLimit(0)
                 .withStreamLimit(0)
-                .withStreamTimeout(0)
+                .withStreamTimeout(60)
                 .build();
         // we have to retry here as mockMvc exits at the very beginning, before the body starts streaming
         executeWithRetry(() -> assertThat(configCaptor.getValue(), equalTo(expectedConfig)),


### PR DESCRIPTION
In order to workaround the connection closing issue https://techjira.zalando.net/browse/ARUHA-196, where connections take a very long time (hours) to get closed when client disconnects due to
RST tcp package missing.