### PR TITLE
aruha-515 do not enforce additionalProperties for composed schemas

### DIFF
--- a/src/main/java/org/zalando/nakadi/validation/JsonSchemaEnrichment.java
+++ b/src/main/java/org/zalando/nakadi/validation/JsonSchemaEnrichment.java
@@ -104,6 +104,7 @@ public class JsonSchemaEnrichment {
             OBJECT_SCHEMA_KEYWORDS.stream().anyMatch(schema::has) ||
             ARRAY_SCHEMA_KEYWORDS.stream().anyMatch(schema::has) ||
             COMPOSED_SCHEMA_KEYWORDS.stream().anyMatch(schema::has) ||
+            schema.has("$ref") ||
             schema.has("type")
         );
     }

--- a/src/main/java/org/zalando/nakadi/validation/JsonSchemaEnrichment.java
+++ b/src/main/java/org/zalando/nakadi/validation/JsonSchemaEnrichment.java
@@ -1,7 +1,6 @@
 package org.zalando.nakadi.validation;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/src/test/resources/org/zalando/nakadi/validation/strict-validation.json
+++ b/src/test/resources/org/zalando/nakadi/validation/strict-validation.json
@@ -201,6 +201,30 @@
     }
   },
   {
+    "description": "Do not strict reference schemas",
+    "original_schema": {
+      "definitions": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "properties": {
+        "foo": { "$ref": "#/definitions/foo" }
+      }
+    },
+    "effective_schema": {
+      "definitions": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "properties": {
+        "foo": { "$ref": "#/definitions/foo" }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
     "description": "Strict if mixed object type",
     "original_schema": {
       "type": ["string", "object"]

--- a/src/test/resources/org/zalando/nakadi/validation/strict-validation.json
+++ b/src/test/resources/org/zalando/nakadi/validation/strict-validation.json
@@ -54,7 +54,7 @@
     }
   },
   {
-    "description": "Add additionalProperties when defining definitions",
+    "description": "Add additionalProperties when schema is empty",
     "original_schema": {
       "definitions": {
         "foo": {
@@ -173,6 +173,12 @@
   {
     "description": "Strict combined schemas",
     "original_schema": {
+      "definitions": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "description": "Some description",
       "anyOf": [
         {
           "type": "object"
@@ -180,6 +186,12 @@
       ]
     },
     "effective_schema": {
+      "definitions": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "description": "Some description",
       "anyOf": [
         {
           "type": "object",


### PR DESCRIPTION
Additional properties should not be enforced when using composed
schemas since it would cause the rejection of all events different from
an empty json object.