### PR TITLE
aruha-404 allow for compatibility mode upgrade

### DIFF
--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/BlockEventPublishingAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/BlockEventPublishingAT.java
@@ -1,16 +1,13 @@
 package org.zalando.nakadi.webservice;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.restassured.http.ContentType;
 import com.jayway.restassured.response.Response;
 import org.apache.http.HttpStatus;
 import org.echocat.jomon.runtime.concurrent.RetryForSpecifiedTimeStrategy;
 import org.json.JSONObject;
 import org.junit.Test;
-import org.zalando.nakadi.config.JsonConfig;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.service.FloodService;
-import org.zalando.nakadi.utils.JsonTestHelper;
 import org.zalando.nakadi.webservice.utils.NakadiTestUtils;
 import org.zalando.problem.MoreStatus;
 
@@ -23,8 +20,6 @@ import static org.echocat.jomon.runtime.concurrent.Retryer.executeWithRetry;
 public class BlockEventPublishingAT extends BaseAT {
 
     private static final String FLOODERS_URL = "/settings/flooders";
-    private static final ObjectMapper MAPPER = (new JsonConfig()).jacksonObjectMapper();
-    private static final JsonTestHelper JSON_HELPER = new JsonTestHelper(MAPPER);
 
     @Test
     public void whenPublishingToBlockedEventTypeThen429() throws IOException {

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/BlockEventPublishingAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/BlockEventPublishingAT.java
@@ -1,11 +1,16 @@
 package org.zalando.nakadi.webservice;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.restassured.http.ContentType;
 import com.jayway.restassured.response.Response;
 import org.apache.http.HttpStatus;
+import org.echocat.jomon.runtime.concurrent.RetryForSpecifiedTimeStrategy;
+import org.json.JSONObject;
 import org.junit.Test;
+import org.zalando.nakadi.config.JsonConfig;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.service.FloodService;
+import org.zalando.nakadi.utils.JsonTestHelper;
 import org.zalando.nakadi.webservice.utils.NakadiTestUtils;
 import org.zalando.problem.MoreStatus;
 
@@ -13,8 +18,13 @@ import java.io.IOException;
 import java.text.MessageFormat;
 
 import static com.jayway.restassured.RestAssured.given;
+import static org.echocat.jomon.runtime.concurrent.Retryer.executeWithRetry;
 
 public class BlockEventPublishingAT extends BaseAT {
+
+    private static final String FLOODERS_URL = "/settings/flooders";
+    private static final ObjectMapper MAPPER = (new JsonConfig()).jacksonObjectMapper();
+    private static final JsonTestHelper JSON_HELPER = new JsonTestHelper(MAPPER);
 
     @Test
     public void whenPublishingToBlockedEventTypeThen429() throws IOException {
@@ -27,15 +37,43 @@ public class BlockEventPublishingAT extends BaseAT {
         final FloodService.Flooder flooder =
                 new FloodService.Flooder(eventType.getName(), FloodService.Type.PRODUCER_ET);
         SettingsControllerAT.blockFlooder(flooder);
+
+        waitForBlock(eventType);
+
         publishEvent(eventType)
                 .then()
                 .statusCode(MoreStatus.TOO_MANY_REQUESTS.getStatusCode())
                 .header("Retry-After", "300");
 
         SettingsControllerAT.unblockFlooder(flooder);
+
+        waitForUnblock(eventType);
+
         publishEvent(eventType)
                 .then()
                 .statusCode(HttpStatus.SC_OK);
+    }
+
+    private void waitForUnblock(final EventType eventType) {
+        executeWithRetry(() -> {
+            return !getFlooders().getJSONObject("producers").getJSONArray("event_types").toList()
+                    .contains(eventType.getName());
+        }, new RetryForSpecifiedTimeStrategy<Boolean>(5000).withResultsThatForceRetry(false).withWaitBetweenEachTry(
+                500));
+    }
+
+    private void waitForBlock(final EventType eventType) {
+        executeWithRetry(() -> {
+            return getFlooders().getJSONObject("producers").getJSONArray("event_types").toList()
+                            .contains(eventType.getName());
+        }, new RetryForSpecifiedTimeStrategy<Boolean>(5000).withResultsThatForceRetry(false).withWaitBetweenEachTry(
+                        500));
+    }
+
+    private JSONObject getFlooders() {
+        return new JSONObject(given()
+                                .header("accept", "application/json").get(FLOODERS_URL)
+                                .getBody().asString());
     }
 
     private Response publishEvent(final EventType eventType) {

--- a/src/main/java/org/zalando/nakadi/validation/SchemaEvolutionService.java
+++ b/src/main/java/org/zalando/nakadi/validation/SchemaEvolutionService.java
@@ -102,12 +102,12 @@ public class SchemaEvolutionService {
                                                     final List<SchemaChange> changes) throws InvalidEventTypeException {
         if (original.getCompatibilityMode() == CompatibilityMode.FIXED
             && eventType.getCompatibilityMode() == CompatibilityMode.COMPATIBLE) {
-            final List<SchemaChange.Type> changesTypes = changes.stream().map(SchemaChange::getType)
+
+            final List<SchemaChange> forbiddenChanges = changes.stream()
+                    .filter(change -> !FIXED_TO_COMPATIBLE_ALLOWED_CHANGES.contains(change.getType()))
                     .collect(Collectors.toList());
-            if (!FIXED_TO_COMPATIBLE_ALLOWED_CHANGES.containsAll(changesTypes)) {
-                final String errorMessage = changes.stream()
-                        .filter(change -> !FIXED_TO_COMPATIBLE_ALLOWED_CHANGES.contains(change.getType()))
-                        .map(this::formatErrorMessage)
+            if (!forbiddenChanges.isEmpty()) {
+                final String errorMessage = forbiddenChanges.stream().map(this::formatErrorMessage)
                         .collect(Collectors.joining(", "));
                 throw new InvalidEventTypeException("Invalid schema: " + errorMessage);
             }

--- a/src/main/java/org/zalando/nakadi/validation/schema/CompatibilityModeChangeConstraint.java
+++ b/src/main/java/org/zalando/nakadi/validation/schema/CompatibilityModeChangeConstraint.java
@@ -1,14 +1,25 @@
 package org.zalando.nakadi.validation.schema;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.zalando.nakadi.domain.CompatibilityMode;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeBase;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class CompatibilityModeChangeConstraint implements SchemaEvolutionConstraint {
+    final Map<CompatibilityMode, List<CompatibilityMode>> allowedChanges = ImmutableMap.of(
+            CompatibilityMode.COMPATIBLE, Lists.newArrayList(CompatibilityMode.COMPATIBLE),
+            CompatibilityMode.FIXED, Lists.newArrayList(CompatibilityMode.FIXED, CompatibilityMode.COMPATIBLE),
+            CompatibilityMode.NONE, Lists.newArrayList(CompatibilityMode.NONE)
+    );
+
     @Override
     public Optional<SchemaEvolutionIncompatibility> validate(final EventType original, final EventTypeBase eventType) {
-        if (eventType.getCompatibilityMode() != original.getCompatibilityMode()) {
+        if (!allowedChanges.get(original.getCompatibilityMode()).contains(eventType.getCompatibilityMode())) {
             return Optional.of(new SchemaEvolutionIncompatibility("changing compatibility_mode is not allowed"));
         } else {
             return Optional.empty();

--- a/src/test/java/org/zalando/nakadi/validation/schema/CompatibilityModeChangeConstraintTest.java
+++ b/src/test/java/org/zalando/nakadi/validation/schema/CompatibilityModeChangeConstraintTest.java
@@ -11,13 +11,23 @@ import static org.zalando.nakadi.utils.IsOptional.isPresent;
 
 public class CompatibilityModeChangeConstraintTest {
     @Test
-    public void failOnChange() throws Exception {
+    public void cannotDowngradeCompatibilityMode() throws Exception {
         final EventTypeTestBuilder builder = new EventTypeTestBuilder();
         final EventType oldET = builder.compatibilityMode(CompatibilityMode.COMPATIBLE).build();
         final EventType newET = builder.compatibilityMode(CompatibilityMode.NONE).build();
         final CompatibilityModeChangeConstraint constraint = new CompatibilityModeChangeConstraint();
 
         assertThat(constraint.validate(oldET, newET), isPresent());
+    }
+
+    @Test
+    public void canPromoteFromFixedToCompatible() throws Exception {
+        final EventTypeTestBuilder builder = new EventTypeTestBuilder();
+        final EventType oldET = builder.compatibilityMode(CompatibilityMode.FIXED).build();
+        final EventType newET = builder.compatibilityMode(CompatibilityMode.COMPATIBLE).build();
+        final CompatibilityModeChangeConstraint constraint = new CompatibilityModeChangeConstraint();
+
+        assertThat(constraint.validate(oldET, newET), isAbsent());
     }
 
     @Test


### PR DESCRIPTION
This PR introduces rules for upgrading an existing FIXED event type schema to a COMPATIBLE schema.