### PR TITLE
aruha-205 fix scm source json missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .cache
 __pycache__
 .coverage
+scm-source.json
 *.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zalando/python:3.4.0-2
+FROM registry.opensource.zalan.do/stups/python:3.4.0-4
 
 COPY requirements.txt /
 RUN pip3 install -r /requirements.txt
@@ -9,6 +9,7 @@ ADD nakadi /nakadi
 RUN find ./nakadi | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
 
 ADD run.sh /nakadi/run.sh
+ADD scm-source.json /scm-source.json
 
 WORKDIR /
 

--- a/local-test/Dockerfile.kafka
+++ b/local-test/Dockerfile.kafka
@@ -1,4 +1,4 @@
-FROM zalando/openjdk:8u45-b14-6
+FROM registry.opensource.zalan.do/stups/openjdk:8u91-b14-1-22
 
 ENV KAFKA_VERSION="0.8.2.1" SCALA_VERSION="2.10"
 ENV KAFKA_IMG="kafka_${SCALA_VERSION}-${KAFKA_VERSION}"


### PR DESCRIPTION
In order to fix the root cause of this violation type, it's required to
add the scm to the built image.

I also needed to change the base image since all others weren't available anymore.