### PR TITLE
Aruha 400 make compatibility mode required

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1604,7 +1604,6 @@ definitions:
             Under this mode, the following json-schema attributes are not supported: `not`, `patternProperties`,
             `additionalProperties` and `additionalItems`. When validating events, additional properties is `false`.
         type: string
-        default: compatible
 
       schema:
         $ref: '#/definitions/EventTypeSchema'
@@ -1660,6 +1659,7 @@ definitions:
       - category
       - owning_application
       - schema
+      - compatibility_mode
 
   EventTypeSchema:
     type: object

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaAT.java
@@ -324,7 +324,7 @@ public class HilaAT extends BaseAT {
 
     @Test(timeout = 15000)
     public void whenStreamTimeout0ThenInfiniteStreaming() throws Exception {
-        IntStream.range(0, 5).forEach(x -> publishEvent(eventType.getName(), "{\"blah\":\"foo\"}"));
+        IntStream.range(0, 5).forEach(x -> publishEvent(eventType.getName(), "{\"foo\":\"bar\"}"));
         final TestStreamingClient client = TestStreamingClient
                 .create(URL, subscription.getId(), "stream_timeout=0")
                 .start();

--- a/src/main/java/org/zalando/nakadi/domain/EventTypeBase.java
+++ b/src/main/java/org/zalando/nakadi/domain/EventTypeBase.java
@@ -58,6 +58,7 @@ public class EventTypeBase {
 
     private Set<String> readScopes;
 
+    @NotNull
     private CompatibilityMode compatibilityMode;
 
     public EventTypeBase() {
@@ -67,7 +68,6 @@ public class EventTypeBase {
         this.options = new EventTypeOptions();
         this.writeScopes = Collections.emptySet();
         this.readScopes = Collections.emptySet();
-        this.compatibilityMode = CompatibilityMode.COMPATIBLE;
     }
 
     public EventTypeBase(final String name, final String topic, final String owningApplication,

--- a/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -197,7 +197,8 @@ public class EventTypeService {
 
             if (eventType.getCompatibilityMode() == CompatibilityMode.FIXED) {
                 throw new InvalidEventTypeException(
-                        "\"compatibility_mode\" should be either \"compatible\" or \"none\"");
+                        "\"compatibility_mode\" should be either \"compatible\" or \"none\". The \"fixed\" mode is for "
+                                + "legacy event types only");
             }
 
             validatePartitionKeys(schema, eventType);

--- a/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
@@ -200,7 +200,8 @@ public class EventTypeControllerTest {
         final Problem expectedProblem = invalidProblem("schema.schema", "may not be null");
 
         final String eventType = "{\"category\": \"data\", \"owning_application\": \"blah-app\", "
-                + "\"name\": \"blah-event-type\", \"schema\": { \"type\": \"JSON_SCHEMA\" }}";
+                + "\"compatibility_mode\": \"compatible\", \"name\": \"blah-event-type\","
+                + " \"schema\": { \"type\": \"JSON_SCHEMA\" }}";
 
         postEventType(eventType).andExpect(status().isUnprocessableEntity())
                                 .andExpect(content().contentType("application/problem+json")).andExpect(content()


### PR DESCRIPTION
Some users have the bad habit of deleting and recreating event types. If they did it after this release, it would inadvertently create a `compatible` event type, which has strict validation, and could break their process.

Making `compatibility_mode` required, at least will make them aware of the changes, since it will force them to read the docs about this new field.