### PR TITLE
ARUHA-541 consumer lag monitoring endpoint

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -632,7 +632,7 @@ paths:
             The flow id of the request, which is written into the logs and passed to called services. Helpful
             for operational troubleshooting and log analysis.
           type: string
-        - name: offset
+        - name: consumed_offset
           in: parameter
           description: |
             Offset to query for unconsumed events. Depends on `partition` parameter. When present adds the property

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -574,6 +574,25 @@ paths:
             The flow id of the request, which is written into the logs and passed to called services. Helpful
             for operational troubleshooting and log analysis.
           type: string
+        - name: X-nakadi-cursors
+          in: header
+          description: |
+            Cursors indicating the partitions and offsets consumed by the client.
+
+            When this header is provided, Nakadi calculates the consumer lag, e.g. the number of events between the
+            provided offset and the most recent published event.
+
+            In this situation, the response will contain the `unconsumed_events` property for every partition.
+
+            The lag calculation is non inclusive, e.g. if the provided offset is the offset of the latest published
+            event, the number of `unconsumed_events` will be zero.
+
+            If this header is not present, partitions won't display `unconsumed_events`.
+          required: false
+          type: array
+          items:
+            type: string
+            format: '#/definitions/Cursor'
       responses:
         '200':
           description: OK
@@ -613,6 +632,15 @@ paths:
             The flow id of the request, which is written into the logs and passed to called services. Helpful
             for operational troubleshooting and log analysis.
           type: string
+        - name: partition
+          in: parameter
+          description: |
+            Partition to query for unconsumed events. Depends on `offset` parameter.
+        - name: offset
+          in: parameter
+          description: |
+            Offset to query for unconsumed events. Depends on `partition` parameter. When present adds the property
+            `unconsumed_events` to the response partition object.
       responses:
         '200':
           description: OK
@@ -1626,6 +1654,11 @@ definitions:
           Might assume the special name BEGIN, meaning a pointer to the offset of the oldest
           available event in the partition.
         type: string
+      unconsumed_events:
+        description: |
+          Number of events unconsumed by the client. This is also known as consumer lag and is used for monitoring
+          purposes by consumers interested in keeping an eye on the number of unconsumed events.
+        type: number
 
   StreamInfo:
     type: object

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -548,6 +548,64 @@ paths:
           description: |
             Schema object.
 
+  '/event-types/{name}/cursors-lag':
+    post:
+      tags:
+        - unmanaged-api
+        - monitoring
+        - management-api
+      security:
+        - oauth2: ['nakadi.event_stream.read']
+      description: |
+        This endpoint is mostly interesting for monitoring purposes. Used when a consumer wants to know how far behing
+        in the stream its application is lagging.
+
+        It provides the number of unconsummed events for each cursor's partition.
+      parameters:
+        - name: name
+          in: path
+          description: EventType name
+          type: string
+          required: true
+        - name: X-Flow-Id
+          in: header
+          description: |
+            The flow id of the request, which is written into the logs and passed to called services. Helpful
+            for operational troubleshooting and log analysis.
+          type: string
+        - name: cursors
+          in: body
+          description: |
+            Each cursor indicates the partition and offset consumed by the client. When a cursor is provided,
+            Nakadi calculates the consumer lag, e.g. the number of events between the provided offset and the most
+            recent published event. This lag will be present in the response as `unconsumed_events` property.
+
+            It's not mandatory to specify cursors for every partition.
+
+            The lag calculation is non inclusive, e.g. if the provided offset is the offset of the latest published
+            event, the number of `unconsumed_events` will be zero.
+
+            All provided cursors must be valid, i.e. a non expired cursor of an event in the stream.
+          required: true
+          schema:
+            type: array
+            items:
+              - $ref: '#/definitions/Cursor'
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: array
+            description: |
+              List of partitions with the number of unconsummed events.
+            items:
+              $ref: '#/definitions/Partition'
+        '401':
+          description: Client is not authenticated
+          schema:
+            $ref: '#/definitions/Problem'
+
+
   '/event-types/{name}/partitions':
     get:
       tags:
@@ -1654,6 +1712,7 @@ definitions:
           Approximate number of events unconsumed by the client. This is also known as consumer lag and is used for
           monitoring purposes by consumers interested in keeping an eye on the number of unconsumed events.
         type: number
+        format: int64
 
   StreamInfo:
     type: object

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1651,8 +1651,8 @@ definitions:
         type: string
       unconsumed_events:
         description: |
-          Number of events unconsumed by the client. This is also known as consumer lag and is used for monitoring
-          purposes by consumers interested in keeping an eye on the number of unconsumed events.
+          Approximate number of events unconsumed by the client. This is also known as consumer lag and is used for
+          monitoring purposes by consumers interested in keeping an eye on the number of unconsumed events.
         type: number
 
   StreamInfo:

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -632,7 +632,7 @@ paths:
             for operational troubleshooting and log analysis.
           type: string
         - name: consumed_offset
-          in: parameter
+          in: query
           description: |
             Offset to query for unconsumed events. Depends on `partition` parameter. When present adds the property
             `unconsumed_events` to the response partition object.

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -632,10 +632,6 @@ paths:
             The flow id of the request, which is written into the logs and passed to called services. Helpful
             for operational troubleshooting and log analysis.
           type: string
-        - name: partition
-          in: parameter
-          description: |
-            Partition to query for unconsumed events. Depends on `offset` parameter.
         - name: offset
           in: parameter
           description: |

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -557,10 +557,12 @@ paths:
       security:
         - oauth2: ['nakadi.event_stream.read']
       description: |
-        This endpoint is mostly interesting for monitoring purposes. Used when a consumer wants to know how far behing
+        GET with payload.
+
+        This endpoint is mostly interesting for monitoring purposes. Used when a consumer wants to know how far behind
         in the stream its application is lagging.
 
-        It provides the number of unconsummed events for each cursor's partition.
+        It provides the number of unconsumed events for each cursor's partition.
       parameters:
         - name: name
           in: path

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -574,20 +574,19 @@ paths:
             The flow id of the request, which is written into the logs and passed to called services. Helpful
             for operational troubleshooting and log analysis.
           type: string
-        - name: X-nakadi-cursors
-          in: header
+        - name: cursors
+          in: query
           description: |
-            Cursors indicating the partitions and offsets consumed by the client.
+            Each cursor indicates the partition and offset consumed by the client. When this parameter is provided,
+            Nakadi calculates the consumer lag, e.g. the number of events between the provided offset and the most
+            recent published event. This lag will be present in the response as `unconsumed_events` property.
 
-            When this header is provided, Nakadi calculates the consumer lag, e.g. the number of events between the
-            provided offset and the most recent published event.
-
-            In this situation, the response will contain the `unconsumed_events` property for every partition.
+            It's not mandatory to specify cursors for every partition.
 
             The lag calculation is non inclusive, e.g. if the provided offset is the offset of the latest published
             event, the number of `unconsumed_events` will be zero.
 
-            If this header is not present, partitions won't display `unconsumed_events`.
+            The value of this parameter must be a json array URL encoded.
           required: false
           type: array
           items:


### PR DESCRIPTION
Ticket link https://techjira.zalando.net/browse/ARUHA-531

Previous to Timelines, cursor's offsets used to be sequential Long
numbers as Strings, for example "00000123". Because of that, several
consumers used to convert such strings back into numbers, our example
above would be converted to 123, and later use them as numbers for
several purposes.

One of the things consumers used to do was to query for `/partitions`
endpoint to get the newest available offset and then calculate the
distance between the newest and the latest consumed offset. This is how
many consumers from low level API would detect lag in consumer.

After introducing timelines, it will be no longer possible to easily
convert an offset to a number and perform such operations on the client
side. For that reason, we are introducing an extension to the
`/partitions` endpoint that will allow consumers to get the number of
unconsumed events without the need to perform any conversions or
calculations on their side.