### PR TITLE
Still a docker/issues/22753 on Mac (1.12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ running, you might want to run this command:
 ```sh
 eval "$(docker-machine env default)"
 ```
-Note: Docker Beta for Mac OS (1.12.0-rc3-beta18) currently is not supported due to the bug in networking host configuration.
+Note: Docker for Mac OS (previously in beta) version 1.12 (1.12.0 or 1.12.1) currently is not supported due to the [bug](https://github.com/docker/docker/issues/22753#issuecomment-242711639) in networking host configuration.
 
 ## API Overview and Usage
 


### PR DESCRIPTION
Even with Docker 1.12 out of beta the `network_mode: host` bug is still there: https://github.com/docker/docker/issues/22753#issuecomment-242711639

I'm also waiting for this to be fixed.