### PR TITLE
aruha-246 fix data change event partition

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -792,7 +792,8 @@ paths:
 
         - `hash`: Resolution of the partition follows the computation of a hash from the value of
           the fields indicated in the EventType's `partition_key_fields`, guaranteeing that Events
-          with same values on those fields end in the same partition.
+          with same values on those fields end in the same partition. Given the event type's category
+          is DataChangeEvent, field path is considered relative to "data".
       responses:
         '200':
           description: Returns a list of all partitioning strategies known to Nakadi
@@ -1158,7 +1159,7 @@ definitions:
           type: string
         description: |
           Required when 'partition_resolution_strategy' is set to 'hash'. Must be absent otherwise.
-          Indicates the fields used for evaluatiion the partition of Events of this type.
+          Indicates the fields used for evaluation the partition of Events of this type.
 
           If set it MUST be a valid required field as defined in the schema.
 

--- a/src/main/java/de/zalando/aruha/nakadi/partitioning/HashPartitionStrategy.java
+++ b/src/main/java/de/zalando/aruha/nakadi/partitioning/HashPartitionStrategy.java
@@ -15,7 +15,7 @@ import static java.lang.Math.abs;
 
 public class HashPartitionStrategy implements PartitionStrategy {
 
-    private final String DATA_PATH_PREFIX = EventValidation.DATA_CHANGE_WRAP_FIELD + ".";
+    private static final String DATA_PATH_PREFIX = EventValidation.DATA_CHANGE_WRAP_FIELD + ".";
 
     @Override
     public String calculatePartition(final EventType eventType, final JSONObject event, final List<String> partitions) throws InvalidPartitionKeyFieldsException {

--- a/src/main/java/de/zalando/aruha/nakadi/partitioning/HashPartitionStrategy.java
+++ b/src/main/java/de/zalando/aruha/nakadi/partitioning/HashPartitionStrategy.java
@@ -1,5 +1,6 @@
 package de.zalando.aruha.nakadi.partitioning;
 
+import de.zalando.aruha.nakadi.domain.EventCategory;
 import de.zalando.aruha.nakadi.domain.EventType;
 import de.zalando.aruha.nakadi.exceptions.ExceptionWrapper;
 import de.zalando.aruha.nakadi.exceptions.InvalidPartitionKeyFieldsException;
@@ -28,6 +29,7 @@ public class HashPartitionStrategy implements PartitionStrategy {
             final int hashValue = partitionKeyFields.stream()
                     // The problem is that JSONObject doesn't override hashCode(). Therefore convert it to
                     // a string first and then use hashCode()
+                    .map(pkf -> EventCategory.DATA.equals(eventType.getCategory()) ? "data." + pkf : pkf)
                     .map(wrapFunction(okf -> traversableJsonEvent.get(okf).toString().hashCode()))
                     .mapToInt(hc -> hc)
                     .sum();

--- a/src/main/java/de/zalando/aruha/nakadi/partitioning/HashPartitionStrategy.java
+++ b/src/main/java/de/zalando/aruha/nakadi/partitioning/HashPartitionStrategy.java
@@ -5,6 +5,7 @@ import de.zalando.aruha.nakadi.domain.EventType;
 import de.zalando.aruha.nakadi.exceptions.ExceptionWrapper;
 import de.zalando.aruha.nakadi.exceptions.InvalidPartitionKeyFieldsException;
 import de.zalando.aruha.nakadi.util.JsonPathAccess;
+import de.zalando.aruha.nakadi.validation.EventValidation;
 import org.json.JSONObject;
 
 import java.util.List;
@@ -13,6 +14,8 @@ import static de.zalando.aruha.nakadi.exceptions.ExceptionWrapper.wrapFunction;
 import static java.lang.Math.abs;
 
 public class HashPartitionStrategy implements PartitionStrategy {
+
+    private final String DATA_PATH_PREFIX = EventValidation.DATA_CHANGE_WRAP_FIELD + ".";
 
     @Override
     public String calculatePartition(final EventType eventType, final JSONObject event, final List<String> partitions) throws InvalidPartitionKeyFieldsException {
@@ -29,7 +32,7 @@ public class HashPartitionStrategy implements PartitionStrategy {
             final int hashValue = partitionKeyFields.stream()
                     // The problem is that JSONObject doesn't override hashCode(). Therefore convert it to
                     // a string first and then use hashCode()
-                    .map(pkf -> EventCategory.DATA.equals(eventType.getCategory()) ? "data." + pkf : pkf)
+                    .map(pkf -> EventCategory.DATA.equals(eventType.getCategory()) ? DATA_PATH_PREFIX + pkf : pkf)
                     .map(wrapFunction(okf -> traversableJsonEvent.get(okf).toString().hashCode()))
                     .mapToInt(hc -> hc)
                     .sum();

--- a/src/main/java/de/zalando/aruha/nakadi/util/JsonPathAccess.java
+++ b/src/main/java/de/zalando/aruha/nakadi/util/JsonPathAccess.java
@@ -27,12 +27,12 @@ public class JsonPathAccess {
 
         while ((field = pathTokenizer.nextToken()) != null) {
             if (!(curr instanceof JSONObject)) {
-                throw new InvalidPartitionKeyFieldsException("field " + field + "doesn't exist.");
+                throw new InvalidPartitionKeyFieldsException("field " + field + " doesn't exist.");
             }
             try {
                 curr = ((JSONObject) curr).get(field);
             } catch (JSONException e) {
-                throw new InvalidPartitionKeyFieldsException("field " + field + "doesn't exist.");
+                throw new InvalidPartitionKeyFieldsException("field " + field + " doesn't exist.");
             }
         }
         return curr;

--- a/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/EventValidation.java
@@ -12,6 +12,9 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class EventValidation {
+
+    public static final String DATA_CHANGE_WRAP_FIELD = "data";
+
     public static EventTypeValidator forType(final EventType eventType) {
         final EventTypeValidator etv = new EventTypeValidator(eventType);
 
@@ -52,7 +55,7 @@ public class EventValidation {
         properties.put("data_type", new JSONObject().put("type", "string"));
         properties.put("data_op", new JSONObject().put("type", "string")
                 .put("enum", Arrays.asList(new String[] { "C", "U", "D", "S" })));
-        properties.put("data", schema);
+        properties.put(DATA_CHANGE_WRAP_FIELD, schema);
 
         wrapper.put("additionalProperties", false);
 

--- a/src/test/java/de/zalando/aruha/nakadi/partitioning/PartitionResolverTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/partitioning/PartitionResolverTest.java
@@ -17,8 +17,11 @@ import static de.zalando.aruha.nakadi.partitioning.PartitionStrategy.HASH_STRATE
 import static de.zalando.aruha.nakadi.partitioning.PartitionStrategy.RANDOM_STRATEGY;
 import static de.zalando.aruha.nakadi.partitioning.PartitionStrategy.USER_DEFINED_STRATEGY;
 import static de.zalando.aruha.nakadi.utils.TestUtils.buildDefaultEventType;
+import static de.zalando.aruha.nakadi.utils.TestUtils.loadEventType;
+import static de.zalando.aruha.nakadi.utils.TestUtils.readFile;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
 import static org.mockito.Matchers.any;
 
 public class PartitionResolverTest {
@@ -76,6 +79,15 @@ public class PartitionResolverTest {
         eventType.setPartitionStrategy(HASH_STRATEGY);
 
         partitionResolver.validate(eventType);
+    }
+
+    @Test
+    public void whenValidateWithHashPartitionStrategyAndDataChangeEventLookupIntoDataField() throws Exception {
+        final EventType eventType = loadEventType("de/zalando/aruha/nakadi/domain/event-type.with.partition-key-fields.json");
+        eventType.setPartitionStrategy(HASH_STRATEGY);
+        final JSONObject event = new JSONObject(readFile("sample-data-event.json"));
+
+        assertThat(partitionResolver.resolvePartition(eventType, event), is(notNullValue()));
     }
 
     @Test(expected = InvalidEventTypeException.class)

--- a/src/test/java/de/zalando/aruha/nakadi/utils/TestUtils.java
+++ b/src/test/java/de/zalando/aruha/nakadi/utils/TestUtils.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.Random;
 import java.util.UUID;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import de.zalando.aruha.nakadi.config.JsonConfig;
@@ -35,7 +36,7 @@ public class TestUtils {
 
     private static final Random RANDOM = new Random();
 
-    private TestUtils() { }
+    private static final ObjectMapper objectMapper = new JsonConfig().jacksonObjectMapper();
 
     public static String randomUUID() {
         return UUID.randomUUID().toString();
@@ -121,6 +122,11 @@ public class TestUtils {
     public static JSONObject buildBusinessEvent() throws IOException {
         final String json = Resources.toString(Resources.getResource("sample-business-event.json"), Charsets.UTF_8);
         return new JSONObject(json);
+    }
+
+    public static EventType loadEventType(final String filename) throws IOException {
+        final String json = readFile(filename);
+        return objectMapper.readValue(json, EventType.class);
     }
 
     public static MappingJackson2HttpMessageConverter createMessageConverter() {

--- a/src/test/resources/sample-data-event.json
+++ b/src/test/resources/sample-data-event.json
@@ -1,0 +1,13 @@
+{
+  "metadata": {
+    "eid": "12341234-1234-1324-1324-123412341234",
+    "occurred_at": "1992-08-03T10:00:00Z"
+  },
+  "data_op": "U",
+  "data": {
+    "id": "abcdef123456",
+    "sku": "A1",
+    "name": "Super Shirt",
+    "price": 1000
+  }
+}


### PR DESCRIPTION
When defining `partition_key_fields` users expect that the lookup path
to be relative to the originally defined schema, but since Nakadi
manipulates the schema for DataChangeEvent's, we need to add this
special case in order to scope the path to the nested "data" field.

This ways users no longer need to prepend "data." to
partition_key_fields.