### PR TITLE
aruha-190 define offsets format

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1191,10 +1191,10 @@ definitions:
             000000001.
           - the remaining 17 characters defines the index, a strictly increasing sequence in the scope of a timeline.
             This maps Kafka offsets just by converting to hexadecimals.
+          - offsets for empty partitions have a special value of BEGIN.
           - offsets are fully ordered and comparable lexicographicaly.
           - it's not possible to determine how many events there are between two offsets from different timelines.
           - timeline and index are always padded by zeros.
-          - the first event in a log has a special offset of BEGIN.
   SubscriptionCursor:
     allOf:
       - $ref: '#/definitions/Cursor'

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1184,8 +1184,14 @@ definitions:
       offset:
         type: string
         description: |
-          Offset of the event being pointed to.
+          Offset of the event being pointed to. Regarding its format and guarantees:
 
+          - offsets have a fixed size of 26 characters ranging from 0 to F (Hexadecimals).
+          - the first 9 characters are used to define the timeline, a monotonically increasing sequence.
+          - the remaining 17 characters defines the index, a strictly increasing sequence in the scope of a timeline.
+            This maps Kafka offsets just by converting to hexadecimals.
+          - offsets are fully ordered and comparable lexicographicaly.
+          - it's not possible to determine how many events there are between two offsets from different timelines.
   SubscriptionCursor:
     allOf:
       - $ref: '#/definitions/Cursor'

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1197,7 +1197,7 @@ definitions:
           - it's not possible to determine how many events there are between two offsets. Check
             SubscriptionEventTypeStats for that.
           - timeline and index are zero padded.
-        example: "0000000AB/0123456789ABCDEF"
+        example: "0000000AB/0123456789ABCDEFF"
   SubscriptionCursor:
     allOf:
       - $ref: '#/definitions/Cursor'

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1192,6 +1192,7 @@ definitions:
             This maps Kafka offsets just by converting to hexadecimals.
           - offsets are fully ordered and comparable lexicographicaly.
           - it's not possible to determine how many events there are between two offsets from different timelines.
+          - timeline and index are always padded by zeros.
   SubscriptionCursor:
     allOf:
       - $ref: '#/definitions/Cursor'

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1186,7 +1186,7 @@ definitions:
         description: |
           Offset of the event being pointed to. Regarding its format and guarantees:
 
-          - offsets have a fixed size of 27 characters ranging from 0 to F (Hexadecimals).
+          - offsets have a fixed size of 27 characters.
           - the first 9 characters are used to define the timeline, a monotonically increasing sequence. Starts with
             000000001.
           - its followed by the separator "/".

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1194,8 +1194,9 @@ definitions:
             This maps Kafka offsets just by converting to hexadecimals.
           - offsets for empty partitions have a special value of BEGIN.
           - offsets are fully ordered and comparable lexicographicaly.
-          - it's not possible to determine how many events there are between two offsets from different timelines.
-          - timeline and index are always padded by zeros.
+          - it's not possible to determine how many events there are between two offsets. Check
+            SubscriptionEventTypeStats for that.
+          - timeline and index are zero padded.
   SubscriptionCursor:
     allOf:
       - $ref: '#/definitions/Cursor'

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1194,6 +1194,7 @@ definitions:
           - offsets are fully ordered and comparable lexicographicaly.
           - it's not possible to determine how many events there are between two offsets from different timelines.
           - timeline and index are always padded by zeros.
+          - the first event in a log has a special offset of BEGIN.
   SubscriptionCursor:
     allOf:
       - $ref: '#/definitions/Cursor'

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1187,7 +1187,8 @@ definitions:
           Offset of the event being pointed to. Regarding its format and guarantees:
 
           - offsets have a fixed size of 26 characters ranging from 0 to F (Hexadecimals).
-          - the first 9 characters are used to define the timeline, a monotonically increasing sequence.
+          - the first 9 characters are used to define the timeline, a monotonically increasing sequence. Starts with
+            000000001.
           - the remaining 17 characters defines the index, a strictly increasing sequence in the scope of a timeline.
             This maps Kafka offsets just by converting to hexadecimals.
           - offsets are fully ordered and comparable lexicographicaly.

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1186,18 +1186,18 @@ definitions:
         description: |
           Offset of the event being pointed to. Regarding its format and guarantees:
 
-          - offsets have a fixed size of 27 characters.
-          - the first 9 characters are used to define the timeline, a monotonically increasing sequence. Starts with
+          - offsets have a fixed size of 25 characters.
+          - the first 8 characters are used to define the timeline, a monotonically increasing sequence. Starts with
             000000001.
           - its followed by the separator "/".
-          - the remaining 17 characters defines the index, a strictly increasing sequence in the scope of a timeline.
+          - the remaining 16 characters defines the index, a strictly increasing sequence in the scope of a timeline.
             This maps Kafka offsets just by converting to hexadecimals.
           - offsets for empty partitions have a special value of BEGIN.
           - offsets are fully ordered and comparable lexicographicaly.
           - it's not possible to determine how many events there are between two offsets. Check
             SubscriptionEventTypeStats for that.
           - timeline and index are zero padded.
-        example: "0000000AB/0123456789ABCDEFF"
+        example: "000000AB/0123456789ABCDEF"
   SubscriptionCursor:
     allOf:
       - $ref: '#/definitions/Cursor'

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1197,6 +1197,7 @@ definitions:
           - it's not possible to determine how many events there are between two offsets. Check
             SubscriptionEventTypeStats for that.
           - timeline and index are zero padded.
+        example: "000000001/12345678901234567"
   SubscriptionCursor:
     allOf:
       - $ref: '#/definitions/Cursor'

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1186,9 +1186,10 @@ definitions:
         description: |
           Offset of the event being pointed to. Regarding its format and guarantees:
 
-          - offsets have a fixed size of 26 characters ranging from 0 to F (Hexadecimals).
+          - offsets have a fixed size of 27 characters ranging from 0 to F (Hexadecimals).
           - the first 9 characters are used to define the timeline, a monotonically increasing sequence. Starts with
             000000001.
+          - its followed by the separator "/".
           - the remaining 17 characters defines the index, a strictly increasing sequence in the scope of a timeline.
             This maps Kafka offsets just by converting to hexadecimals.
           - offsets for empty partitions have a special value of BEGIN.

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1197,7 +1197,7 @@ definitions:
           - it's not possible to determine how many events there are between two offsets. Check
             SubscriptionEventTypeStats for that.
           - timeline and index are zero padded.
-        example: "000000001/12345678901234567"
+        example: "0000000AB/0123456789ABCDEF"
   SubscriptionCursor:
     allOf:
       - $ref: '#/definitions/Cursor'


### PR DESCRIPTION
Up to now Nakadi Cursors were advertised to be opaque entities and
clients should not make assumptions about its structure and meaning.

But we've been observing clients making assumptions and coding based on
them. This could lead to a major confusion in the future if we no longer
hold those assumptions true.

In order to mitigate this risk, we are committing to a well defined
structure beforehand. It's inspired by Postgres WAL format
https://www.postgresql.org/docs/9.2/static/wal-internals.html and we aim
to address two issues with this format:

1. Make Nakadi operations easier (this feature would have been
tremendously useful for cluster migration or implementing partition
rebalacing)
2. Provide a well defined set of guarantees for consumers to rely one.

**update**

As for why 27 characters = 9 (max integer 7FFFFFFF) + separator + 17 (max long 7FFFFFFFFFFFFFFF).