### PR TITLE
Reduce allocations writing batch events for subscription consumers. 

### DIFF
--- a/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -26,6 +26,7 @@ import org.zalando.nakadi.service.subscription.state.StartingState;
 import org.zalando.nakadi.service.subscription.state.State;
 import org.zalando.nakadi.service.subscription.zk.ZKSubscription;
 import org.zalando.nakadi.service.subscription.zk.ZkSubscriptionClient;
+import org.zalando.nakadi.util.FeatureToggleService;
 
 public class StreamingContext implements SubscriptionStreamer {
 
@@ -49,6 +50,7 @@ public class StreamingContext implements SubscriptionStreamer {
     private final CursorConverter cursorConverter;
     private final String subscriptionId;
     private final MetricRegistry metricRegistry;
+    private final FeatureToggleService featureToggleService;
     private State currentState = new DummyState();
     private ZKSubscription clientListChanges;
 
@@ -73,6 +75,7 @@ public class StreamingContext implements SubscriptionStreamer {
         this.cursorConverter = builder.cursorConverter;
         this.subscriptionId = builder.subscriptionId;
         this.metricRegistry = builder.metricRegistry;
+        this.featureToggleService = builder.featureToggleService;
     }
 
     public StreamParameters getParameters() {
@@ -109,6 +112,10 @@ public class StreamingContext implements SubscriptionStreamer {
 
     public MetricRegistry getMetricRegistry() {
         return  metricRegistry;
+    }
+
+    public FeatureToggleService getFeatureToggleService() {
+        return featureToggleService;
     }
 
     @Override
@@ -241,6 +248,7 @@ public class StreamingContext implements SubscriptionStreamer {
         private CursorConverter cursorConverter;
         private String subscriptionId;
         private MetricRegistry metricRegistry;
+        private FeatureToggleService featureToggleService;
 
         public Builder setOut(final SubscriptionOutput out) {
             this.out = out;
@@ -324,6 +332,11 @@ public class StreamingContext implements SubscriptionStreamer {
 
         public Builder setMetricRegistry(final MetricRegistry metricRegistry) {
             this.metricRegistry = metricRegistry;
+            return this;
+        }
+
+        public Builder setFeatureToggleService(FeatureToggleService featureToggleService) {
+            this.featureToggleService = featureToggleService;
             return this;
         }
 

--- a/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -335,7 +335,7 @@ public class StreamingContext implements SubscriptionStreamer {
             return this;
         }
 
-        public Builder setFeatureToggleService(FeatureToggleService featureToggleService) {
+        public Builder setFeatureToggleService(final FeatureToggleService featureToggleService) {
             this.featureToggleService = featureToggleService;
             return this;
         }

--- a/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionStreamerFactory.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionStreamerFactory.java
@@ -27,6 +27,7 @@ import org.zalando.nakadi.service.CursorTokenService;
 import org.zalando.nakadi.service.subscription.model.Session;
 import org.zalando.nakadi.service.subscription.zk.CuratorZkSubscriptionClient;
 import org.zalando.nakadi.service.timeline.TimelineService;
+import org.zalando.nakadi.util.FeatureToggleService;
 
 @Service
 public class SubscriptionStreamerFactory {
@@ -41,6 +42,7 @@ public class SubscriptionStreamerFactory {
     private final ObjectMapper objectMapper;
     private final CursorConverter cursorConverter;
     private final MetricRegistry metricRegistry;
+    private final FeatureToggleService featureToggleService;
 
     @Autowired
     public SubscriptionStreamerFactory(
@@ -51,7 +53,8 @@ public class SubscriptionStreamerFactory {
             final CursorTokenService cursorTokenService,
             final ObjectMapper objectMapper,
             final CursorConverter cursorConverter,
-            @Qualifier("streamMetricsRegistry") final MetricRegistry metricRegistry) {
+            @Qualifier("streamMetricsRegistry") final MetricRegistry metricRegistry,
+            final FeatureToggleService featureToggleService) {
         this.zkHolder = zkHolder;
         this.subscriptionDbRepository = subscriptionDbRepository;
         this.timelineService = timelineService;
@@ -60,6 +63,7 @@ public class SubscriptionStreamerFactory {
         this.objectMapper = objectMapper;
         this.cursorConverter = cursorConverter;
         this.metricRegistry = metricRegistry;
+        this.featureToggleService = featureToggleService;
     }
 
     public SubscriptionStreamer build(
@@ -93,6 +97,7 @@ public class SubscriptionStreamerFactory {
                 .setCursorConverter(cursorConverter)
                 .setSubscriptionId(subscriptionId)
                 .setMetricRegistry(metricRegistry)
+                .setFeatureToggleService(featureToggleService)
                 .build();
     }
 

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -218,13 +218,13 @@ class StreamingState extends State {
             try {
 
                 final ObjectMapper mapper = getContext().getObjectMapper();
-                final String eventType = getContext().getEventTypesForTopics().get(pk.getTopic());
                 final String token = getContext().getCursorTokenService().generateToken();
+                final Timeline timeline = getContext().getTimelinesForTopics().get(pk.getTopic());
                 final SubscriptionCursor cursor = getContext()
                     .getCursorConverter()
                     .convert(
                         pk.createKafkaCursor(offsets.get(pk).getSentOffset())
-                            .toNakadiCursor(), eventType, token
+                            .toNakadiCursor(timeline), token
                     );
 
                 writeStreamBatch(data, metadata, cursor, getOut(), mapper, bytesSentMeter);

--- a/src/main/java/org/zalando/nakadi/util/FeatureToggleService.java
+++ b/src/main/java/org/zalando/nakadi/util/FeatureToggleService.java
@@ -29,7 +29,8 @@ public interface FeatureToggleService {
         CHECK_APPLICATION_LEVEL_PERMISSIONS("check_application_level_permissions"),
         CHECK_PARTITIONS_KEYS("check_partitions_keys"),
         CHECK_OWNING_APPLICATION("check_owning_application"),
-        LIMIT_CONSUMERS_NUMBER("limit_consumers_number");
+        LIMIT_CONSUMERS_NUMBER("limit_consumers_number"),
+        SEND_SUBSCRIPTION_BATCH_VIA_OUTPUT_STREAM("send_subscription_batch_via_output_stream");
 
         private final String id;
 

--- a/src/test/java/org/zalando/nakadi/service/subscription/state/StreamingStateTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/state/StreamingStateTest.java
@@ -26,9 +26,11 @@ import org.zalando.nakadi.service.subscription.zk.ZKSubscription;
 import org.zalando.nakadi.service.subscription.zk.ZkSubscriptionClient;
 import org.zalando.nakadi.view.SubscriptionCursor;
 
+import static junit.framework.TestCase.assertSame;
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -45,7 +47,7 @@ public class StreamingStateTest {
     private static final String SESSION_ID = "ssid";
     private MetricRegistry metricRegistry;
 
-    final ObjectMapper mapper = new JsonConfig().jacksonObjectMapper();
+    private final ObjectMapper mapper = new JsonConfig().jacksonObjectMapper();
 
     @Before
     public void prepareMocks() {
@@ -141,13 +143,15 @@ public class StreamingStateTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final Meter meter = mock(Meter.class);
         final SubscriptionOutput so = new SubscriptionOutput() {
-            @Override public void onInitialized(String sessionId) throws IOException { }
+            @Override public void onInitialized(final String sessionId) throws IOException {
+                // Not used in test
+            }
 
-            @Override public void onException(Exception ex) {
+            @Override public void onException(final Exception ex) {
                 fail(ex.getMessage());
             }
 
-            @Override public void streamData(byte[] data) throws IOException {
+            @Override public void streamData(final byte[] data) throws IOException {
                 baos.write(data);
                 baos.flush();
             }
@@ -179,7 +183,7 @@ public class StreamingStateTest {
 
             // there's only one newline and it's at the end
             final int newlineCount = (json).replaceAll("[^\n]", "").length();
-            assertTrue(newlineCount == 1);
+            assertSame(newlineCount, 1);
             assertTrue(json.endsWith("\n"));
 
             final Map<String, Object> batchM =
@@ -193,7 +197,7 @@ public class StreamingStateTest {
             assertEquals(cursorToken, cursorM.get("cursor_token"));
 
             final List<Map<String, String>> eventsM = (List<Map<String, String>>) batchM.get("events");
-            assertTrue(eventsM.size() == 3);
+            assertSame(eventsM.size(), 3);
 
             // check the order is preserved as well as the data via get
             assertEquals("b", eventsM.get(0).get("a"));
@@ -214,13 +218,15 @@ public class StreamingStateTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final Meter meter = mock(Meter.class);
         final SubscriptionOutput so = new SubscriptionOutput() {
-            @Override public void onInitialized(String sessionId) throws IOException { }
+            @Override public void onInitialized(final String sessionId) throws IOException {
+                // Not used in test
+            }
 
-            @Override public void onException(Exception ex) {
+            @Override public void onException(final Exception ex) {
                 fail(ex.getMessage());
             }
 
-            @Override public void streamData(byte[] data) throws IOException {
+            @Override public void streamData(final byte[] data) throws IOException {
                 baos.write(data);
                 baos.flush();
             }
@@ -248,7 +254,7 @@ public class StreamingStateTest {
 
             // there's only one newline and it's at the end
             final int newlineCount = (json).replaceAll("[^\n]", "").length();
-            assertTrue(newlineCount == 1);
+            assertSame(newlineCount, 1);
             assertTrue(json.endsWith("\n"));
 
             final Map<String, Object> batchM =
@@ -264,7 +270,7 @@ public class StreamingStateTest {
             final List<Map<String, String>> eventsM = (List<Map<String, String>>) batchM.get("events");
             // did not write an empty batch
             assertFalse(json.contains("\"events\""));
-            assertTrue(eventsM == null);
+            assertNull(eventsM );
 
             verify(meter, times(1)).mark(anyInt());
 


### PR DESCRIPTION
**do not merge: needs to be rebased against #589 when that merges** 

Write batch subscription events directly to the output stream.

If `SEND_SUBSCRIPTION_BATCH_VIA_OUTPUT_STREAM` is enabled, send the batch and its events directly to the `SubscriptionOutput`'s underlying OutputStream as bytes instead of building up an intermediate batch String via `serializeBatch`. The standard parts of the batch are allocated statically as bytes instead of per call. This is done to reduce the number of allocations generated for a batch and is based on some performance tuning investigations.

Each call to `SubscriptionOutput.streamData` in the production path calls flush on its underlying OutputStream. This might be a problem and if it is, `SubscriptionOutput` will probably have to allow StreamState to access to its OutputStream.