### PR TITLE
aruha-262 fix date time validation once and for all

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,6 @@ dependencies {
     compile 'org.zalando:problem:0.5.0'
     compile 'org.zalando:problem-spring-web:0.5.0'
     compile 'com.google.guava:guava:19.0'
-    compile 'joda-time:joda-time:2.2'
     compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
     compile 'org.slf4j:slf4j-log4j12:1.7.14'
     compile "io.dropwizard.metrics:metrics-core:$dropwizardVersion"

--- a/src/main/java/de/zalando/aruha/nakadi/validation/EventBodyMustRespectSchema.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/EventBodyMustRespectSchema.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsonorg.JsonOrgModule;
 import de.zalando.aruha.nakadi.domain.EventType;
 import de.zalando.aruha.nakadi.domain.ValidationStrategyConfiguration;
+import org.everit.json.schema.FormatValidator;
 import org.everit.json.schema.Schema;
 import org.everit.json.schema.ValidationException;
 import org.everit.json.schema.loader.SchemaLoader;
@@ -154,8 +155,16 @@ class JSONSchemaValidator implements EventValidator {
 
     private final Schema schema;
 
+    private static final FormatValidator DATE_TIME_VALIDATOR = new RFC3339DateTimeValidator();
+
     public JSONSchemaValidator(final JSONObject effectiveSchema) {
-        schema = SchemaLoader.load(effectiveSchema);
+        schema = SchemaLoader
+                .builder()
+                .schemaJson(effectiveSchema)
+                .addFormatValidator("date-time", DATE_TIME_VALIDATOR)
+                .build()
+                .load()
+                .build();
     }
 
     @Override

--- a/src/main/java/de/zalando/aruha/nakadi/validation/MetadataValidator.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/MetadataValidator.java
@@ -1,12 +1,13 @@
 package de.zalando.aruha.nakadi.validation;
 
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 import org.json.JSONObject;
 
 import java.util.Optional;
 
 public class MetadataValidator implements EventValidator {
+
+    private final RFC3339DateTimeValidator validator = new RFC3339DateTimeValidator();
+
     @Override
     public Optional<ValidationError> accepts(final JSONObject event) {
         return Optional
@@ -16,13 +17,6 @@ public class MetadataValidator implements EventValidator {
     }
 
     private Optional<ValidationError> checkDateTime(final String occurredAt) {
-        try {
-            final DateTimeFormatter dateFormatter = ISODateTimeFormat.dateTimeParser();
-            dateFormatter.parseDateTime(occurredAt);
-
-            return Optional.empty();
-        } catch (IllegalArgumentException e) {
-            return Optional.of(new ValidationError("occurred_at must be a valid date-time"));
-        }
+        return validator.validate(occurredAt).map(ValidationError::new);
     }
 }

--- a/src/main/java/de/zalando/aruha/nakadi/validation/RFC3339DateTimeValidator.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/RFC3339DateTimeValidator.java
@@ -2,6 +2,7 @@ package de.zalando.aruha.nakadi.validation;
 
 import org.everit.json.schema.FormatValidator;
 
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -21,7 +22,7 @@ public class RFC3339DateTimeValidator implements FormatValidator {
     @Override
     public Optional<String> validate(final String dateTime) {
         try {
-            java.time.LocalDate.parse(dateTime, ISO_OFFSET_DATE_TIME);
+            OffsetDateTime.parse(dateTime, ISO_OFFSET_DATE_TIME);
 
             // Unfortunately, ISO_OFFSET_DATE_TIME accepts offsets with seconds, which is not RFC3339 compliant. So
             // we need to do some further checks using a regex in order to be sure that it adhere to the given format.

--- a/src/main/java/de/zalando/aruha/nakadi/validation/RFC3339DateTimeValidator.java
+++ b/src/main/java/de/zalando/aruha/nakadi/validation/RFC3339DateTimeValidator.java
@@ -1,0 +1,39 @@
+package de.zalando.aruha.nakadi.validation;
+
+import org.everit.json.schema.FormatValidator;
+
+import java.time.format.DateTimeParseException;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+public class RFC3339DateTimeValidator implements FormatValidator {
+
+    private final String errorMessage = "must be a valid date-time";
+
+    // Valid offsets are either Z or hh:mm. The format hh:mm:ss is not valid
+    private final String dateTimeOffsetPattern = "^.*(Z|((\\+|-)\\d\\d:\\d\\d))$";
+    private final Pattern pattern = Pattern.compile(dateTimeOffsetPattern);
+    private final Optional<String> error = Optional.of(errorMessage);
+
+    @Override
+    public Optional<String> validate(final String dateTime) {
+        try {
+            java.time.LocalDate.parse(dateTime, ISO_OFFSET_DATE_TIME);
+
+            // Unfortunately, ISO_OFFSET_DATE_TIME accepts offsets with seconds, which is not RFC3339 compliant. So
+            // we need to do some further checks using a regex in order to be sure that it adhere to the given format.
+            final Matcher matcher = pattern.matcher(dateTime);
+            if (matcher.matches()) {
+                return Optional.empty();
+            } else {
+                return error;
+            }
+
+        } catch (final DateTimeParseException e) {
+            return error;
+        }
+    }
+}

--- a/src/test/java/de/zalando/aruha/nakadi/validation/JSONSchemaValidationTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/validation/JSONSchemaValidationTest.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import static de.zalando.aruha.nakadi.utils.IsOptional.isAbsent;
-import static de.zalando.aruha.nakadi.utils.IsOptional.isPresent;
 import static de.zalando.aruha.nakadi.utils.TestUtils.buildEventType;
 import static de.zalando.aruha.nakadi.utils.TestUtils.readFile;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -161,58 +160,6 @@ public class JSONSchemaValidationTest {
         final Optional<ValidationError> error = EventValidation.forType(et).validate(event);
 
         assertThat(error.get().getMessage(), equalTo("#/metadata: required key [occurred_at] not found"));
-    }
-
-    @Test
-    public void requireMetadataOccurredAtToBeFormattedAsDateTime() {
-        final EventType et = buildEventType("some-event-type", basicSchema());
-        et.setCategory(EventCategory.BUSINESS);
-
-        final JSONObject event = businessEvent();
-        event.getJSONObject("metadata").put("occurred_at", "x");
-
-        final Optional<ValidationError> error = EventValidation.forType(et).validate(event);
-
-        assertThat(error, isPresent());
-    }
-
-    @Test
-    public void requireMetadataOccurredAtToBeFormattedAsDateTimeWithValidDate() {
-        final EventType et = buildEventType("some-event-type", basicSchema());
-        et.setCategory(EventCategory.BUSINESS);
-
-        final JSONObject event = businessEvent();
-        event.getJSONObject("metadata").put("occurred_at", "1996-60-15T16:39:57-08:00");
-
-        final Optional<ValidationError> error = EventValidation.forType(et).validate(event);
-
-        assertThat(error, isPresent());
-    }
-
-    @Test
-    public void requireMetadataOccurredAtToBeFormattedAsDateTimeWithMilliseconds() {
-        final EventType et = buildEventType("some-event-type", basicSchema());
-        et.setCategory(EventCategory.BUSINESS);
-
-        final JSONObject event = businessEvent();
-        event.getJSONObject("metadata").put("occurred_at", "1996-10-15T16:39:57.1245678+07:00");
-
-        final Optional<ValidationError> error = EventValidation.forType(et).validate(event);
-
-        assertThat(error, isAbsent());
-    }
-
-    @Test
-    public void acceptsDateTimeZoneWithoutColonSeparation() {
-        final EventType et = buildEventType("some-event-type", basicSchema());
-        et.setCategory(EventCategory.BUSINESS);
-
-        final JSONObject event = businessEvent();
-        event.getJSONObject("metadata").put("occurred_at", "1996-10-15T16:39:57+0800");
-
-        final Optional<ValidationError> error = EventValidation.forType(et).validate(event);
-
-        assertThat(error, isAbsent());
     }
 
     @Test

--- a/src/test/java/de/zalando/aruha/nakadi/validation/RFC3339DateTimeValidatorTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/validation/RFC3339DateTimeValidatorTest.java
@@ -1,0 +1,42 @@
+package de.zalando.aruha.nakadi.validation;
+
+import org.junit.Test;
+
+import static de.zalando.aruha.nakadi.utils.IsOptional.isAbsent;
+import static de.zalando.aruha.nakadi.utils.IsOptional.isPresent;
+import static org.junit.Assert.assertThat;
+
+public class RFC3339DateTimeValidatorTest {
+    private final RFC3339DateTimeValidator validator = new RFC3339DateTimeValidator();
+
+    @Test
+    public void requireMetadataOccurredAtToBeFormattedAsDateTime() {
+        final String invalidDateTimes[] = new String[] {
+                "x", // totally non sense string
+                "1996-10-15T16:39:57+07:00:30", // invalid seconds in the offset
+                "1996-10-15T16:39:57+0700", // invalid missing colon in the offset
+                "1996-10-15T16:39:57 07:00", // invalid missing signal in the offset
+                "1996-10-45T16:39:57Z", // check for lenience (there are no months with 45 days)
+                "1996-10-45 16:39:57Z", // requires "T" as separator
+                "1996-10-45t16:39:57Z", // the RFC requires uppercase T, sorry
+                "1996-10-45T16:39:57z", // the RFC requires uppercase Z as well, sorry again
+                "1996-10-45T16:39:57", // offsets are required
+        };
+
+        final String validDateTimes[] = new String[] {
+                "1996-10-15T16:39:57+07:00", // just a very simple example
+                "1996-10-15T16:39:57-07:00", // just a very simple example
+                "1996-10-15T16:39:57.123+07:00", // simple example with milliseconds
+                "1996-10-15T16:39:57.1234Z", // tricky 4 milliseconds digits (yes it's valid, sorry)
+                "1996-10-15T16:39:57.12Z", // yes, it' valid, just 2 milliseconds digits
+        };
+
+        for (final String invalid : invalidDateTimes) {
+            assertThat(invalid, validator.validate(invalid), isPresent());
+        }
+
+        for (final String valid : validDateTimes) {
+            assertThat(valid, validator.validate(valid), isAbsent());
+        }
+    }
+}

--- a/src/test/java/de/zalando/aruha/nakadi/validation/RFC3339DateTimeValidatorTest.java
+++ b/src/test/java/de/zalando/aruha/nakadi/validation/RFC3339DateTimeValidatorTest.java
@@ -16,6 +16,7 @@ public class RFC3339DateTimeValidatorTest {
                 "1996-10-15T16:39:57+07:00:30", // invalid seconds in the offset
                 "1996-10-15T16:39:57+0700", // invalid missing colon in the offset
                 "1996-10-15T16:39:57 07:00", // invalid missing signal in the offset
+                "1996-10-15T16:39:57.1234567890Z", // invalid 10 digits milliseconds
                 "1996-10-45T16:39:57Z", // check for lenience (there are no months with 45 days)
                 "1996-10-45 16:39:57Z", // requires "T" as separator
                 "1996-10-45t16:39:57Z", // the RFC requires uppercase T, sorry
@@ -28,6 +29,7 @@ public class RFC3339DateTimeValidatorTest {
                 "1996-10-15T16:39:57-07:00", // just a very simple example
                 "1996-10-15T16:39:57.123+07:00", // simple example with milliseconds
                 "1996-10-15T16:39:57.1234Z", // tricky 4 milliseconds digits (yes it's valid, sorry)
+                "1996-10-15T16:39:57.123456789Z", // valid up to 9 milliseconds digits
                 "1996-10-15T16:39:57.12Z", // yes, it' valid, just 2 milliseconds digits
         };
 

--- a/src/test/resources/product-event.json
+++ b/src/test/resources/product-event.json
@@ -7,7 +7,7 @@
   "data_op": "C",
   "data": {
     "owner_id": "sometenantid",
-    "event_timestamp": "2016-05-10T16:43:24.672Z",
+    "event_timestamp": "1996-10-15T16:39:57.1245678Z",
     "product_status": "active",
     "event_type": "create",
     "product_id": "C2FDA95C-CB3B-4EA2-9386-500E9227521D",


### PR DESCRIPTION
Overriding default everit date-time validator by a correct
implementation of RFC3339 validation fixes #274 and another non reported
bug that allowed offset string without colon to be accepted.