### PR TITLE
aruha-578 Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+When closing a release, don't forget to also change the version in the [API file](api/nakadi-event-bus-api.yaml).
+
+## [Unreleased]
+
+## [1.0.0] - 2017-01-18
+### Added
+- Introducing new change log file @rcillo
+
+### Changed
+- Make a clear statement that Nakadi API follows semver and is 1.0.0 stable @rcillo

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -68,7 +68,7 @@ info:
     Other aspects of the Event Bus are at this moment to be defined and otherwise specified, not included
     in this version of this specification.
 
-  version: '0.8.0'
+  version: '1.0.0'
   contact:
     name: Team Aruha @ Zalando
     email: team-aruha+nakadi-maintainers@zalando.de


### PR DESCRIPTION
In order to better communicate changes we are going to maintain a change
log file following a well defined standard.

Since this standard required semver adoption, we are using this
opportunity to bump version from 0.8.0 to 1.0.0, which better reflects
the maturity of the project's API definition.

Read more about the standard at http://keepachangelog.com