### PR TITLE
Aruha 402-1 bugfix view specific schema version

### DIFF
--- a/src/main/java/org/zalando/nakadi/controller/SchemaController.java
+++ b/src/main/java/org/zalando/nakadi/controller/SchemaController.java
@@ -53,13 +53,13 @@ public class SchemaController {
                 return Responses.create(eventTypeResult.getProblem(), request);
             }
 
-            return ResponseEntity.status(HttpStatus.OK).body(eventTypeResult.getValue().getSchema().getSchema());
+            return ResponseEntity.status(HttpStatus.OK).body(eventTypeResult.getValue().getSchema());
         }
 
         final Result<EventTypeSchema> result = schemaService.getSchemaVersion(name, version);
         if (!result.isSuccessful())
             return Responses.create(result.getProblem(), request);
 
-        return ResponseEntity.status(HttpStatus.OK).body(result.getValue().getSchema());
+        return ResponseEntity.status(HttpStatus.OK).body(result.getValue());
     }
 }

--- a/src/main/java/org/zalando/nakadi/repository/db/SchemaRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/db/SchemaRepository.java
@@ -37,7 +37,7 @@ public class SchemaRepository extends AbstractDbRepository {
                 "WHERE ets_event_type_name = ? AND ets_schema_object ->> 'version' = ?";
 
         try {
-            return jdbcTemplate.query(sql, new Object[]{name, version}, new SchemaRowMapper()).get(0);
+            return jdbcTemplate.queryForObject(sql, new Object[]{name, version}, new SchemaMapper());
         } catch (EmptyResultDataAccessException e) {
             throw new NoSuchSchemaException("EventType \"" + name
                     + "\" has no schema with version \"" + version + "\"", e);
@@ -56,6 +56,19 @@ public class SchemaRepository extends AbstractDbRepository {
         public EventTypeSchema mapRow(final ResultSet rs, final int rowNum) throws SQLException {
             try {
                 return jsonMapper.readValue(rs.getString("ets_schema_object"), EventTypeSchema.class);
+            } catch (IOException e) {
+                throw new SQLException(e);
+            }
+        }
+    }
+
+    private class SchemaMapper implements RowMapper<EventTypeSchema> {
+        @Override
+        public EventTypeSchema mapRow(final ResultSet rs, final int rowNum) throws SQLException {
+            try {
+                final EventTypeSchema eventType =
+                        jsonMapper.readValue(rs.getString("ets_schema_object"), EventTypeSchema.class);
+                return eventType;
             } catch (IOException e) {
                 throw new SQLException(e);
             }

--- a/src/main/java/org/zalando/nakadi/repository/db/SchemaRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/db/SchemaRepository.java
@@ -7,7 +7,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Component;
 import org.zalando.nakadi.domain.EventTypeSchema;
-import org.zalando.nakadi.exceptions.InternalNakadiException;
 import org.zalando.nakadi.exceptions.NoSuchSchemaException;
 
 import java.io.IOException;

--- a/src/main/java/org/zalando/nakadi/repository/db/SchemaRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/db/SchemaRepository.java
@@ -37,7 +37,7 @@ public class SchemaRepository extends AbstractDbRepository {
                 "WHERE ets_event_type_name = ? AND ets_schema_object ->> 'version' = ?";
 
         try {
-            return jdbcTemplate.queryForObject(sql, new Object[]{name, version}, new SchemaMapper());
+            return jdbcTemplate.queryForObject(sql, new Object[]{name, version}, new SchemaRowMapper());
         } catch (EmptyResultDataAccessException e) {
             throw new NoSuchSchemaException("EventType \"" + name
                     + "\" has no schema with version \"" + version + "\"", e);
@@ -56,19 +56,6 @@ public class SchemaRepository extends AbstractDbRepository {
         public EventTypeSchema mapRow(final ResultSet rs, final int rowNum) throws SQLException {
             try {
                 return jsonMapper.readValue(rs.getString("ets_schema_object"), EventTypeSchema.class);
-            } catch (IOException e) {
-                throw new SQLException(e);
-            }
-        }
-    }
-
-    private class SchemaMapper implements RowMapper<EventTypeSchema> {
-        @Override
-        public EventTypeSchema mapRow(final ResultSet rs, final int rowNum) throws SQLException {
-            try {
-                final EventTypeSchema eventType =
-                        jsonMapper.readValue(rs.getString("ets_schema_object"), EventTypeSchema.class);
-                return eventType;
             } catch (IOException e) {
                 throw new SQLException(e);
             }

--- a/src/main/java/org/zalando/nakadi/repository/db/SchemaRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/db/SchemaRepository.java
@@ -41,7 +41,7 @@ public class SchemaRepository extends AbstractDbRepository {
                     jdbcTemplate.query(sql, new Object[]{name, version}, new SchemaRowMapper());
             if (schemas.size() != 1)
                 throw new InternalNakadiException(
-                        String.format("Unexpected number of schemas with version {}: {}", version, schemas.size()));
+                        String.format("Unexpected number of schemas with version %s: %s", version, schemas.size()));
             return schemas.get(0);
         } catch (EmptyResultDataAccessException e) {
             throw new NoSuchSchemaException("EventType \"" + name

--- a/src/main/java/org/zalando/nakadi/repository/db/SchemaRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/db/SchemaRepository.java
@@ -37,12 +37,7 @@ public class SchemaRepository extends AbstractDbRepository {
                 "WHERE ets_event_type_name = ? AND ets_schema_object ->> 'version' = ?";
 
         try {
-            final List<EventTypeSchema> schemas =
-                    jdbcTemplate.query(sql, new Object[]{name, version}, new SchemaRowMapper());
-            if (schemas.size() != 1)
-                throw new InternalNakadiException(
-                        String.format("Unexpected number of schemas with version %s: %s", version, schemas.size()));
-            return schemas.get(0);
+            return jdbcTemplate.query(sql, new Object[]{name, version}, new SchemaRowMapper()).get(0);
         } catch (EmptyResultDataAccessException e) {
             throw new NoSuchSchemaException("EventType \"" + name
                     + "\" has no schema with version \"" + version + "\"", e);

--- a/src/main/java/org/zalando/nakadi/repository/db/SchemaRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/db/SchemaRepository.java
@@ -32,7 +32,7 @@ public class SchemaRepository extends AbstractDbRepository {
     }
 
     public EventTypeSchema getSchemaVersion(final String name, final String version)
-            throws NoSuchSchemaException, InternalNakadiException {
+            throws NoSuchSchemaException {
         final String sql = "SELECT ets_schema_object FROM zn_data.event_type_schema " +
                 "WHERE ets_event_type_name = ? AND ets_schema_object ->> 'version' = ?";
 

--- a/src/main/java/org/zalando/nakadi/service/SchemaService.java
+++ b/src/main/java/org/zalando/nakadi/service/SchemaService.java
@@ -48,7 +48,7 @@ public class SchemaService {
     public Result<EventTypeSchema> getSchemaVersion(final String name, final String version) {
         final Matcher versionMatcher = VERSION_PATTERN.matcher(version);
         if (!versionMatcher.matches()) {
-            return Result.problem(Problem.valueOf(Response.Status.NOT_FOUND));
+            return Result.problem(Problem.valueOf(Response.Status.NOT_FOUND, "Invalid version number"));
         }
 
         try {

--- a/src/main/java/org/zalando/nakadi/service/SchemaService.java
+++ b/src/main/java/org/zalando/nakadi/service/SchemaService.java
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.zalando.nakadi.domain.EventTypeSchema;
-import org.zalando.nakadi.exceptions.InternalNakadiException;
 import org.zalando.nakadi.exceptions.NoSuchSchemaException;
 import org.zalando.nakadi.repository.db.SchemaRepository;
 import org.zalando.problem.Problem;

--- a/src/main/java/org/zalando/nakadi/service/SchemaService.java
+++ b/src/main/java/org/zalando/nakadi/service/SchemaService.java
@@ -55,8 +55,7 @@ public class SchemaService {
             return Result.ok(schema);
         } catch (final NoSuchSchemaException e) {
             LOG.debug("Could not find EventTypeSchema version: {} for EventType: {}", version, name);
-            return Result.problem(Problem.valueOf(Response.Status.NOT_FOUND,
-                    "Could not find schema version " + version + " for event type " + name));
+            return Result.problem(e.asProblem());
         }
     }
 }

--- a/src/main/java/org/zalando/nakadi/service/SchemaService.java
+++ b/src/main/java/org/zalando/nakadi/service/SchemaService.java
@@ -56,11 +56,8 @@ public class SchemaService {
             return Result.ok(schema);
         } catch (final NoSuchSchemaException e) {
             LOG.debug("Could not find EventTypeSchema version: {} for EventType: {}", version, name);
-            return Result.problem(Problem.valueOf(Response.Status.NOT_FOUND, 
-				    "Could not find schema version " + version + " for event type " + name));
-        } catch (final InternalNakadiException e) {
-            LOG.error("Problem loading event type schema version " + version + " for EventType " + name, e);
-            return Result.problem(Problem.valueOf(Response.Status.NOT_FOUND, "Schema type of version does not exist"));
+            return Result.problem(Problem.valueOf(Response.Status.NOT_FOUND,
+                    "Could not find schema version " + version + " for event type " + name));
         }
     }
 }

--- a/src/main/java/org/zalando/nakadi/service/SchemaService.java
+++ b/src/main/java/org/zalando/nakadi/service/SchemaService.java
@@ -56,7 +56,8 @@ public class SchemaService {
             return Result.ok(schema);
         } catch (final NoSuchSchemaException e) {
             LOG.debug("Could not find EventTypeSchema version: {} for EventType: {}", version, name);
-            return Result.problem(e.asProblem());
+            return Result.problem(Problem.valueOf(Response.Status.NOT_FOUND, 
+				    "Could not find schema version " + version + " for event type " + name);
         } catch (final InternalNakadiException e) {
             LOG.error("Problem loading event type schema version " + version + " for EventType " + name, e);
             return Result.problem(Problem.valueOf(Response.Status.NOT_FOUND, "Schema type of version does not exist"));

--- a/src/main/java/org/zalando/nakadi/service/SchemaService.java
+++ b/src/main/java/org/zalando/nakadi/service/SchemaService.java
@@ -48,7 +48,7 @@ public class SchemaService {
     public Result<EventTypeSchema> getSchemaVersion(final String name, final String version) {
         final Matcher versionMatcher = VERSION_PATTERN.matcher(version);
         if (!versionMatcher.matches()) {
-            return Result.problem(Problem.valueOf(Response.Status.NOT_FOUND, "Invalid version number"));
+            return Result.problem(Problem.valueOf(Response.Status.BAD_REQUEST, "Invalid version number"));
         }
 
         try {
@@ -57,7 +57,7 @@ public class SchemaService {
         } catch (final NoSuchSchemaException e) {
             LOG.debug("Could not find EventTypeSchema version: {} for EventType: {}", version, name);
             return Result.problem(Problem.valueOf(Response.Status.NOT_FOUND, 
-				    "Could not find schema version " + version + " for event type " + name);
+				    "Could not find schema version " + version + " for event type " + name));
         } catch (final InternalNakadiException e) {
             LOG.error("Problem loading event type schema version " + version + " for EventType " + name, e);
             return Result.problem(Problem.valueOf(Response.Status.NOT_FOUND, "Schema type of version does not exist"));

--- a/src/main/java/org/zalando/nakadi/service/SchemaService.java
+++ b/src/main/java/org/zalando/nakadi/service/SchemaService.java
@@ -59,7 +59,7 @@ public class SchemaService {
             return Result.problem(e.asProblem());
         } catch (final InternalNakadiException e) {
             LOG.error("Problem loading event type schema version " + version + " for EventType " + name, e);
-            return Result.problem(e.asProblem());
+            return Result.problem(Problem.valueOf(Response.Status.NOT_FOUND, "Schema type of version does not exist"));
         }
     }
 }

--- a/src/test/java/org/zalando/nakadi/controller/SchemaControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/SchemaControllerTest.java
@@ -60,7 +60,7 @@ public class SchemaControllerTest {
                 new SchemaController(schemaService, eventTypeService)
                         .getSchemaVersion(eventType.getName(), "latest", nativeWebRequest);
         Assert.assertEquals(HttpStatus.OK, result.getStatusCode());
-        Assert.assertEquals(eventType.getSchema().getSchema(), result.getBody().toString());
+        Assert.assertEquals(eventType.getSchema().toString(), result.getBody().toString());
     }
 
     @Test
@@ -83,7 +83,7 @@ public class SchemaControllerTest {
                 new SchemaController(schemaService, eventTypeService).getSchemaVersion(eventType.getName(),
                         eventType.getSchema().getVersion().toString(), nativeWebRequest);
         Assert.assertEquals(HttpStatus.OK, result.getStatusCode());
-        Assert.assertEquals(eventType.getSchema().getSchema(), result.getBody().toString());
+        Assert.assertEquals(eventType.getSchema().toString(), result.getBody().toString());
     }
 
     @Test


### PR DESCRIPTION
In this PR:
* return an EventTypeSchema instead of only the schema
* return 404 not found instead of 500 if the event type or the schema version does not exist
* return 400 bad request with details if the version number is invalid
* improved query handling in SchemaRepository