### PR TITLE
aruha-584 consumer quota

### DIFF
--- a/src/main/java/org/zalando/nakadi/controller/EventStreamController.java
+++ b/src/main/java/org/zalando/nakadi/controller/EventStreamController.java
@@ -235,8 +235,10 @@ public class EventStreamController {
 
     /**
      * Every consumer identifies itself using a client-id to use its quota. The client id is a combination of
-     * application name and event type so that every application can consume up to the quota limit per partition.
-     * Leader partitions from a single event type are guaranteed to be located on different brokers.
+     * application name and event type so that every application can consume up to the quota limit per partition, given
+     * partitions from the same event type are located in different brokers. In case of broker failure, multiple
+     * partitions from the same event type could be served by the same broker due to Kafka fallback. In this case, the
+     * quota would be shared between partitions, reducing the overall throughput for that event type.
      **/
     private String getKafkaQuotaClientId(final String eventTypeName, final Client client) {
         return client.getClientId() + "-" + eventTypeName;

--- a/src/main/java/org/zalando/nakadi/controller/EventStreamController.java
+++ b/src/main/java/org/zalando/nakadi/controller/EventStreamController.java
@@ -238,7 +238,7 @@ public class EventStreamController {
      * application name and event type so that every application can consume up to the quota limit per partition.
      * Leader partitions from a single event type are guaranteed to be located on different brokers.
      **/
-    private String getKafkaQuotaClientId(final @PathVariable("name") String eventTypeName, final Client client) {
+    private String getKafkaQuotaClientId(final String eventTypeName, final Client client) {
         return client.getClientId() + "-" + eventTypeName;
     }
 

--- a/src/main/java/org/zalando/nakadi/repository/TopicRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/TopicRepository.java
@@ -49,7 +49,7 @@ public interface TopicRepository {
 
     TopicPartition getPartition(String topicId, String partition) throws NakadiException;
 
-    EventConsumer createEventConsumer(String topic, List<Cursor> cursors) throws NakadiException,
+    EventConsumer createEventConsumer(final String clientId, String topic, List<Cursor> cursors) throws NakadiException,
             InvalidCursorException;
 
     int compareOffsets(String firstOffset, String secondOffset) throws InternalNakadiException;

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
@@ -2,14 +2,6 @@ package org.zalando.nakadi.repository.kafka;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-import javax.annotation.Nullable;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -19,6 +11,16 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 @Component
 @Profile("!test")
@@ -137,13 +139,23 @@ public class KafkaFactory {
         }
     }
 
+    public Consumer<String, String> getConsumer(final Properties properties) {
+        return new KafkaConsumer<>(properties);
+    }
+
     public Consumer<String, String> getConsumer() {
         return new KafkaConsumer<>(kafkaLocationManager.getKafkaConsumerProperties());
     }
 
-    public NakadiKafkaConsumer createNakadiConsumer(final String topic, final List<KafkaCursor> kafkaCursors,
+    public Consumer<String, String> getConsumer(final String clientId) {
+        final Properties properties = kafkaLocationManager.getKafkaConsumerProperties();
+        properties.put("client.id", clientId);
+        return this.getConsumer(properties);
+    }
+
+    public NakadiKafkaConsumer createNakadiConsumer(final String clientId, final String topic, final List<KafkaCursor> kafkaCursors,
                                                     final long pollTimeout) {
-        return new NakadiKafkaConsumer(getConsumer(), topic, kafkaCursors, pollTimeout);
+        return new NakadiKafkaConsumer(getConsumer(clientId), topic, kafkaCursors, pollTimeout);
     }
 
 }

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
@@ -144,7 +144,7 @@ public class KafkaFactory {
     }
 
     public Consumer<String, String> getConsumer() {
-        return new KafkaConsumer<>(kafkaLocationManager.getKafkaConsumerProperties());
+        return getConsumer(kafkaLocationManager.getKafkaConsumerProperties());
     }
 
     public Consumer<String, String> getConsumer(final String clientId) {

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
@@ -153,8 +153,8 @@ public class KafkaFactory {
         return this.getConsumer(properties);
     }
 
-    public NakadiKafkaConsumer createNakadiConsumer(final String clientId, final String topic, final List<KafkaCursor> kafkaCursors,
-                                                    final long pollTimeout) {
+    public NakadiKafkaConsumer createNakadiConsumer(final String clientId, final String topic,
+                                                    final List<KafkaCursor> kafkaCursors, final long pollTimeout) {
         return new NakadiKafkaConsumer(getConsumer(clientId), topic, kafkaCursors, pollTimeout);
     }
 

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -449,7 +449,7 @@ public class KafkaTopicRepository implements TopicRepository {
     }
 
     @Override
-    public EventConsumer createEventConsumer(final String topic, final List<Cursor> cursors)
+    public EventConsumer createEventConsumer(final String clientId, final String topic, final List<Cursor> cursors)
             throws ServiceUnavailableException, InvalidCursorException {
         this.validateCursors(topic, cursors);
 
@@ -471,7 +471,7 @@ public class KafkaTopicRepository implements TopicRepository {
             kafkaCursors.add(kafkaCursor);
         }
 
-        return kafkaFactory.createNakadiConsumer(topic, kafkaCursors, nakadiSettings.getKafkaPollTimeoutMs());
+        return kafkaFactory.createNakadiConsumer(clientId, topic, kafkaCursors, nakadiSettings.getKafkaPollTimeoutMs());
     }
 
     public int compareOffsets(final String firstOffset, final String secondOffset) {

--- a/src/test/java/org/zalando/nakadi/controller/EventStreamControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventStreamControllerTest.java
@@ -278,7 +278,8 @@ public class EventStreamControllerTest {
     public void whenNormalCaseThenParametersArePassedToConfigAndStreamStarted() throws Exception {
         final EventConsumer eventConsumerMock = mock(EventConsumer.class);
         when(eventTypeRepository.findByName(TEST_EVENT_TYPE_NAME)).thenReturn(EVENT_TYPE);
-        when(topicRepositoryMock.createEventConsumer(eq(KAFKA_CLIENT_ID), eq(TEST_TOPIC), eq(ImmutableList.of(new Cursor("0", "0")))))
+        when(topicRepositoryMock.createEventConsumer(eq(KAFKA_CLIENT_ID), eq(TEST_TOPIC),
+                eq(ImmutableList.of(new Cursor("0", "0")))))
                 .thenReturn(eventConsumerMock);
 
         final ArgumentCaptor<Integer> statusCaptor = getStatusCaptor();
@@ -452,7 +453,8 @@ public class EventStreamControllerTest {
         EVENT_TYPE.setReadScopes(SCOPE_READ);
         final EventConsumer eventConsumerMock = mock(EventConsumer.class);
         when(eventTypeRepository.findByName(TEST_EVENT_TYPE_NAME)).thenReturn(EVENT_TYPE);
-        when(topicRepositoryMock.createEventConsumer(eq(KAFKA_CLIENT_ID), eq(TEST_TOPIC), eq(ImmutableList.of(new Cursor("0", "0")))))
+        when(topicRepositoryMock.createEventConsumer(eq(KAFKA_CLIENT_ID), eq(TEST_TOPIC),
+                eq(ImmutableList.of(new Cursor("0", "0")))))
                 .thenReturn(eventConsumerMock);
     }
 

--- a/src/test/java/org/zalando/nakadi/controller/EventStreamControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventStreamControllerTest.java
@@ -33,12 +33,12 @@ import org.zalando.nakadi.security.Client;
 import org.zalando.nakadi.security.ClientResolver;
 import org.zalando.nakadi.security.FullAccessClient;
 import org.zalando.nakadi.security.NakadiClient;
+import org.zalando.nakadi.service.BlacklistService;
 import org.zalando.nakadi.service.ClosedConnectionsCrutch;
 import org.zalando.nakadi.service.ConsumerLimitingService;
 import org.zalando.nakadi.service.EventStream;
 import org.zalando.nakadi.service.EventStreamConfig;
 import org.zalando.nakadi.service.EventStreamFactory;
-import org.zalando.nakadi.service.BlacklistService;
 import org.zalando.nakadi.util.FeatureToggleService;
 import org.zalando.nakadi.utils.JsonTestHelper;
 import org.zalando.nakadi.utils.TestUtils;
@@ -85,8 +85,9 @@ public class EventStreamControllerTest {
     private static final String TEST_TOPIC = "test-topic";
     private static final EventType EVENT_TYPE = TestUtils.buildDefaultEventType();
     private static final Set<String> SCOPE_READ = Collections.singleton("oauth2.scope.read");
-    private static final Client FULL_ACCESS_CLIENT = new FullAccessClient("clientId");
     private static final String CLIENT_ID = "clientId";
+    private static final Client FULL_ACCESS_CLIENT = new FullAccessClient(CLIENT_ID);
+    private static final String KAFKA_CLIENT_ID = CLIENT_ID + "-" + TEST_EVENT_TYPE_NAME;
 
     private HttpServletRequest requestMock;
     private HttpServletResponse responseMock;
@@ -238,7 +239,7 @@ public class EventStreamControllerTest {
     public void whenInvalidCursorsThenPreconditionFailed() throws Exception {
         final Cursor cursor = new Cursor("0", "0");
         when(eventTypeRepository.findByName(TEST_EVENT_TYPE_NAME)).thenReturn(EVENT_TYPE);
-        when(topicRepositoryMock.createEventConsumer(eq(TEST_TOPIC), eq(ImmutableList.of(cursor))))
+        when(topicRepositoryMock.createEventConsumer(eq(KAFKA_CLIENT_ID), eq(TEST_TOPIC), eq(ImmutableList.of(cursor))))
                 .thenThrow(new InvalidCursorException(CursorError.UNAVAILABLE, cursor));
 
         final StreamingResponseBody responseBody = createStreamingResponseBody(0, 0, 0, 0, 0,
@@ -277,7 +278,7 @@ public class EventStreamControllerTest {
     public void whenNormalCaseThenParametersArePassedToConfigAndStreamStarted() throws Exception {
         final EventConsumer eventConsumerMock = mock(EventConsumer.class);
         when(eventTypeRepository.findByName(TEST_EVENT_TYPE_NAME)).thenReturn(EVENT_TYPE);
-        when(topicRepositoryMock.createEventConsumer(eq(TEST_TOPIC), eq(ImmutableList.of(new Cursor("0", "0")))))
+        when(topicRepositoryMock.createEventConsumer(eq(KAFKA_CLIENT_ID), eq(TEST_TOPIC), eq(ImmutableList.of(new Cursor("0", "0")))))
                 .thenReturn(eventConsumerMock);
 
         final ArgumentCaptor<Integer> statusCaptor = getStatusCaptor();
@@ -311,7 +312,7 @@ public class EventStreamControllerTest {
         assertThat(statusCaptor.getValue(), equalTo(HttpStatus.OK.value()));
         assertThat(contentTypeCaptor.getValue(), equalTo("application/x-json-stream"));
         
-        verify(topicRepositoryMock, times(1)).createEventConsumer(eq(TEST_TOPIC),
+        verify(topicRepositoryMock, times(1)).createEventConsumer(eq(KAFKA_CLIENT_ID), eq(TEST_TOPIC),
                 eq(ImmutableList.of(new Cursor("0", "0"))));
         verify(eventStreamFactoryMock, times(1)).createEventStream(eq(eventConsumerMock), eq(outputStream),
                 eq(streamConfig), any());
@@ -451,7 +452,7 @@ public class EventStreamControllerTest {
         EVENT_TYPE.setReadScopes(SCOPE_READ);
         final EventConsumer eventConsumerMock = mock(EventConsumer.class);
         when(eventTypeRepository.findByName(TEST_EVENT_TYPE_NAME)).thenReturn(EVENT_TYPE);
-        when(topicRepositoryMock.createEventConsumer(eq(TEST_TOPIC), eq(ImmutableList.of(new Cursor("0", "0")))))
+        when(topicRepositoryMock.createEventConsumer(eq(KAFKA_CLIENT_ID), eq(TEST_TOPIC), eq(ImmutableList.of(new Cursor("0", "0")))))
                 .thenReturn(eventConsumerMock);
     }
 

--- a/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -65,7 +65,7 @@ public class KafkaTopicRepositoryTest {
     private final NakadiSettings nakadiSettings = mock(NakadiSettings.class);
     private final KafkaSettings kafkaSettings = mock(KafkaSettings.class);
     private final ZookeeperSettings zookeeperSettings = mock(ZookeeperSettings.class);
-    private final String KAFKA_CLIENT_ID = "application_name-topic_name";
+    private static final String KAFKA_CLIENT_ID = "application_name-topic_name";
 
     @SuppressWarnings("unchecked")
     public static final ProducerRecord EXPECTED_PRODUCER_RECORD = new ProducerRecord(MY_TOPIC, 0, "0", "payload");


### PR DESCRIPTION
In order to use Kafka quota on a fine grained level, we are going to
identify consumers using a combination of application name and event
type name. This will guarantee that an application can stream up to the
default quota from a single partition, since Kafka quotas are
implemented per client-id per broker.