### PR TITLE
ARUHA-282: switched off codacy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ services:
 before_script:
   - sudo /etc/init.d/postgresql stop
   - pip install --user codecov
-  - curl http://www.jpm4j.org/install/script | sudo sh
-  - sudo jpm install com.codacy:codacy-coverage-reporter:assembly
+#  - curl http://www.jpm4j.org/install/script | sudo sh
+#  - sudo jpm install com.codacy:codacy-coverage-reporter:assembly
 
 env:
   - TEST_SUITE="travis_wait gradle check --stacktrace"   # unit tests
@@ -23,4 +23,4 @@ script: "$TEST_SUITE"
 
 after_success:
   - codecov
-  - codacy-coverage-reporter -l Java -r build/reports/jacoco/test/jacocoTestReport.xml
+#  - codacy-coverage-reporter -l Java -r build/reports/jacoco/test/jacocoTestReport.xml


### PR DESCRIPTION
@v1ctor @adyach @antban please review
I temporary switch off codacy as repo.jpm4j.org is currently down and our build on travis fails.