### PR TITLE
aruha-400 fix migration

### DIFF
--- a/database/migration/aruha-400-schema-evolution.sql
+++ b/database/migration/aruha-400-schema-evolution.sql
@@ -11,20 +11,19 @@ CREATE INDEX ON zn_data.event_type_schema ((ets_schema_object->>'created_at'));
 CREATE UNIQUE INDEX ON zn_data.event_type_schema ((ets_schema_object->>'version'),
                                                   (ets_event_type_name));
 
-UPDATE zn_data.event_type
-SET et_event_type_object  = jsonb_set(et_event_type_object, '{schema,version}', '"0.1.0"', false);
+UPDATE zn_data.event_type SET et_event_type_object  = jsonb_set(et_event_type_object, '{schema,version}', '"0.1.0"', true);
 
 UPDATE zn_data.event_type
-SET et_event_type_object  = jsonb_set(et_event_type_object, '{created_at}', '"2016-11-09T19:32:00Z"', false);
+SET et_event_type_object  = jsonb_set(et_event_type_object, '{created_at}', '"2016-11-09T19:32:00Z"', true);
 
 UPDATE zn_data.event_type
-SET et_event_type_object  = jsonb_set(et_event_type_object, '{updated_at}', '"2016-11-09T19:32:00Z"', false);
+SET et_event_type_object  = jsonb_set(et_event_type_object, '{updated_at}', '"2016-11-09T19:32:00Z"', true);
 
 UPDATE zn_data.event_type
-SET et_event_type_object  = jsonb_set(et_event_type_object, '{schema,created_at}', '"2016-11-09T19:32:00Z"', false);
+SET et_event_type_object  = jsonb_set(et_event_type_object, '{schema,created_at}', '"2016-11-09T19:32:00Z"', true);
 
 UPDATE zn_data.event_type
-SET et_event_type_object  = jsonb_set(et_event_type_object, '{compatibility_mode}', '"fixed"', false);
+SET et_event_type_object  = jsonb_set(et_event_type_object, '{compatibility_mode}', '"fixed"', true);
 
 INSERT INTO zn_data.event_type_schema (ets_event_type_name, ets_schema_object)
 SELECT et_name, et_event_type_object -> 'schema' FROM zn_data.event_type;


### PR DESCRIPTION
It was incorrectly using `create_missing` parameter as `null`. This migration should set this value even if it's not present.