### PR TITLE
ARUHA-365: returned back pseudo random session id generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ ADD build/libs/nakadi.jar nakadi.jar
 
 EXPOSE 8080
 
-ENTRYPOINT java -jar nakadi.jar
+ENTRYPOINT java -Djava.security.egd=file:/dev/./urandom -jar nakadi.jar


### PR DESCRIPTION
Since we removed "-Djava.security.egd=file:/dev/./urandom" from dockerfile endtrypoint it sometimes takes a lot of time for Nakadi to start in Docker (at least in my environment):

`INFO: Creation of SecureRandom instance for session ID generation using [SHA1PRNG] took [23,655] milliseconds.`

I suggest to return it back.