### PR TITLE
ARUHA-406: Avoid Kafka unavailability from cascading to Nakadi

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,6 @@ dependencies {
         exclude module: "json"
     }
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.4.0'
-//    compile 'com.netflix.hystrix:hystrix-core:1.5.6'
 
     // tests
     testCompile 'org.hamcrest:hamcrest-all:1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     compile 'org.springframework.boot:spring-boot-starter-actuator:1.3.1.RELEASE'
     compile 'org.zalando.zmon:zmon-actuator:0.9.3'
 
-    compile 'org.springframework.cloud:spring-cloud-starter-hystrix:1.2.1.RELEASE'
+    compile 'org.springframework.cloud:spring-cloud-starter-hystrix:1.1.3.RELEASE'
 
     // storage
     compile 'org.springframework.boot:spring-boot-starter-jdbc:1.3.1.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,8 @@ dependencies {
     compile 'org.springframework.boot:spring-boot-starter-actuator:1.3.1.RELEASE'
     compile 'org.zalando.zmon:zmon-actuator:0.9.3'
 
+    compile 'org.springframework.cloud:spring-cloud-starter-hystrix:1.2.1.RELEASE'
+
     // storage
     compile 'org.springframework.boot:spring-boot-starter-jdbc:1.3.1.RELEASE'
     compile 'org.postgresql:postgresql:9.4.1207'
@@ -145,6 +147,7 @@ dependencies {
         exclude module: "json"
     }
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.4.0'
+//    compile 'com.netflix.hystrix:hystrix-core:1.5.6'
 
     // tests
     testCompile 'org.hamcrest:hamcrest-all:1.3'

--- a/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -55,6 +55,7 @@ public class KafkaRepositoryAT extends BaseAT {
     private static final int KAFKA_BATCH_SIZE = 1048576;
     private static final long KAFKA_LINGER_MS = 0;
     public static final long RETRY_AFTER_SECONDS = 300;
+    private static final long HYSTRIX_DELTA_TIMEOUT = 5000;
 
     private NakadiSettings nakadiSettings;
     private KafkaSettings kafkaSettings;
@@ -75,7 +76,8 @@ public class KafkaRepositoryAT extends BaseAT {
                 DEFAULT_COMMIT_TIMEOUT,
                 NAKADI_POLL_TIMEOUT,
                 NAKADI_SEND_TIMEOUT,
-                RETRY_AFTER_SECONDS);
+                RETRY_AFTER_SECONDS,
+                HYSTRIX_DELTA_TIMEOUT);
         kafkaSettings = new KafkaSettings(KAFKA_REQUEST_TIMEOUT, KAFKA_BATCH_SIZE, KAFKA_LINGER_MS);
         zookeeperSettings = new ZookeeperSettings(ZK_SESSION_TIMEOUT, ZK_CONNECTION_TIMEOUT);
         kafkaHelper = new KafkaTestHelper(KAFKA_URL);

--- a/src/main/java/org/zalando/nakadi/Application.java
+++ b/src/main/java/org/zalando/nakadi/Application.java
@@ -2,8 +2,10 @@ package org.zalando.nakadi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 
 @SpringBootApplication
+@EnableCircuitBreaker
 public class Application {
 
     public static void main(final String[] args) {

--- a/src/main/java/org/zalando/nakadi/config/NakadiSettings.java
+++ b/src/main/java/org/zalando/nakadi/config/NakadiSettings.java
@@ -16,6 +16,7 @@ public class NakadiSettings {
     private final long kafkaPollTimeoutMs;
     private final long kafkaSendTimeoutMs;
     private final long retryAfter;
+    private final long hystrixCommandTimeoutDeltaMs;
 
     @Autowired
     public NakadiSettings(@Value("${nakadi.topic.max.partitionNum}") final int maxTopicPartitionCount,
@@ -26,7 +27,9 @@ public class NakadiSettings {
                           @Value("${nakadi.stream.default.commitTimeout}") final long defaultCommitTimeoutSeconds,
                           @Value("${nakadi.kafka.poll.timeoutMs}") final long kafkaPollTimeoutMs,
                           @Value("${nakadi.kafka.send.timeoutMs}") final long kafkaSendTimeoutMs,
-                          @Value("${nakadi.flood.retry.after}") final long retryAfter) {
+                          @Value("${nakadi.flood.retry.after}") final long retryAfter,
+                          @Value("${nakadi.hystrix.command.timeout.delta.ms}")
+                              final long hystrixCommandTimeoutDeltaMs) {
         this.maxTopicPartitionCount = maxTopicPartitionCount;
         this.defaultTopicPartitionCount = defaultTopicPartitionCount;
         this.defaultTopicReplicaFactor = defaultTopicReplicaFactor;
@@ -36,6 +39,7 @@ public class NakadiSettings {
         this.kafkaPollTimeoutMs = kafkaPollTimeoutMs;
         this.kafkaSendTimeoutMs = kafkaSendTimeoutMs;
         this.retryAfter = retryAfter;
+        this.hystrixCommandTimeoutDeltaMs = hystrixCommandTimeoutDeltaMs;
     }
 
     public int getDefaultTopicPartitionCount() {
@@ -72,5 +76,9 @@ public class NakadiSettings {
 
     public long getRetryAfter() {
         return retryAfter;
+    }
+
+    public long getHystrixCommandTimeoutDeltaMs() {
+        return hystrixCommandTimeoutDeltaMs;
     }
 }

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSyncPostCommand.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSyncPostCommand.java
@@ -1,0 +1,193 @@
+package org.zalando.nakadi.repository.kafka;
+
+import com.google.common.base.Preconditions;
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.InterruptException;
+import org.apache.kafka.common.errors.NetworkException;
+import org.apache.kafka.common.errors.NotLeaderForPartitionException;
+import org.apache.kafka.common.errors.UnknownServerException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.zalando.nakadi.domain.BatchItem;
+import org.zalando.nakadi.domain.EventPublishingStatus;
+import org.zalando.nakadi.domain.EventPublishingStep;
+import org.zalando.nakadi.exceptions.EventPublishingException;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Command is aimed to prevent calls in cases Kafka is not available.
+ */
+public class KafkaSyncPostCommand extends HystrixCommand<KafkaSyncPostCommand.CommandResult> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaSyncPostCommand.class);
+    private static final String GROUP_KEY_SUFFIX = "kafka-sync-post-";
+    private static final int HYSTRIX_COMMAND_TIMEOUT_DELTA = 5000;
+
+    private final String topicId;
+    private final List<BatchItem> batch;
+    private final KafkaFactory kafkaFactory;
+    private final long sendTimeout;
+
+    public KafkaSyncPostCommand(final String topicId,
+                                final List<BatchItem> batch,
+                                final KafkaFactory kafkaFactory,
+                                final long sendTimeout) {
+        super(HystrixCommandGroupKey.Factory.asKey(GROUP_KEY_SUFFIX + topicId),
+                (int) sendTimeout + HYSTRIX_COMMAND_TIMEOUT_DELTA);
+        this.topicId = topicId;
+        this.batch = batch;
+        this.kafkaFactory = kafkaFactory;
+        this.sendTimeout = sendTimeout;
+    }
+
+    @Override
+    protected CommandResult run() throws Exception {
+        batch.forEach(item -> Preconditions.checkNotNull(
+                item.getPartition(), "BatchItem partition can't be null at the moment of publishing!"));
+        final Producer<String, String> producer = kafkaFactory.takeProducer();
+        final Map<BatchItem, CompletableFuture<Exception>> sendFutures = new HashMap<>();
+        try {
+            for (final BatchItem item : batch) {
+                item.setStep(EventPublishingStep.PUBLISHING);
+                sendFutures.put(item, publishItem(producer, topicId, item));
+            }
+            final CompletableFuture<Void> multiFuture = CompletableFuture.allOf(
+                    sendFutures.values().toArray(new CompletableFuture<?>[sendFutures.size()]));
+            multiFuture.get(sendTimeout, TimeUnit.MILLISECONDS);
+
+            // Now lets check for errors
+            final Optional<Exception> needReset = sendFutures.entrySet().stream()
+                    .filter(entry -> isExceptionShouldLeadToReset(entry.getValue().getNow(null)))
+                    .map(entry -> entry.getValue().getNow(null))
+                    .findAny();
+            if (needReset.isPresent()) {
+                LOG.info("Terminating producer while publishing to topic " + topicId +
+                        " because of unrecoverable exception", needReset.get());
+                kafkaFactory.terminateProducer(producer);
+            }
+        } catch (final TimeoutException ex) {
+            failUnpublished(batch, "timed out");
+            throw new EventPublishingException("Error publishing message to kafka", ex);
+        } catch (final ExecutionException ex) {
+            failUnpublished(batch, "internal error");
+            throw new EventPublishingException("Error publishing message to kafka", ex);
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            failUnpublished(batch, "interrupted");
+            throw new EventPublishingException("Error publishing message to kafka", ex);
+        } finally {
+            kafkaFactory.releaseProducer(producer);
+        }
+
+        return processExceptions(sendFutures);
+    }
+
+    private CommandResult processExceptions(final Map<BatchItem, CompletableFuture<Exception>> sendFutures)
+            throws EventPublishingException {
+        final List<Exception> exceptions = sendFutures.entrySet().stream()
+                .map(entry -> entry.getValue().getNow(null))
+                .collect(Collectors.toList());
+        if (!exceptions.isEmpty()) {
+            LOG.error("Exceptions while publishing batches to kafka: {}", exceptions);
+            failUnpublished(batch, "internal error");
+            final EventPublishingException eventPublishingException =
+                    new EventPublishingException("Error publishing message to kafka");
+            if (hasKafkaConnectionException(exceptions)) {
+                throw eventPublishingException;
+            }
+            return new CommandResult(eventPublishingException);
+        }
+        return new CommandResult();
+    }
+
+    private boolean hasKafkaConnectionException(final List<Exception> exceptions) {
+        return exceptions.stream().filter(ex ->
+                ex instanceof org.apache.kafka.common.errors.TimeoutException ||
+                ex instanceof NetworkException ||
+                ex instanceof UnknownServerException)
+                .findFirst().isPresent();
+    }
+
+    private static boolean isExceptionShouldLeadToReset(@Nullable final Exception exception) {
+        if (null == exception) {
+            return false;
+        }
+        return Stream.of(NotLeaderForPartitionException.class, UnknownTopicOrPartitionException.class).
+                filter(clazz -> clazz.isAssignableFrom(exception.getClass()))
+                .findAny().isPresent();
+    }
+
+    private void failUnpublished(final List<BatchItem> batch, final String reason) {
+        batch.stream()
+                .filter(item -> item.getResponse().getPublishingStatus() != EventPublishingStatus.SUBMITTED)
+                .forEach(item -> item.updateStatusAndDetail(EventPublishingStatus.FAILED, reason));
+    }
+
+    private static CompletableFuture<Exception> publishItem(
+            final Producer<String, String> producer, final String topicId, final BatchItem item)
+            throws EventPublishingException {
+        try {
+            final CompletableFuture<Exception> result = new CompletableFuture<>();
+            final ProducerRecord<String, String> kafkaRecord = new ProducerRecord<>(
+                    topicId,
+                    KafkaCursor.toKafkaPartition(item.getPartition()),
+                    item.getPartition(),
+                    item.getEvent().toString());
+
+            producer.send(kafkaRecord, ((metadata, exception) -> {
+                if (null != exception) {
+                    item.updateStatusAndDetail(EventPublishingStatus.FAILED, "internal error");
+                    result.complete(exception);
+                } else {
+                    item.updateStatusAndDetail(EventPublishingStatus.SUBMITTED, "");
+                    result.complete(null);
+                }
+            }));
+            return result;
+        } catch (final InterruptException e) {
+            item.updateStatusAndDetail(EventPublishingStatus.FAILED, "internal error");
+            throw new EventPublishingException("Error publishing message to kafka", e);
+        } catch (final RuntimeException e) {
+            item.updateStatusAndDetail(EventPublishingStatus.FAILED, "internal error");
+            throw new EventPublishingException("Error publishing message to kafka", e);
+        }
+    }
+
+    public static class CommandResult {
+
+        private final EventPublishingException exception;
+
+        public CommandResult(final EventPublishingException exception) {
+            this.exception = exception;
+        }
+
+        public CommandResult() {
+            this.exception = null;
+        }
+
+        public boolean isFailed() {
+            return exception != null;
+        }
+
+        @Nullable
+        public EventPublishingException getException() {
+            return exception;
+        }
+    }
+
+}

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSyncPostCommand.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSyncPostCommand.java
@@ -21,6 +21,7 @@ import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -101,6 +102,7 @@ public class KafkaSyncPostCommand extends HystrixCommand<KafkaSyncPostCommand.Co
             throws EventPublishingException {
         final List<Exception> exceptions = sendFutures.entrySet().stream()
                 .map(entry -> entry.getValue().getNow(null))
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
         if (!exceptions.isEmpty()) {
             LOG.error("Exceptions while publishing batches to kafka: {}", exceptions);

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -157,7 +157,8 @@ public class KafkaTopicRepository implements TopicRepository {
     public void syncPostBatch(final String topicId, final List<BatchItem> batch) throws EventPublishingException {
         try {
             final KafkaSyncPostCommand.CommandResult result =
-                    new KafkaSyncPostCommand(topicId, batch, kafkaFactory, createSendTimeout()).execute();
+                    new KafkaSyncPostCommand(topicId, batch, kafkaFactory, createSendTimeout(),
+                            nakadiSettings.getHystrixCommandTimeoutDeltaMs()).execute();
             if (result.isFailed()) {
                 throw result.getException();
             }

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Component;
 import org.zalando.nakadi.config.NakadiSettings;
 import org.zalando.nakadi.domain.BatchItem;
 import org.zalando.nakadi.domain.Cursor;
-import org.zalando.nakadi.domain.EventPublishingStatus;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeStatistics;
 import org.zalando.nakadi.domain.SubscriptionBase;
@@ -167,9 +166,6 @@ public class KafkaTopicRepository implements TopicRepository {
             if (cause instanceof EventPublishingException) {
                 throw (EventPublishingException) cause;
             }
-            batch.stream()
-                    .filter(item -> item.getResponse().getPublishingStatus() != EventPublishingStatus.SUBMITTED)
-                    .forEach(item -> item.updateStatusAndDetail(EventPublishingStatus.FAILED, "internal error"));
             throw new EventPublishingException("Error publishing message to kafka", hre);
         }
     }

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -1,34 +1,14 @@
 package org.zalando.nakadi.repository.kafka;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import java.util.Arrays;
-import static java.util.Collections.unmodifiableList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
-import static java.util.stream.Collectors.toList;
-import java.util.stream.Stream;
-import javax.annotation.Nullable;
+import com.netflix.hystrix.exception.HystrixRuntimeException;
 import kafka.admin.AdminUtils;
 import kafka.common.TopicExistsException;
 import kafka.utils.ZkUtils;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.errors.InterruptException;
-import org.apache.kafka.common.errors.NotLeaderForPartitionException;
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,14 +17,7 @@ import org.springframework.stereotype.Component;
 import org.zalando.nakadi.config.NakadiSettings;
 import org.zalando.nakadi.domain.BatchItem;
 import org.zalando.nakadi.domain.Cursor;
-import static org.zalando.nakadi.domain.CursorError.EMPTY_PARTITION;
-import static org.zalando.nakadi.domain.CursorError.INVALID_FORMAT;
-import static org.zalando.nakadi.domain.CursorError.NULL_OFFSET;
-import static org.zalando.nakadi.domain.CursorError.NULL_PARTITION;
-import static org.zalando.nakadi.domain.CursorError.PARTITION_NOT_FOUND;
-import static org.zalando.nakadi.domain.CursorError.UNAVAILABLE;
 import org.zalando.nakadi.domain.EventPublishingStatus;
-import org.zalando.nakadi.domain.EventPublishingStep;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeStatistics;
 import org.zalando.nakadi.domain.SubscriptionBase;
@@ -59,14 +32,31 @@ import org.zalando.nakadi.exceptions.TopicCreationException;
 import org.zalando.nakadi.exceptions.TopicDeletionException;
 import org.zalando.nakadi.repository.EventConsumer;
 import org.zalando.nakadi.repository.TopicRepository;
+import org.zalando.nakadi.repository.zookeeper.ZooKeeperHolder;
+import org.zalando.nakadi.repository.zookeeper.ZookeeperSettings;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Collections.unmodifiableList;
+import static java.util.stream.Collectors.toList;
+import static org.zalando.nakadi.domain.CursorError.EMPTY_PARTITION;
+import static org.zalando.nakadi.domain.CursorError.INVALID_FORMAT;
+import static org.zalando.nakadi.domain.CursorError.NULL_OFFSET;
+import static org.zalando.nakadi.domain.CursorError.NULL_PARTITION;
+import static org.zalando.nakadi.domain.CursorError.PARTITION_NOT_FOUND;
+import static org.zalando.nakadi.domain.CursorError.UNAVAILABLE;
 import static org.zalando.nakadi.repository.kafka.KafkaCursor.fromNakadiCursor;
 import static org.zalando.nakadi.repository.kafka.KafkaCursor.kafkaCursor;
 import static org.zalando.nakadi.repository.kafka.KafkaCursor.toKafkaOffset;
 import static org.zalando.nakadi.repository.kafka.KafkaCursor.toKafkaPartition;
 import static org.zalando.nakadi.repository.kafka.KafkaCursor.toNakadiOffset;
 import static org.zalando.nakadi.repository.kafka.KafkaCursor.toNakadiPartition;
-import org.zalando.nakadi.repository.zookeeper.ZooKeeperHolder;
-import org.zalando.nakadi.repository.zookeeper.ZookeeperSettings;
 
 @Component
 @Profile("!test")
@@ -164,100 +154,28 @@ public class KafkaTopicRepository implements TopicRepository {
                 .anyMatch(partition::equals);
     }
 
-    private static CompletableFuture<Exception> publishItem(
-            final Producer<String, String> producer, final String topicId, final BatchItem item)
-            throws EventPublishingException {
-        try {
-            final CompletableFuture<Exception> result = new CompletableFuture<>();
-            final ProducerRecord<String, String> kafkaRecord = new ProducerRecord<>(
-                    topicId,
-                    toKafkaPartition(item.getPartition()),
-                    item.getPartition(),
-                    item.getEvent().toString());
-
-            producer.send(kafkaRecord, ((metadata, exception) -> {
-                if (null != exception) {
-                    item.updateStatusAndDetail(EventPublishingStatus.FAILED, "internal error");
-                    result.complete(exception);
-                } else {
-                    item.updateStatusAndDetail(EventPublishingStatus.SUBMITTED, "");
-                    result.complete(null);
-                }
-            }));
-            return result;
-        } catch (final InterruptException e) {
-            Thread.currentThread().interrupt();
-            item.updateStatusAndDetail(EventPublishingStatus.FAILED, "internal error");
-            throw new EventPublishingException("Error publishing message to kafka", e);
-        } catch (final RuntimeException e) {
-            item.updateStatusAndDetail(EventPublishingStatus.FAILED, "internal error");
-            throw new EventPublishingException("Error publishing message to kafka", e);
-        }
-    }
-
-    private static boolean isExceptionShouldLeadToReset(@Nullable final Exception exception) {
-        if (null == exception) {
-            return false;
-        }
-        return Stream.of(NotLeaderForPartitionException.class, UnknownTopicOrPartitionException.class).
-                filter(clazz -> clazz.isAssignableFrom(exception.getClass()))
-                .findAny().isPresent();
-    }
-
     @Override
     public void syncPostBatch(final String topicId, final List<BatchItem> batch) throws EventPublishingException {
-        batch.forEach(item -> Preconditions.checkNotNull(
-                item.getPartition(), "BatchItem partition can't be null at the moment of publishing!"));
-        final Producer<String, String> producer = kafkaFactory.takeProducer();
-        final Map<BatchItem, CompletableFuture<Exception>> sendFutures = new HashMap<>();
         try {
-            for (final BatchItem item : batch) {
-                item.setStep(EventPublishingStep.PUBLISHING);
-                sendFutures.put(item, publishItem(producer, topicId, item));
+            final KafkaSyncPostCommand.CommandResult result =
+                    new KafkaSyncPostCommand(topicId, batch, kafkaFactory, createSendTimeout()).execute();
+            if (result.isFailed()) {
+                throw result.getException();
             }
-            final CompletableFuture<Void> multiFuture = CompletableFuture.allOf(
-                    sendFutures.values().toArray(new CompletableFuture<?>[sendFutures.size()]));
-            multiFuture.get(createSendTimeout(), TimeUnit.MILLISECONDS);
-
-            // Now lets check for errors
-            final Optional<Exception> needReset = sendFutures.entrySet().stream()
-                    .filter(entry -> isExceptionShouldLeadToReset(entry.getValue().getNow(null)))
-                    .map(entry -> entry.getValue().getNow(null))
-                    .findAny();
-            if (needReset.isPresent()) {
-                LOG.info("Terminating producer while publishing to topic " + topicId +
-                        " because of unrecoverable exception", needReset.get());
-                kafkaFactory.terminateProducer(producer);
+        } catch (final HystrixRuntimeException hre) {
+            final Throwable cause = hre.getCause();
+            if (cause instanceof EventPublishingException) {
+                throw (EventPublishingException) cause;
             }
-        } catch (final TimeoutException ex) {
-            failUnpublished(batch, "timed out");
-            throw new EventPublishingException("Error publishing message to kafka", ex);
-        } catch (final ExecutionException ex) {
-            failUnpublished(batch, "internal error");
-            throw new EventPublishingException("Error publishing message to kafka", ex);
-        } catch (final InterruptedException ex) {
-            Thread.currentThread().interrupt();
-            failUnpublished(batch, "interrupted");
-            throw new EventPublishingException("Error publishing message to kafka", ex);
-        } finally {
-            kafkaFactory.releaseProducer(producer);
-        }
-        final boolean atLeastOneFailed = batch.stream()
-                .anyMatch(item -> item.getResponse().getPublishingStatus() == EventPublishingStatus.FAILED);
-        if (atLeastOneFailed) {
-            failUnpublished(batch, "internal error");
-            throw new EventPublishingException("Error publishing message to kafka");
+            batch.stream()
+                    .filter(item -> item.getResponse().getPublishingStatus() != EventPublishingStatus.SUBMITTED)
+                    .forEach(item -> item.updateStatusAndDetail(EventPublishingStatus.FAILED, "internal error"));
+            throw new EventPublishingException("Error publishing message to kafka", hre);
         }
     }
 
     private long createSendTimeout() {
         return nakadiSettings.getKafkaSendTimeoutMs() + kafkaSettings.getRequestTimeoutMs();
-    }
-
-    private void failUnpublished(final List<BatchItem> batch, final String reason) {
-        batch.stream()
-                .filter(item -> item.getResponse().getPublishingStatus() != EventPublishingStatus.SUBMITTED)
-                .forEach(item -> item.updateStatusAndDetail(EventPublishingStatus.FAILED, reason));
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,6 +72,7 @@ nakadi:
     plugin:
       factory: org.zalando.nakadi.plugin.auth.DefaultApplicationServiceFactory
   flood.retry.after: 300 # seconds
+  hystrix.command.timeout.delta.ms: 5000
 ---
 
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,7 +46,7 @@ nakadi:
         commitTimeout: 60 # 1 minute
   featureToggle.default: false
   kafka:
-    request.timeout.ms: 7000
+    request.timeout.ms: 30000
     instanceType: t2.large
     poll.timeoutMs: 100
     send.timeoutMs: 5000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,12 @@ spring:
     maxActive: 20
     testOnBorrow: true
     validationQuery: SELECT 1
+
+hystrix.command.default.execution.isolation.strategy: SEMAPHORE
+hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds: 15000
+hystrix.command.default.circuitBreaker.requestVolumeThreshold: 3
+hystrix.command.default.circuitBreaker.sleepWindowInMilliseconds: 5000
+
 nakadi:
   topic:
     min:
@@ -40,7 +46,7 @@ nakadi:
         commitTimeout: 60 # 1 minute
   featureToggle.default: false
   kafka:
-    request.timeout.ms: 30000
+    request.timeout.ms: 7000
     instanceType: t2.large
     poll.timeoutMs: 100
     send.timeoutMs: 5000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,7 +25,7 @@ spring:
 
 hystrix.command.default.execution.isolation.strategy: SEMAPHORE
 hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds: 15000
-hystrix.command.default.circuitBreaker.requestVolumeThreshold: 3
+hystrix.command.default.circuitBreaker.requestVolumeThreshold: 20
 hystrix.command.default.circuitBreaker.sleepWindowInMilliseconds: 5000
 
 nakadi:

--- a/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
@@ -111,7 +111,7 @@ public class EventTypeControllerTest {
         final EventTypeOptionsValidator eventTypeOptionsValidator =
                 new EventTypeOptionsValidator(TOPIC_RETENTION_MIN_MS, TOPIC_RETENTION_MAX_MS);
         final NakadiSettings nakadiSettings = new NakadiSettings(0, 0, 0, TOPIC_RETENTION_TIME_MS, 0, 60,
-                NAKADI_POLL_TIMEOUT, NAKADI_SEND_TIMEOUT, 300);
+                NAKADI_POLL_TIMEOUT, NAKADI_SEND_TIMEOUT, 300, 5000);
         final EventTypeController controller = new EventTypeController(eventTypeService,
                 featureToggleService, eventTypeOptionsValidator, applicationService, nakadiSettings);
 

--- a/src/test/java/org/zalando/nakadi/repository/kafka/KafkaSyncPostCommandTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/kafka/KafkaSyncPostCommandTest.java
@@ -69,7 +69,8 @@ public class KafkaSyncPostCommandTest {
         return new KafkaSyncPostCommand("topic-1",
                 Collections.singletonList(batchItem),
                 kafkaFactory,
-                10000);
+                10000,
+                5000);
     }
 
     private class TestProducer implements Producer<String, String> {

--- a/src/test/java/org/zalando/nakadi/repository/kafka/KafkaSyncPostCommandTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/kafka/KafkaSyncPostCommandTest.java
@@ -1,0 +1,120 @@
+package org.zalando.nakadi.repository.kafka;
+
+import com.netflix.hystrix.exception.HystrixRuntimeException;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.zalando.nakadi.domain.BatchItem;
+import org.zalando.nakadi.domain.EventPublishingStatus;
+import org.zalando.nakadi.exceptions.EventPublishingException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+public class KafkaSyncPostCommandTest {
+
+    private TestProducer mockedKafkaProducer;
+    private KafkaFactory kafkaFactory;
+
+    @Before
+    public void setUp() throws Exception {
+        mockedKafkaProducer = new TestProducer();
+        kafkaFactory = Mockito.mock(KafkaFactory.class);
+        Mockito.when(kafkaFactory.takeProducer()).thenReturn(mockedKafkaProducer);
+    }
+
+    @Test
+    public void testKafkaTimeoutException() {
+        final BatchItem batchItem = new BatchItem(new JSONObject());
+        batchItem.setPartition("0");
+        mockedKafkaProducer.setException(new TimeoutException());
+
+        try {
+            createCommand(batchItem).execute();
+            Assert.fail();
+        } catch (final HystrixRuntimeException hre) {
+            Assert.assertTrue(hre.getCause() instanceof EventPublishingException);
+            Assert.assertTrue(batchItem.getResponse().getPublishingStatus() == EventPublishingStatus.FAILED);
+        }
+    }
+
+    @Test
+    public void testUnknownTopicOrPartitionException() {
+        final BatchItem batchItem = new BatchItem(new JSONObject());
+        batchItem.setPartition("0");
+        mockedKafkaProducer.setException(new UnknownTopicOrPartitionException());
+
+        final KafkaSyncPostCommand.CommandResult result = createCommand(batchItem).execute();
+
+        Assert.assertTrue(result.isFailed());
+        Assert.assertTrue(result.getException() instanceof EventPublishingException);
+        Assert.assertTrue(batchItem.getResponse().getPublishingStatus() == EventPublishingStatus.FAILED);
+    }
+
+    private KafkaSyncPostCommand createCommand(BatchItem batchItem) {
+        return new KafkaSyncPostCommand("topic-1",
+                Collections.singletonList(batchItem),
+                kafkaFactory,
+                10000);
+    }
+
+    private class TestProducer implements Producer<String, String> {
+
+        private Exception exception;
+
+        public void setException(Exception exception) {
+            this.exception = exception;
+        }
+
+        @Override
+        public Future<RecordMetadata> send(ProducerRecord<String, String> record) {
+            return null;
+        }
+
+        @Override
+        public Future<RecordMetadata> send(ProducerRecord<String, String> record, Callback callback) {
+            callback.onCompletion(null, exception);
+            return null;
+        }
+
+        @Override
+        public void flush() {
+
+        }
+
+        @Override
+        public List<PartitionInfo> partitionsFor(String topic) {
+            return null;
+        }
+
+        @Override
+        public Map<MetricName, ? extends Metric> metrics() {
+            return null;
+        }
+
+        @Override
+        public void close() {
+
+        }
+
+        @Override
+        public void close(long timeout, TimeUnit unit) {
+
+        }
+    }
+
+}

--- a/src/test/java/org/zalando/nakadi/repository/kafka/KafkaSyncPostCommandTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/kafka/KafkaSyncPostCommandTest.java
@@ -91,6 +91,7 @@ public class KafkaSyncPostCommandTest {
             return null;
         }
 
+        // intentionally left empty for testing purposes
         @Override
         public void flush() {
 
@@ -106,11 +107,13 @@ public class KafkaSyncPostCommandTest {
             return null;
         }
 
+        // intentionally left empty for testing purposes
         @Override
         public void close() {
 
         }
 
+        // intentionally left empty for testing purposes
         @Override
         public void close(final long timeout, final TimeUnit unit) {
 

--- a/src/test/java/org/zalando/nakadi/repository/kafka/KafkaSyncPostCommandTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/kafka/KafkaSyncPostCommandTest.java
@@ -70,7 +70,7 @@ public class KafkaSyncPostCommandTest {
                 Collections.singletonList(batchItem),
                 kafkaFactory,
                 10000,
-                5000);
+                10000);
     }
 
     private class TestProducer implements Producer<String, String> {

--- a/src/test/java/org/zalando/nakadi/repository/kafka/KafkaSyncPostCommandTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/kafka/KafkaSyncPostCommandTest.java
@@ -91,10 +91,9 @@ public class KafkaSyncPostCommandTest {
             return null;
         }
 
-        // intentionally left empty for testing purposes
         @Override
         public void flush() {
-
+            // intentionally left empty for testing purposes
         }
 
         @Override
@@ -107,16 +106,14 @@ public class KafkaSyncPostCommandTest {
             return null;
         }
 
-        // intentionally left empty for testing purposes
         @Override
         public void close() {
-
+            // intentionally left empty for testing purposes
         }
 
-        // intentionally left empty for testing purposes
         @Override
         public void close(final long timeout, final TimeUnit unit) {
-
+            // intentionally left empty for testing purposes
         }
     }
 

--- a/src/test/java/org/zalando/nakadi/repository/kafka/KafkaSyncPostCommandTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/kafka/KafkaSyncPostCommandTest.java
@@ -65,7 +65,7 @@ public class KafkaSyncPostCommandTest {
         Assert.assertTrue(batchItem.getResponse().getPublishingStatus() == EventPublishingStatus.FAILED);
     }
 
-    private KafkaSyncPostCommand createCommand(BatchItem batchItem) {
+    private KafkaSyncPostCommand createCommand(final BatchItem batchItem) {
         return new KafkaSyncPostCommand("topic-1",
                 Collections.singletonList(batchItem),
                 kafkaFactory,
@@ -76,17 +76,17 @@ public class KafkaSyncPostCommandTest {
 
         private Exception exception;
 
-        public void setException(Exception exception) {
+        public void setException(final Exception exception) {
             this.exception = exception;
         }
 
         @Override
-        public Future<RecordMetadata> send(ProducerRecord<String, String> record) {
+        public Future<RecordMetadata> send(final ProducerRecord<String, String> record) {
             return null;
         }
 
         @Override
-        public Future<RecordMetadata> send(ProducerRecord<String, String> record, Callback callback) {
+        public Future<RecordMetadata> send(final ProducerRecord<String, String> record, final Callback callback) {
             callback.onCompletion(null, exception);
             return null;
         }
@@ -97,7 +97,7 @@ public class KafkaSyncPostCommandTest {
         }
 
         @Override
-        public List<PartitionInfo> partitionsFor(String topic) {
+        public List<PartitionInfo> partitionsFor(final String topic) {
             return null;
         }
 
@@ -112,7 +112,7 @@ public class KafkaSyncPostCommandTest {
         }
 
         @Override
-        public void close(long timeout, TimeUnit unit) {
+        public void close(final long timeout, final TimeUnit unit) {
 
         }
     }

--- a/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -2,7 +2,19 @@ package org.zalando.nakadi.repository.kafka;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.GetChildrenBuilder;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.BufferExhaustedException;
 import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.PartitionInfo;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.zalando.nakadi.config.NakadiSettings;
 import org.zalando.nakadi.domain.BatchItem;
 import org.zalando.nakadi.domain.Cursor;
@@ -15,18 +27,6 @@ import org.zalando.nakadi.exceptions.EventPublishingException;
 import org.zalando.nakadi.exceptions.InvalidCursorException;
 import org.zalando.nakadi.exceptions.NakadiException;
 import org.zalando.nakadi.repository.zookeeper.ZooKeeperHolder;
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.api.GetChildrenBuilder;
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.producer.BufferExhaustedException;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.KafkaException;
-import org.apache.kafka.common.PartitionInfo;
-import org.json.JSONObject;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.zalando.nakadi.repository.zookeeper.ZookeeperSettings;
 
 import java.util.ArrayList;
@@ -119,6 +119,7 @@ public class KafkaTopicRepositoryTest {
 
         kafkaFactory = createKafkaFactory();
         kafkaTopicRepository = createKafkaRepository(kafkaFactory);
+        Mockito.when(nakadiSettings.getHystrixCommandTimeoutDeltaMs()).thenReturn(5000L);
     }
 
 


### PR DESCRIPTION
This change only for publishing events.