### PR TITLE
aruha-538 disable subscription creation

### DIFF
--- a/src/main/java/org/zalando/nakadi/controller/SubscriptionController.java
+++ b/src/main/java/org/zalando/nakadi/controller/SubscriptionController.java
@@ -83,7 +83,7 @@ public class SubscriptionController {
                     return Responses.create(new ServiceUnavailableException(
                             "Subscription creation is temporarily unavailable", e).asProblem(), request);
                 } catch (final NakadiException e) {
-                    Responses.create(e.asProblem(), request);
+                    return Responses.create(e.asProblem(), request);
                 }
             }
 

--- a/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionService.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionService.java
@@ -49,8 +49,6 @@ import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.zalando.nakadi.util.FeatureToggleService.Feature.DISABLE_SUBSCRIPTION_CREATION;
-
 @Component
 public class SubscriptionService {
 
@@ -111,14 +109,6 @@ public class SubscriptionService {
                 .map(Optional::get)
                 .forEach(eventType -> client.checkScopes(eventType.getReadScopes()));
 
-        if (featureToggleService.isFeatureEnabled(DISABLE_SUBSCRIPTION_CREATION)) {
-            try {
-                return Result.ok(getExistingSubscription(subscriptionBase));
-            } catch (final NoSuchSubscriptionException e) {
-                throw new ServiceUnavailableException("Subscription creation is temporarily unavailable", e);
-            }
-        }
-
         // generate subscription id and try to create subscription in DB
         final Subscription subscription = subscriptionRepository.createSubscription(subscriptionBase);
         return Result.ok(subscription);
@@ -138,7 +128,7 @@ public class SubscriptionService {
         }
     }
 
-    private Subscription getExistingSubscription(final SubscriptionBase subscriptionBase)
+    public Subscription getExistingSubscription(final SubscriptionBase subscriptionBase)
             throws NoSuchSubscriptionException, InternalNakadiException, ServiceUnavailableException {
         return subscriptionRepository.getSubscription(
                 subscriptionBase.getOwningApplication(),

--- a/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionService.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionService.java
@@ -32,7 +32,6 @@ import org.zalando.nakadi.service.subscription.model.Partition;
 import org.zalando.nakadi.service.subscription.zk.ZkSubscriptionClient;
 import org.zalando.nakadi.service.subscription.zk.ZkSubscriptionClientFactory;
 import org.zalando.nakadi.service.subscription.zk.ZkSubscriptionNode;
-import org.zalando.nakadi.util.FeatureToggleService;
 import org.zalando.nakadi.util.SubscriptionsUriHelper;
 import org.zalando.problem.MoreStatus;
 import org.zalando.problem.Problem;
@@ -59,19 +58,16 @@ public class SubscriptionService {
     private final EventTypeRepository eventTypeRepository;
     private final ZkSubscriptionClientFactory zkSubscriptionClientFactory;
     private final TopicRepository topicRepository;
-    private final FeatureToggleService featureToggleService;
 
     @Autowired
     public SubscriptionService(final SubscriptionDbRepository subscriptionRepository,
                                final ZkSubscriptionClientFactory zkSubscriptionClientFactory,
                                final TopicRepository topicRepository,
-                               final EventTypeRepository eventTypeRepository,
-                               final FeatureToggleService featureToggleService) {
+                               final EventTypeRepository eventTypeRepository) {
         this.subscriptionRepository = subscriptionRepository;
         this.zkSubscriptionClientFactory = zkSubscriptionClientFactory;
         this.topicRepository = topicRepository;
         this.eventTypeRepository = eventTypeRepository;
-        this.featureToggleService = featureToggleService;
     }
 
     public Result<Subscription> createSubscription(final SubscriptionBase subscriptionBase, final Client client)

--- a/src/main/java/org/zalando/nakadi/util/FeatureToggleService.java
+++ b/src/main/java/org/zalando/nakadi/util/FeatureToggleService.java
@@ -24,6 +24,7 @@ public interface FeatureToggleService {
         CONNECTION_CLOSE_CRUTCH("close_crutch"),
         DISABLE_EVENT_TYPE_CREATION("disable_event_type_creation"),
         DISABLE_EVENT_TYPE_DELETION("disable_event_type_deletion"),
+        DISABLE_SUBSCRIPTION_CREATION("disable_subscription_creation"),
         HIGH_LEVEL_API("high_level_api"),
         CHECK_APPLICATION_LEVEL_PERMISSIONS("check_application_level_permissions"),
         CHECK_PARTITIONS_KEYS("check_partitions_keys"),

--- a/src/main/java/org/zalando/nakadi/util/FeatureToggleServiceDefault.java
+++ b/src/main/java/org/zalando/nakadi/util/FeatureToggleServiceDefault.java
@@ -12,7 +12,8 @@ import java.util.Set;
 public class FeatureToggleServiceDefault implements FeatureToggleService {
     private static final Set<Feature> DEPRECATED_FEATURES = ImmutableSet.of(
             Feature.DISABLE_EVENT_TYPE_CREATION,
-            Feature.DISABLE_EVENT_TYPE_DELETION
+            Feature.DISABLE_EVENT_TYPE_DELETION,
+            Feature.DISABLE_SUBSCRIPTION_CREATION
     );
 
     @Override

--- a/src/test/java/org/zalando/nakadi/controller/SubscriptionControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/SubscriptionControllerTest.java
@@ -113,7 +113,7 @@ public class SubscriptionControllerTest {
         when(zkSubscriptionClientFactory.createZkSubscriptionClient(any())).thenReturn(zkSubscriptionClient);
         final SubscriptionService subscriptionService = new SubscriptionService(subscriptionRepository,
                 zkSubscriptionClientFactory,
-                topicRepository, eventTypeRepository);
+                topicRepository, eventTypeRepository, featureToggleService);
         final SubscriptionController controller = new SubscriptionController(featureToggleService, applicationService,
                 subscriptionService);
         final MappingJackson2HttpMessageConverter jackson2HttpMessageConverter =

--- a/src/test/java/org/zalando/nakadi/controller/SubscriptionControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/SubscriptionControllerTest.java
@@ -115,7 +115,7 @@ public class SubscriptionControllerTest {
         when(zkSubscriptionClientFactory.createZkSubscriptionClient(any())).thenReturn(zkSubscriptionClient);
         final SubscriptionService subscriptionService = new SubscriptionService(subscriptionRepository,
                 zkSubscriptionClientFactory,
-                topicRepository, eventTypeRepository, featureToggleService);
+                topicRepository, eventTypeRepository);
         final SubscriptionController controller = new SubscriptionController(featureToggleService, applicationService,
                 subscriptionService);
         final MappingJackson2HttpMessageConverter jackson2HttpMessageConverter =
@@ -134,7 +134,6 @@ public class SubscriptionControllerTest {
                 .withOwningApplication("app")
                 .withEventTypes(ImmutableSet.of("myET"))
                 .buildSubscriptionBase();
-        final Subscription subscription = new Subscription("123", new DateTime(DateTimeZone.UTC), subscriptionBase);
         when(subscriptionRepository.getSubscription(any(), any(), any())).thenThrow(NoSuchSubscriptionException.class);
         when(featureToggleService.isFeatureEnabled(FeatureToggleService.Feature.DISABLE_SUBSCRIPTION_CREATION))
                 .thenReturn(true);

--- a/src/test/java/org/zalando/nakadi/controller/SubscriptionControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/SubscriptionControllerTest.java
@@ -104,6 +104,8 @@ public class SubscriptionControllerTest {
 
         final FeatureToggleService featureToggleService = mock(FeatureToggleService.class);
         when(featureToggleService.isFeatureEnabled(any())).thenReturn(true);
+        when(featureToggleService.isFeatureEnabled(FeatureToggleService.Feature.DISABLE_SUBSCRIPTION_CREATION))
+                .thenReturn(false);
 
         topicRepository = mock(TopicRepository.class);
         final ZkSubscriptionClientFactory zkSubscriptionClientFactory = mock(ZkSubscriptionClientFactory.class);


### PR DESCRIPTION
In order to migrate the database, we need to disable features that write
to the database, so that we can dump & restore consistently, without
loosing any data.