### PR TITLE
ARUHA-247: Optimise API definition for swagger tooling.

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -90,7 +90,7 @@ info:
     parameters (number of partitions, retention times, etc), as well as their modification.
 
 
-  version: '0.5.1'
+  version: '0.6.0'
   contact:
     name: Team Aruha @ Zalando
     email: team-aruha+nakadi-maintainers@zalando.de
@@ -116,28 +116,6 @@ securityDefinitions:
         Grants access for consuming Event streams.
 
 paths:
-  /metrics:
-    get:
-      tags:
-        - monitoring
-      summary: Get monitoring metrics
-      responses:
-        '200':
-          description: Ok
-          schema:
-            $ref: '#/definitions/Metrics'
-        '401':
-          description: Client is not authenticated
-          schema:
-            $ref: '#/definitions/Problem'
-        '500':
-          description: Server error
-          schema:
-            $ref: '#/definitions/Problem'
-        '503':
-          description: Service (temporarily) unavailable
-          schema:
-            $ref: '#/definitions/Problem'
   /event-types:
     get:
       tags:
@@ -162,15 +140,6 @@ paths:
           description: Client is not authenticated
           schema:
             $ref: '#/definitions/Problem'
-        '500':
-          description: Server error
-          schema:
-            $ref: '#/definitions/Problem'
-        '503':
-          description: Service (temporarily) unavailable
-          schema:
-            $ref: '#/definitions/Problem'
-
     post:
       tags:
         - schema-registry-api
@@ -234,15 +203,6 @@ paths:
           description: Unprocessable Entity
           schema:
             $ref: '#/definitions/Problem'
-        '500':
-          description: Server error
-          schema:
-            $ref: '#/definitions/Problem'
-        '503':
-          description: Service (temporarily) unavailable
-          schema:
-            $ref: '#/definitions/Problem'
-
 
   /event-types/{name}:
     get:
@@ -270,18 +230,6 @@ paths:
             $ref: '#/definitions/EventType'
         '401':
           description: Client is not authenticated
-          schema:
-            $ref: '#/definitions/Problem'
-        '404':
-          description: EventType not found
-          schema:
-            $ref: '#/definitions/Problem'
-        '500':
-          description: Server error
-          schema:
-            $ref: '#/definitions/Problem'
-        '503':
-          description: Service (temporarily) unavailable
           schema:
             $ref: '#/definitions/Problem'
 
@@ -324,23 +272,10 @@ paths:
           description: Client is not authenticated
           schema:
             $ref: '#/definitions/Problem'
-        '404':
-          description: EventType not found.
-          schema:
-              $ref: '#/definitions/Problem'
         '422':
           description: Unprocessable Entity
           schema:
             $ref: '#/definitions/Problem'
-        '500':
-          description: Server error
-          schema:
-            $ref: '#/definitions/Problem'
-        '503':
-          description: Service (temporarily) unavailable
-          schema:
-            $ref: '#/definitions/Problem'
-
     delete:
       tags:
         - schema-registry-api
@@ -370,22 +305,6 @@ paths:
           description: EventType is successfuly removed
         '401':
           description: Client is not authenticated
-          schema:
-            $ref: '#/definitions/Problem'
-        '403':
-          description: Client is not authorized to perform this operation
-          schema:
-            $ref: '#/definitions/Problem'
-        '404':
-          description: EventType not found.
-          schema:
-              $ref: '#/definitions/Problem'
-        '500':
-          description: Server error
-          schema:
-            $ref: '#/definitions/Problem'
-        '503':
-          description: Service (temporarily) unavailable
           schema:
             $ref: '#/definitions/Problem'
 
@@ -456,22 +375,10 @@ paths:
             type: array
             items:
               $ref: '#/definitions/BatchItemResponse'
-        '400':
-          description: Bad request
-          schema:
-            $ref: '#/definitions/Problem'
         '401':
           description: Client is not authenticated
           schema:
             $ref: '#/definitions/Problem'
-        '404':
-          description: EventType not found.
-          schema:
-              $ref: '#/definitions/Problem'
-        '405':
-          description: Not allowed.
-          schema:
-              $ref: '#/definitions/Problem'
         '422':
           description: |
             At least one event failed to be validated, enriched or partitioned. None were submitted.
@@ -479,14 +386,6 @@ paths:
             type: array
             items:
               $ref: '#/definitions/BatchItemResponse'
-        '500':
-          description: Server error
-          schema:
-            $ref: '#/definitions/Problem'
-        '503':
-          description: Service (temporarily) unavailable
-          schema:
-            $ref: '#/definitions/Problem'
     get:
       tags:
         - stream-api
@@ -621,28 +520,12 @@ paths:
             Stream format is a continuous series of `EventStreamBatch`s separated by `\n`
           schema:
             $ref: '#/definitions/EventStreamBatch'
-        '400':
-          description: Bad syntax
-          schema:
-            $ref: '#/definitions/Problem'
         '401':
           description: Not authenticated
           schema:
             $ref: '#/definitions/Problem'
-        '404':
-          description: EventType not found
-          schema:
-            $ref: '#/definitions/Problem'
         '422':
           description: Unprocessable entity
-          schema:
-            $ref: '#/definitions/Problem'
-        '500':
-          description: Internal Server Error. Details are provided on the returned `Problem`.
-          schema:
-            $ref: '#/definitions/Problem'
-        '503':
-          description: Service (temporarily) unavailable
           schema:
             $ref: '#/definitions/Problem'
 
@@ -681,16 +564,8 @@ paths:
             description: An array of `Partition`s
             items:
               $ref: '#/definitions/Partition'
-        '404':
-          description: EventType not found
-          schema:
-            $ref: '#/definitions/Problem'
-        '500':
-          description: Server error
-          schema:
-            $ref: '#/definitions/Problem'
-        '503':
-          description: Service (temporarily) unavailable
+        '401':
+          description: Client is not authenticated
           schema:
             $ref: '#/definitions/Problem'
 
@@ -730,18 +605,6 @@ paths:
           description: Client is not authenticated
           schema:
             $ref: '#/definitions/Problem'
-        '404':
-          description: Not found
-          schema:
-            $ref: '#/definitions/Problem'
-        '500':
-          description: Server error
-          schema:
-            $ref: '#/definitions/Problem'
-        '503':
-          description: Service (temporarily) unavailable
-          schema:
-            $ref: '#/definitions/Problem'
 
   '/registry/enrichment-strategies':
     get:
@@ -759,15 +622,10 @@ paths:
             type: array
             items:
               type: string
-        '500':
-          description: Server error
+        '401':
+          description: Client is not authenticated
           schema:
             $ref: '#/definitions/Problem'
-        '503':
-          description: Service (temporarily) unavailable
-          schema:
-            $ref: '#/definitions/Problem'
-
 
   '/registry/partition-strategies':
     get:
@@ -800,8 +658,8 @@ paths:
             type: array
             items:
               type: string
-        '500':
-          description: Server error
+        '401':
+          description: Client is not authenticated
           schema:
             $ref: '#/definitions/Problem'
 
@@ -827,7 +685,6 @@ definitions:
 
       For concrete examples of what will be enforced by Nakadi see the objects BusinessEvent and
       DataChangeEvent below.
-    additionalProperties: true
 
   EventMetadata:
     type: object
@@ -835,127 +692,116 @@ definitions:
       Metadata for this Event.
 
       Contains commons fields for both Business and DataChange Events. Most are enriched by Nakadi
-      upon reception, but they in general MIGHT be set by the client.
+      upon reception, but they in general MIGHT be set by the client.  
     properties:
-      metadata:
-        type: object
-        properties:
-          eid:
-            description: |
-              Identifier of this Event.
+      eid:
+        description: |
+          Identifier of this Event.
 
-              Clients MUST generate this value and it SHOULD be guaranteed to be unique from the
-              perspective of the producer. Consumers MIGHT use this value to assert uniqueness of
-              reception of the Event.
-            type: string
-            format: uuid
-            example: '105a76d8-db49-4144-ace7-e683e8f4ba46'
-          event_type:
-            description: |
-              The EventType of this Event. This is enriched by Nakadi on reception of the Event
-              based on the endpoint where the Producer sent the Event to.
+          Clients MUST generate this value and it SHOULD be guaranteed to be unique from the
+          perspective of the producer. Consumers MIGHT use this value to assert uniqueness of
+          reception of the Event.
+        type: string
+        format: uuid
+        example: '105a76d8-db49-4144-ace7-e683e8f4ba46'
+      event_type:
+        description: |
+          The EventType of this Event. This is enriched by Nakadi on reception of the Event
+          based on the endpoint where the Producer sent the Event to.
 
-              If provided MUST match the endpoint. Failure to do so will cause rejection of the
-              Event.
-            type: string
-            example: 'pennybags.payment-business-event'
-          occurred_at:
-            description: |
-              Timestamp of creation of the Event generated by the producer.
-            type: string
-            format: date-time
-            example: '1996-12-19T16:39:57-08:00'
-          received_at:
-            type: string
-            description: |
-              Timestamp of the reception of the Event by Nakadi. This is enriched upon reception of
-              the Event.
-              If set by the producer Event will be rejected.
-            format: date-time
-            example: '1996-12-19T16:39:57-08:00'
-          parent_eids:
-            type: array
-            items:
-              type: string
-              format: uuid
-              description: |
-                Event identifier of the Event that caused the generation of this Event.
-                Set by the producer.
-              example: '105a76d8-db49-4144-ace7-e683e8f4ba46'
-          flow_id:
-            description: |
-              The flow-id of the producer of this Event. As this is usually a HTTP header, this is
-              enriched from the header into the metadata by Nakadi to avoid clients having to
-              explicitly copy this.
-            type: string
-            example: 'JAh6xH4OQhCJ9PutIV_RYw'
-          partition:
-            description: |
-              Indicates the partition assigned to this Event.
+          If provided MUST match the endpoint. Failure to do so will cause rejection of the
+          Event.
+        type: string
+        example: 'pennybags.payment-business-event'
+      occurred_at:
+        description: |
+          Timestamp of creation of the Event generated by the producer.
+        type: string
+        format: date-time
+        example: '1996-12-19T16:39:57-08:00'
+      received_at:
+        type: string
+        description: |
+          Timestamp of the reception of the Event by Nakadi. This is enriched upon reception of
+          the Event.
+          If set by the producer Event will be rejected.
+        format: date-time
+        example: '1996-12-19T16:39:57-08:00'
+      parent_eids:
+        type: array
+        items:
+          type: string
+          format: uuid
+          description: |
+            Event identifier of the Event that caused the generation of this Event.
+            Set by the producer.
+          example: '105a76d8-db49-4144-ace7-e683e8f4ba46'
+      flow_id:
+        description: |
+          The flow-id of the producer of this Event. As this is usually a HTTP header, this is
+          enriched from the header into the metadata by Nakadi to avoid clients having to
+          explicitly copy this.
+        type: string
+        example: 'JAh6xH4OQhCJ9PutIV_RYw'
+      partition:
+        description: |
+          Indicates the partition assigned to this Event.
 
-              Required to be set by the client if partition strategy of the EventType is
-              'user_defined'.
-            type: string
-            example: '0'
-        required:
-          - eid
-          - occurred_at
-
-        additionalProperties: false
-
+          Required to be set by the client if partition strategy of the EventType is
+          'user_defined'.
+        type: string
+        example: '0'
     required:
-      - metadata
+      - eid
+      - occurred_at
 
   BusinessEvent:
-    type: object
     description: |
       A Business Event.
 
-      Usually represents a status transition in a Business process.
-    allOf:
-      - $ref: '#/definitions/EventMetadata'
-    additionalProperties: true
-
-  DataChangeEventQualifier:
-    type: object
-    description: |
-      Indicators of a `DataChangeEvent`'s referred data type and the type of operations done on
-      them.
-
-    properties:
-      data_type:
-        type: string
-        example: 'pennybags:order'
-      data_op:
-        type: string
-        enum: ['C', 'U', 'D', 'S']
-        description: |
-          The type of operation executed on the entity.
-          * C: Creation
-          * U: Update
-          * D: Deletion
-          * S: Snapshot
-    required:
-      - data_type
-      - data_op
+      Usually represents a status transition in a Business process.    
+    allOf:  
+      - $ref: '#/definitions/Event'
+      - type: object
+        properties:
+          metadata:
+              $ref: '#/definitions/EventMetadata'
+        required:
+            - metadata
 
   DataChangeEvent:
-    type: object
     description: |
       A Data change Event.
 
-      Represents a change on a resource.
+      Represents a change on a resource. Also contains indicators for the data 
+      type and the type of operation performed.
     allOf:
-      - $ref: '#/definitions/DataChangeEventQualifier'
-      - $ref: '#/definitions/EventMetadata'
-    properties:
-      data:
-        type: object
-        description: |
-            The payload of the type
-    required:
-        - data
-    additionalProperties: false
+      - $ref: '#/definitions/Event'
+      - type: object        
+        properties:
+          data_type:
+            type: string
+            example: 'pennybags:order'
+          data_op:
+            type: string
+            enum: ['C', 'U', 'D', 'S']
+            description: |
+              The type of operation executed on the entity.
+              * C: Creation
+              * U: Update
+              * D: Deletion
+              * S: Snapshot
+          metadata:
+            $ref: '#/definitions/EventMetadata'
+          data:
+            type: object
+            description: |
+                The payload of the type
+        required:
+            - data
+            - metadata
+            - data_type
+            - data_op
 
   Problem:
     type: object
@@ -995,9 +841,6 @@ definitions:
       - type
       - title
       - status
-
-  Metrics:
-    type: object
 
   Partition:
     description: |
@@ -1147,8 +990,7 @@ definitions:
 
       schema:
         type: object
-        allOf:
-          - $ref: '#/definitions/EventTypeSchema'
+        $ref: '#/definitions/EventTypeSchema'
         description: |
           The schema for this EventType. Submitted events will be validated against it.
 
@@ -1164,8 +1006,7 @@ definitions:
 
       default_statistics:
         type: object
-        allOf:
-          - $ref: '#/definitions/EventTypeStatistics'
+        $ref: '#/definitions/EventTypeStatistics'
         description: |
           Statistics of this EventType used for optimization purposes. Internal use of these values
           might change over time.
@@ -1188,6 +1029,7 @@ definitions:
           future there could be others.
       schema:
         type: string
+        $ref: '#/definitions/EventTypeSchema'
         description: |
           The schema as string in the syntax defined in the field type. Failure to respect the
           syntax will fail any operation on an EventType.


### PR DESCRIPTION
ARUHA-247: Optimise API definition for swagger tooling.

This changes the API definition to help swagger ui and codegen tools. Because 
there are structural changes to the object definitions, the API version is 
bumped to 0.6.0. The API JSON format is *not* being changed, just how the 
objects represent the data:

 - BusinessEvent and DataChangeEvent extend Event to make them available to
   swagger codegen's api client as subclasses. This specific subclassing
   technique for allOf allows codegen to subclass from Event but not do weird
   stuff like remove fields in the subclass (it's fiddly, but works).

 - Change how BusinessEvent and DataChangeEvent inline Metadata to make it
   visible to swagger ui, and avoid redundant Java classes. Avoid "Inline"
   anonymous objects in the ui.

 - Change how EventTypeStatistics and EventTypeSchema are inlined to EventType
   to make them visible to swagger ui. Avoid "Inline" anonymous objects in the
   ui.

 - Remove DataChangeEventQualifier and make its fields part of DataChangeEvent.
   DataChangeEventQualifier isn't used anywhere else.

 - Remove Metrics and /metrics as they don't do anything at the moment.

 - Remove non-interesting response codes from path definitions. Make sure all
   resources document happy-path responses and 401, otherwise only document
   notable responses.

 - Remove additionalProperties true/false declarations. Swagger doesn't accept 
   them, and they don't make or break the API (we can assume open for extension
   in the true cases, and closing for extension for the business and data 
   categories isn't strictly needed.

For #222

The result of codegen is visible here: https://github.com/dehora/nakadi-swagger-gen 

Note: try the [w=1 view of the diff](https://github.com/zalando/nakadi/pull/290/files?w=1) to review the changes (a chunk of the changes to Metadata are indendation) 