### PR TITLE
aruha-190 remove id from cursors

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1191,11 +1191,6 @@ definitions:
       - $ref: '#/definitions/Cursor'
       - type: object
         properties:
-          id:
-            type: string
-            format: uuid
-            description: |
-              Id of the cursor (a UUID).
           event_type_name:
             type: string
             description: |
@@ -1205,7 +1200,6 @@ definitions:
             description: |
               An opaque value defined by the server.
         required:
-          - id
           - event_type_name
           - cursor_token
 


### PR DESCRIPTION
The original idea for including an `id` property to cursors was to make
them identifiable, so to easy the task of
debugging (https://github.com/zalando/nakadi/pull/353#discussion_r76253962).

Although, up to now, no state is stored when delivering cursors to
clients. E.g. Nakadi doesn't keep track of what cursors have been delivered.

If we are going to identify cursors with an uuid, in order to recognise
such ID later, when a consumer commits it, it would be required to hold
such information in the server.

Since making the server statefull is not an option, we are removing this
field from the API definition. We believe that improving traceability and
easier debugging easy can be achieved by other means, as for example,
the newly added field `cursor_token`.