### PR TITLE
Aruha 253 undo backward incompatible changes

### DIFF
--- a/database/migration/R2016_07_12/aruha-253-fix-default-statistics.sql
+++ b/database/migration/R2016_07_12/aruha-253-fix-default-statistics.sql
@@ -1,1 +1,0 @@
-UPDATE zn_data.event_type SET et_event_type_object = replace(et_event_type_object::text, 'default_statistic', 'default_statistics')::jsonb WHERE et_event_type_object::text LIKE '%default_statistic%';

--- a/src/acceptance-test/java/de/zalando/aruha/nakadi/webservice/EventTypeAT.java
+++ b/src/acceptance-test/java/de/zalando/aruha/nakadi/webservice/EventTypeAT.java
@@ -88,7 +88,7 @@ public class EventTypeAT extends BaseAT {
 
         final KafkaTestHelper kafkaHelper = new KafkaTestHelper(KAFKA_URL);
         final Set<String> allTopics = kafkaHelper.createConsumer().listTopics().keySet();
-        assertThat(allTopics, not(hasItem(eventType.getName())));
+        assertThat(allTopics, not(hasItem(eventType.getTopic())));
     }
 
     @After

--- a/src/main/java/de/zalando/aruha/nakadi/controller/EventTypeController.java
+++ b/src/main/java/de/zalando/aruha/nakadi/controller/EventTypeController.java
@@ -98,7 +98,7 @@ public class EventTypeController {
             enrichment.validate(eventType);
             partitionResolver.validate(eventType);
             eventTypeRepository.saveEventType(eventType);
-            topicRepository.createTopic(eventType.getTopic(), eventType.getDefaultStatistics());
+            topicRepository.createTopic(eventType.getName(), eventType.getDefaultStatistic());
             return status(HttpStatus.CREATED).build();
         } catch (final InvalidEventTypeException | NoSuchPartitionStrategyException |
                 DuplicatedEventTypeNameException e) {
@@ -216,8 +216,8 @@ public class EventTypeController {
 
         validateName(name, eventType);
         validateSchemaChange(eventType, existingEventType);
-        eventType.setDefaultStatistics(
-                validateStatisticsUpdate(existingEventType.getDefaultStatistics(), eventType.getDefaultStatistics()));
+        eventType.setDefaultStatistic(
+                validateStatisticsUpdate(existingEventType.getDefaultStatistic(), eventType.getDefaultStatistic()));
     }
 
     private EventTypeStatistics validateStatisticsUpdate(final EventTypeStatistics existing, final EventTypeStatistics newStatistics) throws InvalidEventTypeException {

--- a/src/main/java/de/zalando/aruha/nakadi/controller/EventTypeController.java
+++ b/src/main/java/de/zalando/aruha/nakadi/controller/EventTypeController.java
@@ -98,7 +98,7 @@ public class EventTypeController {
             enrichment.validate(eventType);
             partitionResolver.validate(eventType);
             eventTypeRepository.saveEventType(eventType);
-            topicRepository.createTopic(eventType.getName(), eventType.getDefaultStatistic());
+            topicRepository.createTopic(eventType.getTopic(), eventType.getDefaultStatistic());
             return status(HttpStatus.CREATED).build();
         } catch (final InvalidEventTypeException | NoSuchPartitionStrategyException |
                 DuplicatedEventTypeNameException e) {

--- a/src/main/java/de/zalando/aruha/nakadi/domain/EventType.java
+++ b/src/main/java/de/zalando/aruha/nakadi/domain/EventType.java
@@ -47,7 +47,7 @@ public class EventType {
 
     @Valid
     @Nullable
-    private EventTypeStatistics defaultStatistics;
+    private EventTypeStatistics defaultStatistic;
 
     public String getName() { return name; }
 
@@ -89,12 +89,12 @@ public class EventType {
         this.schema = schema;
     }
 
-    public EventTypeStatistics getDefaultStatistics() {
-        return defaultStatistics;
+    public EventTypeStatistics getDefaultStatistic() {
+        return defaultStatistic;
     }
 
-    public void setDefaultStatistics(final EventTypeStatistics defaultStatistics) {
-        this.defaultStatistics = defaultStatistics;
+    public void setDefaultStatistic(final EventTypeStatistics defaultStatistic) {
+        this.defaultStatistic = defaultStatistic;
     }
 
     public List<String> getPartitionKeyFields() {

--- a/src/test/java/de/zalando/aruha/nakadi/controller/EventTypeControllerTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/controller/EventTypeControllerTest.java
@@ -296,7 +296,7 @@ public class EventTypeControllerTest {
         statistics.setMessagesPerMinute(1000);
         statistics.setReadParallelism(1);
         statistics.setWriteParallelism(2);
-        defaultEventType.setDefaultStatistics(statistics);
+        defaultEventType.setDefaultStatistic(statistics);
         postEventType(defaultEventType).andExpect(status().is2xxSuccessful());
         verify(topicRepository, times(1)).createTopic(anyString(), eq(statistics));
     }


### PR DESCRIPTION
During validation time the team decided to not release this change since it would be backwards incompatible and would require some downtime during rollout in order to execute database migrations.

We are going to provide an alternative implementation in order to smoothly rollout with no downtime.