### PR TITLE
Upgrade org.everit.json.schema to 1.3.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,7 +158,7 @@ dependencies {
     compile 'org.apache.curator:curator-recipes:2.9.1'
 
     // json
-    compile 'org.everit.json:org.everit.json.schema:1.2.0'
+    compile 'org.everit.json:org.everit.json.schema:1.3.0'
     compile ('com.fasterxml.jackson.datatype:jackson-datatype-json-org:2.4.0') {
         exclude module: "json"
     }


### PR DESCRIPTION
This has fixes that will allow legal schema processing that fails with 1.2.0, in particular number handling: https://github.com/everit-org/json-schema/issues/31