### PR TITLE
aruha-695 publishing metrics

### DIFF
--- a/src/main/java/org/zalando/nakadi/metrics/MetricUtils.java
+++ b/src/main/java/org/zalando/nakadi/metrics/MetricUtils.java
@@ -10,6 +10,8 @@ public class MetricUtils {
     private static final String LOW_LEVEL_STREAM = "lola";
     private static final String HIGH_LEVEL_STREAM = "hila";
     private static final String BYTES_FLUSHED = "bytes-flushed";
+    private static final String BYTES_SENT = "bytes-sent";
+    private static final String PUBLISHING = "publishing";
 
     public static String metricNameFor(final String eventTypeName, final String metricName) {
         return MetricRegistry.name(EVENTTYPES_PREFIX, eventTypeName.replace('.', '#'), metricName);
@@ -17,6 +19,14 @@ public class MetricUtils {
 
     public static String metricNameForSubscription(final String subscriptionId, final String metricName) {
         return MetricRegistry.name(SUBSCRIPTION_PREFIX, subscriptionId, metricName);
+    }
+
+    public static String metricNameForBytesSent(final String applicationId, final String eventTypeName) {
+        return MetricRegistry.name(
+                PUBLISHING,
+                applicationId.replace(".", "#"),
+                eventTypeName.replace(".", "#"),
+                BYTES_SENT);
     }
 
     public static String metricNameForLoLAStream(final String applicationId, final String eventTypeName) {

--- a/src/main/java/org/zalando/nakadi/repository/TopicRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/TopicRepository.java
@@ -1,5 +1,6 @@
 package org.zalando.nakadi.repository;
 
+import com.codahale.metrics.Meter;
 import org.zalando.nakadi.domain.BatchItem;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.NakadiCursor;
@@ -25,7 +26,7 @@ public interface TopicRepository {
 
     boolean topicExists(String topic) throws NakadiException;
 
-    void syncPostBatch(String topicId, List<BatchItem> batch) throws EventPublishingException;
+    void syncPostBatch(String topicId, List<BatchItem> batch, final Meter meter) throws EventPublishingException;
 
     Optional<PartitionStatistics> loadPartitionStatistics(String topic, String partition)
             throws ServiceUnavailableException;

--- a/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -1,5 +1,7 @@
 package org.zalando.nakadi.repository.kafka;
 
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.curator.framework.CuratorFramework;
@@ -65,6 +67,7 @@ public class KafkaTopicRepositoryTest {
     private final KafkaSettings kafkaSettings = mock(KafkaSettings.class);
     private final ZookeeperSettings zookeeperSettings = mock(ZookeeperSettings.class);
     private static final String KAFKA_CLIENT_ID = "application_name-topic_name";
+    private static final Meter METER = new MetricRegistry().meter("some-meter");
 
     @SuppressWarnings("unchecked")
     public static final ProducerRecord EXPECTED_PRODUCER_RECORD = new ProducerRecord(MY_TOPIC, 0, "0", "payload");
@@ -198,7 +201,7 @@ public class KafkaTopicRepositoryTest {
                 .send(any(), any());
 
         try {
-            kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(), batch);
+            kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(), batch, METER);
             fail();
         } catch (final EventPublishingException e) {
             assertThat(item.getResponse().getPublishingStatus(), equalTo(EventPublishingStatus.FAILED));
@@ -222,7 +225,7 @@ public class KafkaTopicRepositoryTest {
                 .send(any(), any());
 
         try {
-            kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(), batch);
+            kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(), batch, METER);
             fail();
         } catch (final EventPublishingException e) {
             assertThat(item.getResponse().getPublishingStatus(), equalTo(EventPublishingStatus.FAILED));
@@ -255,7 +258,7 @@ public class KafkaTopicRepositoryTest {
         });
 
         try {
-            kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(), batch);
+            kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(), batch, METER);
             fail();
         } catch (final EventPublishingException e) {
             assertThat(firstItem.getResponse().getPublishingStatus(), equalTo(EventPublishingStatus.SUBMITTED));
@@ -371,7 +374,8 @@ public class KafkaTopicRepositoryTest {
                 final BatchItem batchItem = new BatchItem("{}");
                 batchItem.setPartition("1");
                 batches.add(batchItem);
-                kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(), ImmutableList.of(batchItem));
+                kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(), ImmutableList.of(batchItem),
+                        METER);
                 fail();
             } catch (final EventPublishingException e) {
             }


### PR DESCRIPTION
This PR exposes bytes sent per application per event type.

The name of the metric is "publishing.application-name.event-type-name.bytes-sent" and it's a meter.

It can be found in the `/stream-metrics`. These metrics are been introduced for administration purposes at first, but later we are going to document them so that users can also rely on them.

Previous to this PR, the only way to monitor publishing was by topic,
which is Kafka internal information, which we don't want to expose to
users.

This way users can monitor based on Nakadi only.