### PR TITLE
aruha-400 prepare for unknown attributes

### DIFF
--- a/src/main/java/org/zalando/nakadi/config/JsonConfig.java
+++ b/src/main/java/org/zalando/nakadi/config/JsonConfig.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -41,6 +42,7 @@ public class JsonConfig {
         objectMapper.registerModule(new ProblemModule());
         objectMapper.registerModule(new JodaModule());
         objectMapper.configure(WRITE_DATES_AS_TIMESTAMPS , false);
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
         return objectMapper;
     }

--- a/src/test/java/org/zalando/nakadi/controller/SubscriptionControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/SubscriptionControllerTest.java
@@ -207,7 +207,7 @@ public class SubscriptionControllerTest {
     @Test
     public void whenWrongStartFromThenBadRequest() throws Exception {
         final String subscription =
-                "{\"owning_application\":\"app\",\"event_types\":[\"myEt\"],\"start_from\":\"middle\"}";
+                "{\"owning_application\":\"app\",\"event_types\":[\"myEt\"],\"read_from\":\"middle\"}";
         postSubscriptionAsJson(subscription).andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
     }
 


### PR DESCRIPTION
In order to introduce some new fields to event types (compatibility mode
and schema versioning), I plan to first run a migration that would do
so.

But once we run this database migration that adds such fields to event
types, it would break the running version, since it would introduce new
fields that are not known to the current stack.

In order to avoid this incompatibilities, I will first release this
feature first, which ignores unknow attributes instead of breaking.
