### PR TITLE
ARUHA-520 use getBytes(..) to report actual batch size

### DIFF
--- a/src/main/java/org/zalando/nakadi/controller/EventPublishingController.java
+++ b/src/main/java/org/zalando/nakadi/controller/EventPublishingController.java
@@ -108,7 +108,7 @@ public class EventPublishingController {
                                final String eventsAsString, final int eventCount) {
         if (result.getStatus() == EventPublishingStatus.SUBMITTED) {
             eventTypeMetrics.reportSizing(eventCount,
-                    eventsAsString.getBytes(StandardCharsets.UTF_8).length - eventCount + 1);
+                    eventsAsString.getBytes(StandardCharsets.UTF_8).length - eventCount - 1);
         } else if (result.getStatus() == EventPublishingStatus.FAILED && eventCount != 0) {
             final int successfulEvents= result.getResponses()
                     .stream()

--- a/src/main/java/org/zalando/nakadi/controller/EventPublishingController.java
+++ b/src/main/java/org/zalando/nakadi/controller/EventPublishingController.java
@@ -107,7 +107,8 @@ public class EventPublishingController {
     private void reportMetrics(final EventTypeMetrics eventTypeMetrics, final EventPublishResult result,
                                final String eventsAsString, final int eventCount) {
         if (result.getStatus() == EventPublishingStatus.SUBMITTED) {
-            eventTypeMetrics.reportSizing(eventCount, eventsAsString.getBytes(StandardCharsets.UTF_8).length - 2);
+            eventTypeMetrics.reportSizing(eventCount,
+                    eventsAsString.getBytes(StandardCharsets.UTF_8).length - eventCount + 1);
         } else if (result.getStatus() == EventPublishingStatus.FAILED && eventCount != 0) {
             final int successfulEvents= result.getResponses()
                     .stream()

--- a/src/main/java/org/zalando/nakadi/controller/EventPublishingController.java
+++ b/src/main/java/org/zalando/nakadi/controller/EventPublishingController.java
@@ -114,8 +114,8 @@ public class EventPublishingController {
                     .filter(r -> r.getPublishingStatus() == EventPublishingStatus.SUBMITTED)
                     .collect(Collectors.toList())
                     .size();
-            final double avgEventSize = eventsAsString.getBytes(StandardCharsets.UTF_8).length / eventCount;
-            eventTypeMetrics.reportSizing(successfulEvents,(int)Math.round(avgEventSize * successfulEvents));
+            final double avgEventSize = eventsAsString.getBytes(StandardCharsets.UTF_8).length / (double)eventCount;
+            eventTypeMetrics.reportSizing(successfulEvents, (int)Math.round(avgEventSize * successfulEvents));
         }
     }
 

--- a/src/main/java/org/zalando/nakadi/controller/EventPublishingController.java
+++ b/src/main/java/org/zalando/nakadi/controller/EventPublishingController.java
@@ -1,5 +1,6 @@
 package org.zalando.nakadi.controller;
 
+import com.google.common.base.Charsets;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.slf4j.Logger;
@@ -82,7 +83,7 @@ public class EventPublishingController {
             final JSONArray eventsAsJsonObjects = new JSONArray(eventsAsString);
 
             final int eventCount = eventsAsJsonObjects.length();
-            eventTypeMetrics.reportSizing(eventCount, eventsAsString.length());
+            eventTypeMetrics.reportSizing(eventCount, eventsAsString.getBytes(Charsets.UTF_8).length);
 
             return response(publisher.publish(eventsAsJsonObjects, eventTypeName, client));
         } catch (final JSONException e) {


### PR DESCRIPTION
This PR fixes a bug in batch size reporting for batches with multi-byte characters. I don't think a unit test is necessary for this.