### PR TITLE
aruha-592 collect metrics for all requests individually

### DIFF
--- a/src/main/java/org/zalando/nakadi/config/MetricsConfig.java
+++ b/src/main/java/org/zalando/nakadi/config/MetricsConfig.java
@@ -1,0 +1,67 @@
+package org.zalando.nakadi.config;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jvm.BufferPoolMetricSet;
+import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
+import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
+import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
+import com.codahale.metrics.servlets.MetricsServlet;
+import com.ryantenney.metrics.spring.config.annotation.EnableMetrics;
+import com.ryantenney.metrics.spring.config.annotation.MetricsConfigurerAdapter;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.embedded.ServletRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.lang.management.ManagementFactory;
+
+@Configuration
+@EnableMetrics
+public class MetricsConfig {
+    @Bean
+    public ServletRegistrationBean servletRegistrationBean(final MetricRegistry metricRegistry) {
+        return new ServletRegistrationBean(new MetricsServlet(metricRegistry), "/metrics/*");
+    }
+
+    class SubscriptionMetricsServlet extends MetricsServlet {
+        public SubscriptionMetricsServlet(final MetricRegistry metricRegistry) {
+            super(metricRegistry);
+        }
+    }
+
+    @Bean
+    public ServletRegistrationBean subscriptionsServletRegistrationBean(
+            @Qualifier("perPathMetricRegistry") final MetricRegistry metricRegistry) {
+        return new ServletRegistrationBean(new SubscriptionMetricsServlet(metricRegistry), "/request-metrics/*");
+    }
+
+    @Bean
+    public MetricsConfigurerAdapter metricsConfigurerAdapter(final MetricRegistry metricRegistry) {
+        return new MetricsConfigurerAdapter() {
+            @Override
+            public MetricRegistry getMetricRegistry() {
+                return metricRegistry;
+            }
+        };
+    }
+
+    @Bean
+    @Qualifier("perPathMetricRegistry")
+    public MetricRegistry perPathMetricRegistry() {
+        final MetricRegistry metricRegistry = new MetricRegistry();
+
+        return metricRegistry;
+    }
+
+    @Bean
+    public MetricRegistry metricRegistry() {
+        final MetricRegistry metricRegistry = new MetricRegistry();
+
+        metricRegistry.register("jvm.gc", new GarbageCollectorMetricSet());
+        metricRegistry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
+        metricRegistry.register("jvm.memory", new MemoryUsageGaugeSet());
+        metricRegistry.register("jvm.threads", new ThreadStatesGaugeSet());
+
+        return metricRegistry;
+    }
+}

--- a/src/main/java/org/zalando/nakadi/config/NakadiConfig.java
+++ b/src/main/java/org/zalando/nakadi/config/NakadiConfig.java
@@ -1,18 +1,9 @@
 package org.zalando.nakadi.config;
 
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.jvm.BufferPoolMetricSet;
-import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
-import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
-import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
-import com.codahale.metrics.servlets.MetricsServlet;
-import com.ryantenney.metrics.spring.config.annotation.EnableMetrics;
-import com.ryantenney.metrics.spring.config.annotation.MetricsConfigurerAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.embedded.ServletRegistrationBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,10 +18,7 @@ import org.zalando.nakadi.repository.zookeeper.ZooKeeperHolder;
 import org.zalando.nakadi.repository.zookeeper.ZooKeeperLockFactory;
 import org.zalando.nakadi.service.subscription.zk.ZkSubscriptionClientFactory;
 
-import java.lang.management.ManagementFactory;
-
 @Configuration
-@EnableMetrics
 @EnableScheduling
 public class NakadiConfig {
 
@@ -42,21 +30,6 @@ public class NakadiConfig {
     }
 
     @Bean
-    public ServletRegistrationBean servletRegistrationBean(final MetricRegistry metricRegistry) {
-        return new ServletRegistrationBean(new MetricsServlet(metricRegistry), "/metrics/*");
-    }
-
-    @Bean
-    public MetricsConfigurerAdapter metricsConfigurerAdapter(final MetricRegistry metricRegistry) {
-        return new MetricsConfigurerAdapter() {
-            @Override
-            public MetricRegistry getMetricRegistry() {
-                return metricRegistry;
-            }
-        };
-    }
-
-    @Bean
     public ZooKeeperLockFactory zooKeeperLockFactory(final ZooKeeperHolder zooKeeperHolder) {
         return new ZooKeeperLockFactory(zooKeeperHolder);
     }
@@ -64,18 +37,6 @@ public class NakadiConfig {
     @Bean
     public ZkSubscriptionClientFactory zkSubscriptionClientFactory(final ZooKeeperHolder zooKeeperHolder) {
         return new ZkSubscriptionClientFactory(zooKeeperHolder);
-    }
-
-    @Bean
-    public MetricRegistry metricRegistry() {
-        final MetricRegistry metricRegistry = new MetricRegistry();
-
-        metricRegistry.register("jvm.gc", new GarbageCollectorMetricSet());
-        metricRegistry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
-        metricRegistry.register("jvm.memory", new MemoryUsageGaugeSet());
-        metricRegistry.register("jvm.threads", new ThreadStatesGaugeSet());
-
-        return metricRegistry;
     }
 
     @Bean

--- a/src/main/java/org/zalando/nakadi/config/WebConfig.java
+++ b/src/main/java/org/zalando/nakadi/config/WebConfig.java
@@ -2,11 +2,8 @@ package org.zalando.nakadi.config;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.zalando.nakadi.metrics.MonitoringRequestFilter;
-import org.zalando.nakadi.security.ClientResolver;
-import org.zalando.nakadi.util.FlowIdRequestFilter;
-import org.zalando.nakadi.util.GzipBodyRequestFilter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.embedded.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -23,6 +20,10 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+import org.zalando.nakadi.metrics.MonitoringRequestFilter;
+import org.zalando.nakadi.security.ClientResolver;
+import org.zalando.nakadi.util.FlowIdRequestFilter;
+import org.zalando.nakadi.util.GzipBodyRequestFilter;
 
 import javax.servlet.Filter;
 import java.util.List;
@@ -62,8 +63,11 @@ public class WebConfig extends WebMvcConfigurationSupport {
     }
 
     @Bean
-    public FilterRegistrationBean monitoringRequestFilter(final MetricRegistry metricRegistry) {
-        return createFilterRegistrationBean(new MonitoringRequestFilter(metricRegistry), Ordered.HIGHEST_PRECEDENCE);
+    public FilterRegistrationBean monitoringRequestFilter(
+            final MetricRegistry metricRegistry,
+            @Qualifier("perPathMetricRegistry") final MetricRegistry perPathMetricRegistry) {
+        return createFilterRegistrationBean(
+                new MonitoringRequestFilter(metricRegistry, perPathMetricRegistry), Ordered.HIGHEST_PRECEDENCE);
     }
 
     @Bean

--- a/src/main/java/org/zalando/nakadi/metrics/MonitoringRequestFilter.java
+++ b/src/main/java/org/zalando/nakadi/metrics/MonitoringRequestFilter.java
@@ -10,17 +10,22 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 
 public class MonitoringRequestFilter implements Filter {
 
     private final Timer httpConnectionsTimer;
     private final Counter openHttpConnectionsCounter;
+    private final MetricRegistry perPathMetricRegistry;
 
-    public MonitoringRequestFilter(final MetricRegistry metricRegistry) {
-        openHttpConnectionsCounter = metricRegistry.counter(MetricUtils.NAKADI_PREFIX
+    public MonitoringRequestFilter(final MetricRegistry overallMetricRegistry,
+                                   final MetricRegistry perPathMetricRegistry) {
+        openHttpConnectionsCounter = overallMetricRegistry.counter(MetricUtils.NAKADI_PREFIX
                 + "general.openSynchronousHttpConnections");
-        httpConnectionsTimer = metricRegistry.timer(MetricUtils.NAKADI_PREFIX + "general.synchronousHttpConnections");
+        httpConnectionsTimer = overallMetricRegistry
+                .timer(MetricUtils.NAKADI_PREFIX + "general.synchronousHttpConnections");
+        this.perPathMetricRegistry = perPathMetricRegistry;
     }
 
     @Override
@@ -34,11 +39,21 @@ public class MonitoringRequestFilter implements Filter {
         openHttpConnectionsCounter.inc();
         final Timer.Context timerContext = httpConnectionsTimer.time();
 
+        Timer.Context perPathTimerContext = null;
+        if (request instanceof HttpServletRequest) {
+            final HttpServletRequest httpRequest = (HttpServletRequest) request;
+            final String perPathMetricKey = httpRequest.getMethod() + httpRequest.getServletPath();
+            perPathTimerContext = perPathMetricRegistry.timer(perPathMetricKey).time();
+        }
+
         try {
 
             chain.doFilter(request, response);
 
         } finally {
+            if (perPathTimerContext != null) {
+                perPathTimerContext.stop();
+            }
             timerContext.stop();
             openHttpConnectionsCounter.dec();
         }


### PR DESCRIPTION
This PR is part of the task https://techjira.zalando.net/browse/ARUHA-592

Here I'll collect metrics for all requests. So to have timers for every path, like:

- `GET/subscriptions/a7671c51-49d1-48e6-bb03-b50dcf14f3d3/events`
- `POST/subscriptions/a7671c51-49d1-48e6-bb03-b50dcf14f3d3/cursors`
- `GET/event-types/my-event-type/partitions`

After that, I'll build a dashboard called `Nakadi Police` where I'll rank these entries per rate usage per functionality.

This way we will be able to find very quickly which subscription is committing so much, which event type partitions is called like crazy, which event type is slow to publish, which subscription is slow to commit.

I thought about appending/prepending the name of the application to the metric. So we could very fast also spot who is abusing the service or is been impacted by degraded service quality. Wdyt? Something like:

- `application-name.GET/event-types/my-event-type/events`