### PR TITLE
Aruha 338 stream parameters change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -223,6 +223,17 @@ task pushDockerImage {
     }
 }
 
+task testInitNakadi(type: Exec) {
+    environment "NAKADI_STREAM_DEFAULT_COMMITTIMEOUT", "5"
+    commandLine "bash", "-c", "docker-compose up -d --build"
+    doLast {
+        println "Waiting for Nakadi to start up"
+        long start = System.currentTimeMillis()
+        waitForNakadi()
+        println "Nakadi is fully started in " + (System.currentTimeMillis() - start) + " ms"
+    }
+}
+
 task initNakadi(type: Exec) {
     commandLine "bash", "-c", "docker-compose up -d --build"
     doLast {
@@ -267,12 +278,12 @@ task stopStorages(type: Exec) {
 }
 
 task fullTest(type: GradleBuild) {
-    tasks = ['clean', 'bootRepackage', 'initNakadi', 'test', 'acceptanceTest']
+    tasks = ['clean', 'bootRepackage', 'testInitNakadi', 'test', 'acceptanceTest']
     finalizedBy stopNakadi
 }
 
 task fullAcceptanceTest(type: GradleBuild) {
-    tasks = ['clean', 'bootRepackage', 'initNakadi', 'acceptanceTest']
+    tasks = ['clean', 'bootRepackage', 'testInitNakadi', 'acceptanceTest']
     finalizedBy stopNakadi
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -224,7 +224,7 @@ task pushDockerImage {
 }
 
 task testInitNakadi(type: Exec) {
-    environment "NAKADI_STREAM_DEFAULT_COMMITTIMEOUT", "5"
+    environment "JAVA_OPTS", "-Dspring.profiles.active=acceptanceTest"
     commandLine "bash", "-c", "docker-compose up -d --build"
     doLast {
         println "Waiting for Nakadi to start up"

--- a/build.gradle
+++ b/build.gradle
@@ -224,7 +224,7 @@ task pushDockerImage {
 }
 
 task testInitNakadi(type: Exec) {
-    environment "JAVA_OPTS", "-Dspring.profiles.active=acceptanceTest"
+    environment "SPRING_PROFILES_ACTIVE", "acceptanceTest"
     commandLine "bash", "-c", "docker-compose up -d --build"
     doLast {
         println "Waiting for Nakadi to start up"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
      - zookeeper
      - kafka
     environment:
-      - JAVA_OPTS
+      - SPRING_PROFILES_ACTIVE
       - NAKADI_OAUTH2_MODE=OFF
       - NAKADI_FEATURETOGGLE_DEFAULT=true
       - NAKADI_ZOOKEEPER_BROKERS=localhost:2181

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,13 @@ services:
      - zookeeper
      - kafka
     environment:
-      NAKADI_OAUTH2_MODE: "OFF"
-      NAKADI_FEATURETOGGLE_DEFAULT: "true"
-      NAKADI_ZOOKEEPER_BROKERS: localhost:2181
-      SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/local_nakadi_db
-      SPRING_DATASOURCE_USERNAME: nakadi
-      SPRING_DATASOURCE_PASSWORD: nakadi
+      - NAKADI_STREAM_DEFAULT_COMMITTIMEOUT
+      - NAKADI_OAUTH2_MODE=OFF
+      - NAKADI_FEATURETOGGLE_DEFAULT=true
+      - NAKADI_ZOOKEEPER_BROKERS=localhost:2181
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/local_nakadi_db
+      - SPRING_DATASOURCE_USERNAME=nakadi
+      - SPRING_DATASOURCE_PASSWORD=nakadi
     network_mode: "host"
 
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
      - zookeeper
      - kafka
     environment:
-      - NAKADI_STREAM_DEFAULT_COMMITTIMEOUT
+      - JAVA_OPTS
       - NAKADI_OAUTH2_MODE=OFF
       - NAKADI_FEATURETOGGLE_DEFAULT=true
       - NAKADI_ZOOKEEPER_BROKERS=localhost:2181

--- a/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -44,6 +44,7 @@ public class KafkaRepositoryAT extends BaseAT {
     private static final int DEFAULT_REPLICA_FACTOR = 1;
     private static final int MAX_TOPIC_PARTITION_COUNT = 10;
     private static final int DEFAULT_TOPIC_ROTATION = 50000000;
+    private static final int DEFAULT_COMMIT_TIMEOUT = 60;
     private static final int ZK_SESSION_TIMEOUT = 30000;
     private static final int ZK_CONNECTION_TIMEOUT = 10000;
     private static final int KAFKA_SEND_TIMEOUT = 10000;
@@ -67,7 +68,8 @@ public class KafkaRepositoryAT extends BaseAT {
                 DEFAULT_PARTITION_COUNT,
                 DEFAULT_REPLICA_FACTOR,
                 DEFAULT_TOPIC_RETENTION,
-                DEFAULT_TOPIC_ROTATION);
+                DEFAULT_TOPIC_ROTATION,
+                DEFAULT_COMMIT_TIMEOUT);
         kafkaSettings = new KafkaSettings(KAFKA_POLL_TIMEOUT, KAFKA_SEND_TIMEOUT);
         zookeeperSettings = new ZookeeperSettings(ZK_SESSION_TIMEOUT, ZK_CONNECTION_TIMEOUT);
         kafkaHelper = new KafkaTestHelper(KAFKA_URL);

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaAT.java
@@ -100,7 +100,7 @@ public class HilaAT extends BaseAT {
         range(0, 15).forEach(x -> publishEvent(eventType.getName(), "{\"blah\":\"foo\"}"));
 
         final TestStreamingClient client = TestStreamingClient
-                .create(URL, subscription.getId(), "window_size=5")
+                .create(URL, subscription.getId(), "max_uncommitted_size=5")
                 .start();
 
         waitFor(() -> assertThat(client.getBatches(), hasSize(5)));
@@ -154,7 +154,7 @@ public class HilaAT extends BaseAT {
         range(0, 12).forEach(x -> publishEvent(eventType.getName(), "{\"blah\":\"foo\"}"));
 
         final TestStreamingClient client = TestStreamingClient
-                .create(URL, subscription.getId(), "batch_limit=5&batch_flush_timeout=1")
+                .create(URL, subscription.getId(), "batch_limit=5&batch_flush_timeout=1&max_uncommitted_size=20")
                 .start();
 
         waitFor(() -> assertThat(client.getBatches(), hasSize(3)));

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaAT.java
@@ -116,17 +116,17 @@ public class HilaAT extends BaseAT {
         waitFor(() -> assertThat(client.getBatches(), hasSize(12)));
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 15000)
     public void whenCommitTimeoutReachedSessionIsClosed() throws Exception {
 
         publishEvent(eventType.getName(), "{\"blah\":\"foo\"}");
 
         final TestStreamingClient client = TestStreamingClient
-                .create(URL, subscription.getId(), "commit_timeout=1")
+                .create(URL, subscription.getId(), "") // commit_timeout is 5 seconds for test
                 .start();
 
         waitFor(() -> assertThat(client.getBatches(), hasSize(1)));
-        waitFor(() -> assertThat(client.isRunning(), is(false)), 3000);
+        waitFor(() -> assertThat(client.isRunning(), is(false)), 10000);
     }
 
     @Test(timeout = 15000)

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRebalanceAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRebalanceAT.java
@@ -122,21 +122,21 @@ public class HilaRebalanceAT extends BaseAT {
 
     @Test(timeout = 15000)
     public void whenNotCommittedThenEventsAreReplayedAfterRebalance() {
-        range(0, 10)
+        range(0, 2)
                 .forEach(x -> publishBusinessEventWithUserDefinedPartition(
                         eventType.getName(), "blah" + x, String.valueOf(x % 8)));
 
         final TestStreamingClient clientA = TestStreamingClient
-                .create(URL, subscription.getId(), "commit_timeout=2")
+                .create(URL, subscription.getId(), "")
                 .start();
-        waitFor(() -> assertThat(clientA.getBatches(), hasSize(10)));
+        waitFor(() -> assertThat(clientA.getBatches(), hasSize(2)));
 
         final TestStreamingClient clientB = TestStreamingClient
                 .create(URL, subscription.getId(), "")
                 .start();
 
         // after commit_timeout of first client exceeds it is closed and all events are resent to second client
-        waitFor(() -> assertThat(clientB.getBatches(), hasSize(10)));
+        waitFor(() -> assertThat(clientB.getBatches(), hasSize(2)), 10000);
     }
 
     public List<Cursor> getLastCursorsForPartitions(final TestStreamingClient client, final Set<String> partitions) {

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRebalanceAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRebalanceAT.java
@@ -54,7 +54,7 @@ public class HilaRebalanceAT extends BaseAT {
 
         // create a session
         final TestStreamingClient clientA = TestStreamingClient
-                .create(URL, subscription.getId(), "")
+                .create(URL, subscription.getId(), "max_uncommitted_size=100")
                 .start();
         waitFor(() -> assertThat(clientA.getBatches(), hasSize(40)));
 
@@ -75,7 +75,7 @@ public class HilaRebalanceAT extends BaseAT {
 
         // create second session for the same subscription
         final TestStreamingClient clientB = TestStreamingClient
-                .create(URL, subscription.getId(), "stream_limit=20")
+                .create(URL, subscription.getId(), "stream_limit=20&max_uncommitted_size=100")
                 .start();
 
         // wait for rebalance process to start
@@ -122,21 +122,21 @@ public class HilaRebalanceAT extends BaseAT {
 
     @Test(timeout = 15000)
     public void whenNotCommittedThenEventsAreReplayedAfterRebalance() {
-        range(0, 20)
+        range(0, 10)
                 .forEach(x -> publishBusinessEventWithUserDefinedPartition(
                         eventType.getName(), "blah" + x, String.valueOf(x % 8)));
 
         final TestStreamingClient clientA = TestStreamingClient
                 .create(URL, subscription.getId(), "commit_timeout=2")
                 .start();
-        waitFor(() -> assertThat(clientA.getBatches(), hasSize(20)));
+        waitFor(() -> assertThat(clientA.getBatches(), hasSize(10)));
 
         final TestStreamingClient clientB = TestStreamingClient
                 .create(URL, subscription.getId(), "")
                 .start();
 
         // after commit_timeout of first client exceeds it is closed and all events are resent to second client
-        waitFor(() -> assertThat(clientB.getBatches(), hasSize(20)));
+        waitFor(() -> assertThat(clientB.getBatches(), hasSize(10)));
     }
 
     public List<Cursor> getLastCursorsForPartitions(final TestStreamingClient client, final Set<String> partitions) {

--- a/src/main/java/org/zalando/nakadi/config/NakadiSettings.java
+++ b/src/main/java/org/zalando/nakadi/config/NakadiSettings.java
@@ -12,18 +12,21 @@ public class NakadiSettings {
     private final int defaultTopicReplicaFactor;
     private final long defaultTopicRetentionMs;
     private final long defaultTopicRotationMs;
+    private final long defaultCommitTimeoutSeconds;
 
     @Autowired
     public NakadiSettings(@Value("${nakadi.topic.max.partitionNum}") final int maxTopicPartitionCount,
                           @Value("${nakadi.topic.default.partitionNum}") final int defaultTopicPartitionCount,
                           @Value("${nakadi.topic.default.replicaFactor}") final int defaultTopicReplicaFactor,
                           @Value("${nakadi.topic.default.retentionMs}") final long defaultTopicRetentionMs,
-                          @Value("${nakadi.topic.default.rotationMs}") final long defaultTopicRotationMs) {
+                          @Value("${nakadi.topic.default.rotationMs}") final long defaultTopicRotationMs,
+                          @Value("${nakadi.stream.default.commitTimeout}") final long defaultCommitTimeoutSeconds) {
         this.maxTopicPartitionCount = maxTopicPartitionCount;
         this.defaultTopicPartitionCount = defaultTopicPartitionCount;
         this.defaultTopicReplicaFactor = defaultTopicReplicaFactor;
         this.defaultTopicRetentionMs = defaultTopicRetentionMs;
         this.defaultTopicRotationMs = defaultTopicRotationMs;
+        this.defaultCommitTimeoutSeconds = defaultCommitTimeoutSeconds;
     }
 
     public int getDefaultTopicPartitionCount() {
@@ -44,6 +47,10 @@ public class NakadiSettings {
 
     public long getDefaultTopicRotationMs() {
         return defaultTopicRotationMs;
+    }
+
+    public long getDefaultCommitTimeoutSeconds() {
+        return defaultCommitTimeoutSeconds;
     }
 
 }

--- a/src/main/java/org/zalando/nakadi/controller/SubscriptionStreamController.java
+++ b/src/main/java/org/zalando/nakadi/controller/SubscriptionStreamController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+import org.zalando.nakadi.config.NakadiSettings;
 import org.zalando.nakadi.exceptions.NakadiException;
 import org.zalando.nakadi.service.ClosedConnectionsCrutch;
 import org.zalando.nakadi.service.subscription.StreamParameters;
@@ -38,16 +39,19 @@ public class SubscriptionStreamController {
     private final FeatureToggleService featureToggleService;
     private final ObjectMapper jsonMapper;
     private final ClosedConnectionsCrutch closedConnectionsCrutch;
+    private final NakadiSettings nakadiSettings;
 
     @Autowired
     public SubscriptionStreamController(final SubscriptionStreamerFactory subscriptionStreamerFactory,
                                         final FeatureToggleService featureToggleService,
                                         final ObjectMapper objectMapper,
-                                        final ClosedConnectionsCrutch closedConnectionsCrutch) {
+                                        final ClosedConnectionsCrutch closedConnectionsCrutch,
+                                        final NakadiSettings nakadiSettings) {
         this.subscriptionStreamerFactory = subscriptionStreamerFactory;
         this.featureToggleService = featureToggleService;
         this.jsonMapper = objectMapper;
         this.closedConnectionsCrutch = closedConnectionsCrutch;
+        this.nakadiSettings = nakadiSettings;
     }
 
     private class SubscriptionOutputImpl implements SubscriptionOutput {
@@ -109,8 +113,8 @@ public class SubscriptionStreamController {
     @RequestMapping(value = "/subscriptions/{subscription_id}/events", method = RequestMethod.GET)
     public StreamingResponseBody streamEvents(
             @PathVariable("subscription_id") final String subscriptionId,
-            @RequestParam(value = "max_uncommitted_size", required = false, defaultValue = "10") final int maxUncommittedSize,
-            @RequestParam(value = "commit_timeout", required = false, defaultValue = "30") final int commitTimeout,
+            @RequestParam(value = "max_uncommitted_size", required = false, defaultValue = "10")
+            final int maxUncommittedSize,
             @RequestParam(value = "batch_limit", required = false, defaultValue = "1") final int batchLimit,
             @Nullable @RequestParam(value = "stream_limit", required = false) final Long streamLimit,
             @RequestParam(value = "batch_flush_timeout", required = false, defaultValue = "30") final int batchTimeout,
@@ -132,7 +136,8 @@ public class SubscriptionStreamController {
             final SubscriptionOutputImpl output = new SubscriptionOutputImpl(response, outputStream);
             try {
                 final StreamParameters streamParameters = StreamParameters.of(batchLimit, streamLimit, batchTimeout,
-                        streamTimeout, streamKeepAliveLimit, maxUncommittedSize, commitTimeout);
+                        streamTimeout, streamKeepAliveLimit, maxUncommittedSize,
+                        nakadiSettings.getDefaultCommitTimeoutSeconds());
                 streamer = subscriptionStreamerFactory.build(subscriptionId, streamParameters, output, connectionReady);
                 streamer.stream();
             } catch (final InterruptedException ex) {

--- a/src/main/java/org/zalando/nakadi/controller/SubscriptionStreamController.java
+++ b/src/main/java/org/zalando/nakadi/controller/SubscriptionStreamController.java
@@ -109,7 +109,7 @@ public class SubscriptionStreamController {
     @RequestMapping(value = "/subscriptions/{subscription_id}/events", method = RequestMethod.GET)
     public StreamingResponseBody streamEvents(
             @PathVariable("subscription_id") final String subscriptionId,
-            @RequestParam(value = "window_size", required = false, defaultValue = "100") final int windowSize,
+            @RequestParam(value = "max_uncommitted_size", required = false, defaultValue = "10") final int maxUncommittedSize,
             @RequestParam(value = "commit_timeout", required = false, defaultValue = "30") final int commitTimeout,
             @RequestParam(value = "batch_limit", required = false, defaultValue = "1") final int batchLimit,
             @Nullable @RequestParam(value = "stream_limit", required = false) final Long streamLimit,
@@ -132,7 +132,7 @@ public class SubscriptionStreamController {
             final SubscriptionOutputImpl output = new SubscriptionOutputImpl(response, outputStream);
             try {
                 final StreamParameters streamParameters = StreamParameters.of(batchLimit, streamLimit, batchTimeout,
-                        streamTimeout, streamKeepAliveLimit, windowSize, commitTimeout);
+                        streamTimeout, streamKeepAliveLimit, maxUncommittedSize, commitTimeout);
                 streamer = subscriptionStreamerFactory.build(subscriptionId, streamParameters, output, connectionReady);
                 streamer.stream();
             } catch (final InterruptedException ex) {

--- a/src/main/java/org/zalando/nakadi/service/subscription/StreamParameters.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/StreamParameters.java
@@ -30,7 +30,7 @@ public class StreamParameters {
     private final Optional<Integer> batchKeepAliveIterations;
 
     // Applies to stream, number of messages to send to clients
-    public final int windowSizeMessages;
+    public final int maxUncommittedMessages;
 
     // Applies to stream. Timeout without commits.
     public final long commitTimeoutMillis;
@@ -38,13 +38,13 @@ public class StreamParameters {
     private StreamParameters(
             final int batchLimitEvents, @Nullable final Long streamLimitEvents, final long batchTimeoutMillis,
             @Nullable final Long streamTimeoutMillis, @Nullable final Integer batchKeepAliveIterations,
-            final int windowSizeMessages, final long commitTimeoutMillis) {
+            final int maxUncommittedMessages, final long commitTimeoutMillis) {
         this.batchLimitEvents = batchLimitEvents;
         this.streamLimitEvents = Optional.ofNullable(streamLimitEvents);
         this.batchTimeoutMillis = batchTimeoutMillis;
         this.streamTimeoutMillis = Optional.ofNullable(streamTimeoutMillis);
         this.batchKeepAliveIterations = Optional.ofNullable(batchKeepAliveIterations);
-        this.windowSizeMessages = windowSizeMessages;
+        this.maxUncommittedMessages = maxUncommittedMessages;
         this.commitTimeoutMillis = commitTimeoutMillis;
     }
 
@@ -66,7 +66,7 @@ public class StreamParameters {
             final long batchTimeoutSeconds,
             @Nullable final Long streamTimeoutSeconds,
             @Nullable final Integer batchKeepAliveIterations,
-            final int windowSizeMessages,
+            final int maxUncommittedMessages,
             final long commitTimeoutSeconds) {
         return new StreamParameters(
                 batchLimitEvents,
@@ -74,7 +74,7 @@ public class StreamParameters {
                 TimeUnit.SECONDS.toMillis(batchTimeoutSeconds),
                 Optional.ofNullable(streamTimeoutSeconds).map(TimeUnit.SECONDS::toMillis).orElse(null),
                 batchKeepAliveIterations,
-                windowSizeMessages,
+                maxUncommittedMessages,
                 TimeUnit.SECONDS.toMillis(commitTimeoutSeconds));
     }
 }

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -114,8 +114,8 @@ class StreamingState extends State {
 
     private long getMessagesAllowedToSend() {
         final long unconfirmed = offsets.values().stream().mapToLong(PartitionData::getUnconfirmed).sum();
-        final long allowDueWindowSize = getParameters().windowSizeMessages - unconfirmed;
-        return getParameters().getMessagesAllowedToSend(allowDueWindowSize, this.sentEvents);
+        final long limit = getParameters().maxUncommittedMessages - unconfirmed;
+        return getParameters().getMessagesAllowedToSend(limit, this.sentEvents);
     }
 
     private void checkBatchTimeouts() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,6 +36,8 @@ nakadi:
       rotationMs: 86400000 # 1 day
   stream:
     timeoutMs: 31536000000 # 1 year :-P
+    default:
+        commitTimeout: 60 # 1 minute
   featureToggle.default: false
   kafka:
     instanceType: t2.large

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,3 +67,11 @@ nakadi:
   auth:
     plugin:
       factory: org.zalando.nakadi.plugin.auth.DefaultApplicationServiceFactory
+---
+
+spring:
+  profiles: acceptanceTest
+nakadi:
+  stream:
+    default:
+      commitTimeout: 5 # seconds

--- a/src/main/resources/swagger.yaml
+++ b/src/main/resources/swagger.yaml
@@ -219,7 +219,7 @@ paths:
         - name: stream_limit
           in: query
           description: |
-            Maximum number of `Event`s in this stream. If 0 or undefined, will stream indefinately.
+            Maximum number of `Event`s in this stream. If 0 or undefined, will stream indefinitely.
 
             Stream initialization will fail if `stream_limit` is lower than `batch_limit`.
           type: integer

--- a/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
@@ -107,7 +107,7 @@ public class EventTypeControllerTest {
 
         final EventTypeOptionsValidator eventTypeOptionsValidator =
                 new EventTypeOptionsValidator(TOPIC_RETENTION_MIN_MS, TOPIC_RETENTION_MAX_MS);
-        final NakadiSettings nakadiSettings = new NakadiSettings(0, 0, 0, TOPIC_RETENTION_TIME_MS, 0);
+        final NakadiSettings nakadiSettings = new NakadiSettings(0, 0, 0, TOPIC_RETENTION_TIME_MS, 0, 60);
         final EventTypeController controller = new EventTypeController(eventTypeService,
                 featureToggleService, eventTypeOptionsValidator, applicationService, nakadiSettings);
 


### PR DESCRIPTION
This PR is part of bigger task. I'm merging it against a feature branch, so that I could get some early feedback and make reviewing easier. It includes:

## rename window_size and change default value

Renaming window_size to max_uncommitted_size makes the API easier to
understand since it doesn't introduce any new terminology (window
concept is not present anywhere in the api so far).

We are also reducing the default amount to 10 since there are some
potentially large messages and a default of 100 would mean that
several megabytes would be streamed at once.

## remove commit_timeout

Allowing clients to control the commit_timeout implied in potentially
unlimited resource allocation in the server, leading to security and
operational problem.

We removed this parameter from the API but kept it as an application
configuration.

The default value was also changed to 60 seconds for launching locally
but as 5 seconds for testing purposes.