### PR TITLE
aruha-509 fix bug with $ref

### DIFF
--- a/src/main/resources/schema.json
+++ b/src/main/resources/schema.json
@@ -35,6 +35,10 @@
             "type": "string",
             "format": "uri"
         },
+        "$ref": {
+            "type": "string",
+            "format": "uri"
+        },
         "title": {
             "type": "string"
         },

--- a/src/test/resources/org/zalando/nakadi/validation/invalid-json-schema-examples.json
+++ b/src/test/resources/org/zalando/nakadi/validation/invalid-json-schema-examples.json
@@ -147,9 +147,7 @@
         }
       }
     },
-    "errors": ["Invalid schema found in [#/definitions/paradox]: extraneous key [not] is not permitted",
-      "Invalid schema found in [#/items]: extraneous key [$ref] is not permitted",
-      "Invalid schema found in [#/items]: expected type: JSONArray, found: JSONObject"]
+    "errors": ["Invalid schema found in [#/definitions/paradox]: extraneous key [not] is not permitted"]
   },
   {
     "description": "Invalid attribute in combined schemas",


### PR DESCRIPTION
$ref have been accidentally blocked.

This bug actually reveals a core schema meta-schema definition
problem. I've extended the meta-schema definition to accept $ref.