### PR TITLE
Clarify on required docker versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ More detailed information can be found on the [manual](http://zalando.github.io/
 
 ## Quickstart
 
-You can run the project locally using [Docker](https://www.docker.com/).
+You can run the project locally using [Docker](https://www.docker.com/). Note that Nakadi requires very recent versions of docker and docker-compose. See [Dependencies](#dependencies) for more information.
 
 ### Running a Server
 
@@ -454,6 +454,12 @@ For working with an IDE, the `eclipse` IDE task is available and you'll be able 
 ### Dependencies
 
 The Nakadi server is a Java 8 [Spring Boot](http://projects.spring.io/spring-boot/) application. It uses [Kafka 0.9](http://kafka.apache.org/090/documentation.html) as its broker and [PostgreSQL 9.5](http://www.postgresql.org/docs/9.5/static/release-9-5.html) as its supporting database.
+
+Nakadi requires recent versions of docker and docker-compose. In
+particular, the docker-compose version (1.5.x) shipped with Ubuntu
+16.04 does not work for Nakadi. See [Install Docker
+Compose](https://docs.docker.com/compose/install/) for information on
+installing the most recent docker-compose version.
 
 ### What does the project already implement?
 

--- a/README.md
+++ b/README.md
@@ -456,8 +456,7 @@ For working with an IDE, the `eclipse` IDE task is available and you'll be able 
 The Nakadi server is a Java 8 [Spring Boot](http://projects.spring.io/spring-boot/) application. It uses [Kafka 0.9](http://kafka.apache.org/090/documentation.html) as its broker and [PostgreSQL 9.5](http://www.postgresql.org/docs/9.5/static/release-9-5.html) as its supporting database.
 
 Nakadi requires recent versions of docker and docker-compose. In
-particular, the docker-compose version (1.5.x) shipped with Ubuntu
-16.04 does not work for Nakadi. See [Install Docker
+particular, docker-compose >= v1.7.0 is required. See [Install Docker
 Compose](https://docs.docker.com/compose/install/) for information on
 installing the most recent docker-compose version.
 


### PR DESCRIPTION
Nakadi doesn't work with some popular docker versions.
The documentation should mention that you need very recent versions of docker.