### PR TITLE
ARUHA-299: postgres database update script does not work for ubuntu user

### DIFF
--- a/database/nakadi/execute_db_scripts_in_container.sh
+++ b/database/nakadi/execute_db_scripts_in_container.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-find /docker-entrypoint-initdb.d -type f -name "*.sql" -exec psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -a -f '{}' \;
+find /docker-entrypoint-initdb.d -type f -name "*.sql" | sort |
+while read -r filename; do psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -a -f "$filename"; done


### PR DESCRIPTION
One user has a problem with running docker-compose.  The database update script runs sql scripts in reverse order for some reason.