### PR TITLE
aruha-190 renaming event type property

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1196,10 +1196,10 @@ definitions:
             format: uuid
             description: |
               Id of the cursor (a UUID).
-          event_type_name:
+          event_type:
             type: string
             description: |
-              The name of the event type this partition's events belong to
+              The name of the event type this partition's events belong to.
           cursor_token:
             type: string
             description: |


### PR DESCRIPTION
There is no way to be over specific on the meaning of this field. We use
the same approach in other parts of the API.