### PR TITLE
Consume payload as byte[] instead of java.lang.String to reduce GC overhead and to improve performance

### DIFF
--- a/src/acceptance-test/java/org/zalando/nakadi/repository/db/EventTypeCacheTestAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/repository/db/EventTypeCacheTestAT.java
@@ -28,6 +28,8 @@ import org.zalando.nakadi.domain.Timeline;
 import org.zalando.nakadi.repository.EventTypeRepository;
 import org.zalando.nakadi.repository.zookeeper.ZooKeeperHolder;
 import org.zalando.nakadi.service.timeline.TimelineSync;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.fail;
@@ -83,7 +85,7 @@ public class EventTypeCacheTestAT {
                 .create()
                 .creatingParentsIfNeeded()
                 .withMode(CreateMode.PERSISTENT)
-                .forPath("/nakadi/event_types/" + et.getName(), "some-value".getBytes());
+                .forPath("/nakadi/event_types/" + et.getName(), "some-value".getBytes(UTF_8));
 
         etc.updated(et.getName());
 

--- a/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -172,7 +172,7 @@ public class KafkaRepositoryAT extends BaseAT {
     }
 
     private Map<String, List<PartitionInfo>> getAllTopics() {
-        final KafkaConsumer<String, String> kafkaConsumer = kafkaHelper.createConsumer();
+        final KafkaConsumer<String, byte[]> kafkaConsumer = kafkaHelper.createConsumer();
         return kafkaConsumer.listTopics();
     }
 

--- a/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaTestHelper.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaTestHelper.java
@@ -24,7 +24,7 @@ public class KafkaTestHelper {
         this.kafkaUrl = kafkaUrl;
     }
 
-    public KafkaConsumer<String, String> createConsumer() {
+    public KafkaConsumer<String, byte[]> createConsumer() {
         return new KafkaConsumer<>(createKafkaProperties());
     }
 
@@ -37,7 +37,7 @@ public class KafkaTestHelper {
         props.put("bootstrap.servers", kafkaUrl);
         props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
         props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
-        props.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+        props.put("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
         props.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
         return props;
     }
@@ -76,7 +76,7 @@ public class KafkaTestHelper {
 
     public List<Cursor> getNextOffsets(final String topic) {
 
-        final KafkaConsumer<String, String> consumer = createConsumer();
+        final KafkaConsumer<String, byte[]> consumer = createConsumer();
         final List<TopicPartition> partitions = consumer
                 .partitionsFor(topic)
                 .stream()

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/CompressedEventPublishingAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/CompressedEventPublishingAT.java
@@ -17,6 +17,7 @@ import java.util.zip.GZIPOutputStream;
 
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.http.ContentType.JSON;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.text.MessageFormat.format;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_ENCODING;
 import static javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
@@ -70,7 +71,7 @@ public class CompressedEventPublishingAT extends BaseAT {
     private byte[] compressWithGzip(final String string) throws IOException {
         final ByteArrayOutputStream baOutputStream = new ByteArrayOutputStream(string.length());
         final GZIPOutputStream gzipOutputStream = new GZIPOutputStream(baOutputStream);
-        gzipOutputStream.write(string.getBytes());
+        gzipOutputStream.write(string.getBytes(UTF_8));
         gzipOutputStream.close();
         final byte[] compressed = baOutputStream.toByteArray();
         baOutputStream.close();

--- a/src/main/java/org/zalando/nakadi/controller/SubscriptionStreamController.java
+++ b/src/main/java/org/zalando/nakadi/controller/SubscriptionStreamController.java
@@ -110,10 +110,9 @@ public class SubscriptionStreamController {
         }
 
         @Override
-        public void streamData(final byte[] data) throws IOException {
+        public OutputStream getOutputStream() {
             headersSent = true;
-            out.write(data);
-            out.flush();
+            return out;
         }
     }
 

--- a/src/main/java/org/zalando/nakadi/domain/ConsumedEvent.java
+++ b/src/main/java/org/zalando/nakadi/domain/ConsumedEvent.java
@@ -6,15 +6,15 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public class ConsumedEvent {
 
-    private final String event;
+    private final byte[] event;
     private final NakadiCursor position;
 
-    public ConsumedEvent(final String event, final NakadiCursor position) {
+    public ConsumedEvent(final byte[] event, final NakadiCursor position) {
         this.event = event;
         this.position = position;
     }
 
-    public String getEvent() {
+    public byte[] getEvent() {
         return event;
     }
 

--- a/src/main/java/org/zalando/nakadi/repository/EventConsumer.java
+++ b/src/main/java/org/zalando/nakadi/repository/EventConsumer.java
@@ -10,6 +10,6 @@ public interface EventConsumer extends Closeable {
 
     Optional<ConsumedEvent> readEvent();
 
-    Consumer<String, String> getConsumer();
+    Consumer<String, byte[]> getConsumer();
 
 }

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
@@ -134,15 +134,15 @@ public class KafkaFactory {
         }
     }
 
-    public Consumer<String, String> getConsumer(final Properties properties) {
+    public Consumer<String, byte[]> getConsumer(final Properties properties) {
         return new KafkaConsumer<>(properties);
     }
 
-    public Consumer<String, String> getConsumer() {
+    public Consumer<String, byte[]> getConsumer() {
         return getConsumer(kafkaLocationManager.getKafkaConsumerProperties());
     }
 
-    public Consumer<String, String> getConsumer(final String clientId) {
+    public Consumer<String, byte[]> getConsumer(final String clientId) {
         final Properties properties = kafkaLocationManager.getKafkaConsumerProperties();
         // properties.put("client.id", clientId);
         return this.getConsumer(properties);

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -77,7 +77,7 @@ public class KafkaLocationManager {
     private Properties buildKafkaProperties(final List<Broker> brokers) {
         final Properties props = new Properties();
         props.put("bootstrap.servers", buildBootstrapServers(brokers));
-        props.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+        props.put("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
         props.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
         return props;
     }

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -282,7 +282,7 @@ public class KafkaTopicRepository implements TopicRepository {
     @Override
     public Optional<PartitionStatistics> loadPartitionStatistics(final Timeline timeline, final String partition)
             throws ServiceUnavailableException {
-        try (Consumer<String, String> consumer = kafkaFactory.getConsumer()) {
+        try (Consumer<String, byte[]> consumer = kafkaFactory.getConsumer()) {
             final Optional<PartitionInfo> tp = consumer.partitionsFor(timeline.getTopic()).stream()
                     .filter(p -> KafkaCursor.toNakadiPartition(p.partition()).equals(partition))
                     .findAny();
@@ -306,7 +306,7 @@ public class KafkaTopicRepository implements TopicRepository {
     @Override
     public List<PartitionStatistics> loadTopicStatistics(final Collection<Timeline> timelines)
             throws ServiceUnavailableException {
-        try (Consumer<String, String> consumer = kafkaFactory.getConsumer()) {
+        try (Consumer<String, byte[]> consumer = kafkaFactory.getConsumer()) {
             final Map<TopicPartition, Timeline> backMap = new HashMap<>();
             for (final Timeline timeline : timelines) {
                 consumer.partitionsFor(timeline.getTopic())
@@ -347,7 +347,7 @@ public class KafkaTopicRepository implements TopicRepository {
         }
     }
 
-    public Consumer<String, String> createKafkaConsumer() {
+    public Consumer<String, byte[]> createKafkaConsumer() {
         return kafkaFactory.getConsumer();
     }
 

--- a/src/main/java/org/zalando/nakadi/repository/kafka/NakadiKafkaConsumer.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/NakadiKafkaConsumer.java
@@ -17,12 +17,12 @@ public class NakadiKafkaConsumer implements EventConsumer {
 
     private Queue<ConsumedEvent> eventQueue;
 
-    private final Consumer<String, String> kafkaConsumer;
+    private final Consumer<String, byte[]> kafkaConsumer;
     private final long pollTimeout;
     private final Timeline timeline;
 
     public NakadiKafkaConsumer(
-            final Consumer<String, String> kafkaConsumer,
+            final Consumer<String, byte[]> kafkaConsumer,
             final List<KafkaCursor> kafkaCursors,
             final long pollTimeout,
             final Timeline timeline) {
@@ -59,7 +59,7 @@ public class NakadiKafkaConsumer implements EventConsumer {
     }
 
     @Override
-    public Consumer<String, String> getConsumer() {
+    public Consumer<String, byte[]> getConsumer() {
         return kafkaConsumer;
     }
 
@@ -69,7 +69,7 @@ public class NakadiKafkaConsumer implements EventConsumer {
     }
 
     private void pollFromKafka() {
-        final ConsumerRecords<String, String> records = kafkaConsumer.poll(pollTimeout);
+        final ConsumerRecords<String, byte[]> records = kafkaConsumer.poll(pollTimeout);
         eventQueue = StreamSupport
                 .stream(records.spliterator(), false)
                 .map(record -> {

--- a/src/main/java/org/zalando/nakadi/service/EventStream.java
+++ b/src/main/java/org/zalando/nakadi/service/EventStream.java
@@ -2,6 +2,7 @@ package org.zalando.nakadi.service;
 
 import com.codahale.metrics.Meter;
 import com.google.common.collect.Lists;
+import org.apache.commons.io.output.CountingOutputStream;
 import org.apache.kafka.common.KafkaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,6 +12,8 @@ import org.zalando.nakadi.repository.EventConsumer;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
@@ -18,6 +21,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
 import org.zalando.nakadi.view.Cursor;
 
 import static java.lang.System.currentTimeMillis;
@@ -54,7 +58,7 @@ public class EventStream {
             int messagesRead = 0;
             final Map<String, Integer> keepAliveInARow = createMapWithPartitionKeys(partition -> 0);
 
-            final Map<String, List<String>> currentBatches =
+            final Map<String, List<byte[]>> currentBatches =
                     createMapWithPartitionKeys(partition -> Lists.newArrayList());
             // Partition to NakadiCursor.
             final Map<String, NakadiCursor> latestOffsets = config.getCursors().stream().collect(
@@ -142,30 +146,47 @@ public class EventStream {
                 .collect(Collectors.toMap(identity(), valueFunction));
     }
 
-    public static String createStreamEvent(final Cursor cursor, final List<String> events) {
-        final StringBuilder builder = new StringBuilder()
-                .append("{\"cursor\":{\"partition\":\"").append(cursor.getPartition())
-                .append("\",\"offset\":\"").append(cursor.getOffset()).append("\"}");
+    public static int writeStreamEvent(final OutputStream outputStream, final Cursor cursor, final List<byte[]> events)
+            throws IOException {
+        final CountingOutputStream countingOutputStream = new CountingOutputStream(outputStream) {
+            @Override
+            public void flush() throws IOException {
+                // block flushing
+            }
+        };
+        final Writer writer = new OutputStreamWriter(countingOutputStream);
+        writer.write("{\"cursor\":{\"partition\":\"");
+        writer.write(cursor.getPartition());
+        writer.write("\",\"offset\":\"");
+        writer.write(cursor.getOffset());
+        writer.write("\"}");
         if (!events.isEmpty()) {
-            builder.append(",\"events\":[");
-            events.forEach(event -> builder.append(event).append(","));
-            builder.deleteCharAt(builder.length() - 1).append("]");
+            writer.write(",\"events\":[");
+            writer.flush();
+            boolean first = true;
+            for (final byte[] event : events) {
+                if (!first) {
+                    countingOutputStream.write(',');
+                }
+                countingOutputStream.write(event);
+                first = false;
+            }
+            countingOutputStream.write(']');
         }
-
-        builder.append("}").append(BATCH_SEPARATOR);
-
-        return builder.toString();
+        writer.write("}");
+        writer.write(BATCH_SEPARATOR);
+        writer.flush();
+        outputStream.flush();
+        return countingOutputStream.getCount();
     }
 
-    private void sendBatch(final NakadiCursor topicPosition, final List<String> currentBatch)
+    private void sendBatch(final NakadiCursor topicPosition, final List<byte[]> currentBatch)
             throws IOException {
         // create stream event batch for current partition and send it; if there were
         // no events, it will be just a keep-alive
-        final String streamEvent = createStreamEvent(cursorConverter.convert(topicPosition), currentBatch);
-        final byte[] batchBytes = streamEvent.getBytes(UTF8);
-        outputStream.write(batchBytes);
-        bytesFlushedMeter.mark(batchBytes.length);
-        outputStream.flush();
+        final int batchBytesCount = writeStreamEvent(outputStream, cursorConverter.convert(topicPosition),
+                currentBatch);
+        bytesFlushedMeter.mark(batchBytesCount);
     }
 
     public void close() throws IOException {

--- a/src/main/java/org/zalando/nakadi/service/EventStream.java
+++ b/src/main/java/org/zalando/nakadi/service/EventStream.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -25,13 +24,13 @@ import java.util.stream.Collectors;
 import org.zalando.nakadi.view.Cursor;
 
 import static java.lang.System.currentTimeMillis;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.function.Function.identity;
 
 public class EventStream {
 
     private static final Logger LOG = LoggerFactory.getLogger(EventStream.class);
     public static final String BATCH_SEPARATOR = "\n";
-    public static final Charset UTF8 = Charset.forName("UTF-8");
 
     private final OutputStream outputStream;
     private final EventConsumer eventConsumer;
@@ -154,7 +153,7 @@ public class EventStream {
                 // block flushing
             }
         };
-        final Writer writer = new OutputStreamWriter(countingOutputStream);
+        final Writer writer = new OutputStreamWriter(countingOutputStream, UTF_8);
         writer.write("{\"cursor\":{\"partition\":\"");
         writer.write(cursor.getPartition());
         writer.write("\",\"offset\":\"");

--- a/src/main/java/org/zalando/nakadi/service/subscription/KafkaClient.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/KafkaClient.java
@@ -83,7 +83,7 @@ public class KafkaClient {
         }
     }
 
-    public org.apache.kafka.clients.consumer.Consumer<String, String> createKafkaConsumer() {
+    public org.apache.kafka.clients.consumer.Consumer<String, byte[]> createKafkaConsumer() {
         // TODO: Refactor to use correct layering
         return ((KafkaTopicRepository) topicRepository).createKafkaConsumer();
     }

--- a/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionOutput.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionOutput.java
@@ -1,11 +1,12 @@
 package org.zalando.nakadi.service.subscription;
 
 import java.io.IOException;
+import java.io.OutputStream;
 
 public interface SubscriptionOutput {
     void onInitialized(String sessionId) throws IOException;
 
     void onException(Exception ex);
 
-    void streamData(byte[] data) throws IOException;
+    OutputStream getOutputStream();
 }

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java
@@ -11,7 +11,7 @@ import java.util.TreeMap;
 
 class PartitionData {
     private final ZKSubscription subscription;
-    private final NavigableMap<Long, String> nakadiEvents = new TreeMap<>();
+    private final NavigableMap<Long, byte[]> nakadiEvents = new TreeMap<>();
     private final Logger log;
 
     private long commitOffset;
@@ -33,7 +33,7 @@ class PartitionData {
     }
 
     @Nullable
-    SortedMap<Long, String> takeEventsToStream(final long currentTimeMillis, final int batchSize,
+    SortedMap<Long, byte[]> takeEventsToStream(final long currentTimeMillis, final int batchSize,
                                                final long batchTimeoutMillis) {
         final boolean countReached = (nakadiEvents.size() >= batchSize) && batchSize > 0;
         final boolean timeReached = (currentTimeMillis - lastSendMillis) >= batchTimeoutMillis;
@@ -53,8 +53,8 @@ class PartitionData {
         return lastSendMillis;
     }
 
-    private SortedMap<Long, String> extract(final int count) {
-        final SortedMap<Long, String> result = new TreeMap<>();
+    private SortedMap<Long, byte[]> extract(final int count) {
+        final SortedMap<Long, byte[]> result = new TreeMap<>();
         for (int i = 0; i < count && !nakadiEvents.isEmpty(); ++i) {
             final Long offset = nakadiEvents.firstKey();
             result.put(offset, nakadiEvents.remove(offset));
@@ -127,7 +127,7 @@ class PartitionData {
         return new CommitResult(seekKafka, committed);
     }
 
-    void addEventFromKafka(final long offset, final String event) {
+    void addEventFromKafka(final long offset, final byte[] event) {
         if (offset > (sentOffset + nakadiEvents.size() + 1)) {
             log.warn(
                     "Adding event from kafka that is too far from last sent. " +

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -32,6 +32,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 
 class StreamingState extends State {
     private final Map<Partition.PartitionKey, PartitionData> offsets = new HashMap<>();
@@ -230,7 +232,7 @@ class StreamingState extends State {
                 // block flushing
             }
         };
-        final Writer writer = new OutputStreamWriter(countingOutputStream);
+        final Writer writer = new OutputStreamWriter(countingOutputStream, UTF_8);
 
         writer.write("{\"cursor\":");
         writer.write(cursorSerialized);

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -1,20 +1,23 @@
 package org.zalando.nakadi.service.subscription.state;
 
 import com.codahale.metrics.Meter;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Preconditions;
+import org.apache.commons.io.output.CountingOutputStream;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
 import org.slf4j.LoggerFactory;
+import org.zalando.nakadi.domain.Timeline;
 import org.zalando.nakadi.metrics.MetricUtils;
 import org.zalando.nakadi.service.EventStream;
 import org.zalando.nakadi.service.subscription.model.Partition;
 import org.zalando.nakadi.service.subscription.zk.ZKSubscription;
 import org.zalando.nakadi.view.SubscriptionCursor;
-import org.zalando.nakadi.domain.Timeline;
 
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -37,7 +40,7 @@ class StreamingState extends State {
     // correctly, and p0 is not receiving any updates - reassignment won't complete.
     private final Map<Partition.PartitionKey, Long> releasingPartitions = new HashMap<>();
     private ZKSubscription topologyChangeSubscription;
-    private Consumer<String, String> kafkaConsumer;
+    private Consumer<String, byte[]> kafkaConsumer;
     private boolean pollPaused;
     private long lastCommitMillis;
     private long committedEvents;
@@ -135,7 +138,7 @@ class StreamingState extends State {
             scheduleTask(this::pollDataFromKafka, getKafkaPollTimeout(), TimeUnit.MILLISECONDS);
             return;
         }
-        final ConsumerRecords<String, String> records = kafkaConsumer.poll(getKafkaPollTimeout());
+        final ConsumerRecords<String, byte[]> records = kafkaConsumer.poll(getKafkaPollTimeout());
         if (!records.isEmpty()) {
             for (final TopicPartition tp : records.partitions()) {
                 final Partition.PartitionKey pk = new Partition.PartitionKey(tp.topic(),
@@ -174,7 +177,7 @@ class StreamingState extends State {
     private void streamToOutput() {
         final long currentTimeMillis = System.currentTimeMillis();
         int freeSlots = (int) getMessagesAllowedToSend();
-        SortedMap<Long, String> toSend;
+        SortedMap<Long, byte[]> toSend;
         for (final Map.Entry<Partition.PartitionKey, PartitionData> e : offsets.entrySet()) {
             while (null != (toSend = e.getValue().takeEventsToStream(
                     currentTimeMillis,
@@ -196,15 +199,13 @@ class StreamingState extends State {
         }
     }
 
-    private void flushData(final Partition.PartitionKey pk, final SortedMap<Long, String> data,
+    private void flushData(final Partition.PartitionKey pk, final SortedMap<Long, byte[]> data,
                            final Optional<String> metadata) {
         try {
             final long numberOffset = offsets.get(pk).getSentOffset();
-            final String batch = serializeBatch(pk, numberOffset, new ArrayList<>(data.values()), metadata);
-
-            final byte[] batchBytes = batch.getBytes(EventStream.UTF8);
-            getOut().streamData(batchBytes);
-            bytesSentMeter.mark(batchBytes.length);
+            final int batchBytesCount = writeBatch(getOut().getOutputStream(), pk, numberOffset,
+                    new ArrayList<>(data.values()), metadata);
+            bytesSentMeter.mark(batchBytesCount);
             batchesSent++;
         } catch (final IOException e) {
             getLog().error("Failed to write data to output.", e);
@@ -212,9 +213,9 @@ class StreamingState extends State {
         }
     }
 
-    private String serializeBatch(final Partition.PartitionKey partitionKey, final long offset,
-                                  final List<String> events, final Optional<String> metadata)
-            throws JsonProcessingException {
+    private int writeBatch(final OutputStream outputStream, final Partition.PartitionKey partitionKey,
+                           final long offset, final List<byte[]> events, final Optional<String> metadata)
+            throws IOException {
 
         final Timeline timeline = getContext().getTimelinesForTopics().get(partitionKey.getTopic());
         final String token = getContext().getCursorTokenService().generateToken();
@@ -223,18 +224,39 @@ class StreamingState extends State {
                 token);
         final String cursorSerialized = getContext().getObjectMapper().writeValueAsString(cursor);
 
-        final StringBuilder builder = new StringBuilder()
-                .append("{\"cursor\":")
-                .append(cursorSerialized);
-        if (!events.isEmpty()) {
-            builder.append(",\"events\":[");
-            events.forEach(event -> builder.append(event).append(","));
-            builder.deleteCharAt(builder.length() - 1).append("]");
-        }
-        metadata.ifPresent(s -> builder.append(",\"info\":{\"debug\":\"").append(s).append("\"}"));
+        final CountingOutputStream countingOutputStream = new CountingOutputStream(outputStream) {
+            @Override
+            public void flush() throws IOException {
+                // block flushing
+            }
+        };
+        final Writer writer = new OutputStreamWriter(countingOutputStream);
 
-        builder.append("}").append(EventStream.BATCH_SEPARATOR);
-        return builder.toString();
+        writer.write("{\"cursor\":");
+        writer.write(cursorSerialized);
+        if (!events.isEmpty()) {
+            writer.write(",\"events\":[");
+            writer.flush();
+            boolean first = true;
+            for (final byte[] event : events) {
+                if (!first) {
+                    countingOutputStream.write(',');
+                }
+                countingOutputStream.write(event);
+                first = false;
+            }
+            countingOutputStream.write(']');
+        }
+        if (metadata.isPresent()) {
+            writer.write(",\"info\":{\"debug\":\"");
+            writer.write(metadata.get());
+            writer.write("\"}");
+            writer.flush();
+        }
+        writer.append("}").append(EventStream.BATCH_SEPARATOR);
+        writer.flush();
+        outputStream.flush();
+        return countingOutputStream.getCount();
     }
 
     @Override

--- a/src/test/java/org/zalando/nakadi/repository/kafka/NakadiKafkaConsumerTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/kafka/NakadiKafkaConsumerTest.java
@@ -18,6 +18,8 @@ import org.mockito.ArgumentCaptor;
 import org.zalando.nakadi.domain.ConsumedEvent;
 import org.zalando.nakadi.domain.Timeline;
 import org.zalando.nakadi.utils.TestUtils;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static junit.framework.TestCase.fail;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -98,8 +100,8 @@ public class NakadiKafkaConsumerTest {
     public void whenReadEventsThenGetRightEvents() {
 
         // ARRANGE //
-        final byte[] event1 = randomString().getBytes();
-        final byte[] event2 = randomString().getBytes();
+        final byte[] event1 = randomString().getBytes(UTF_8);
+        final byte[] event2 = randomString().getBytes(UTF_8);
         final int event1Offset = randomUInt();
         final int event2Offset = randomUInt();
         final ConsumerRecords<String, byte[]> consumerRecords = new ConsumerRecords<>(ImmutableMap.of(

--- a/src/test/java/org/zalando/nakadi/repository/kafka/NakadiKafkaConsumerTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/kafka/NakadiKafkaConsumerTest.java
@@ -51,7 +51,7 @@ public class NakadiKafkaConsumerTest {
     public void whenCreateConsumerThenKafkaConsumerConfiguredCorrectly() {
 
         // ARRANGE //
-        final KafkaConsumer<String, String> kafkaConsumerMock = mock(KafkaConsumer.class);
+        final KafkaConsumer<String, byte[]> kafkaConsumerMock = mock(KafkaConsumer.class);
 
         final Class<List<TopicPartition>> topicPartitionListClass = (Class) List.class;
         final ArgumentCaptor<List<TopicPartition>> partitionsCaptor = ArgumentCaptor.forClass(topicPartitionListClass);
@@ -98,18 +98,18 @@ public class NakadiKafkaConsumerTest {
     public void whenReadEventsThenGetRightEvents() {
 
         // ARRANGE //
-        final String event1 = randomString();
-        final String event2 = randomString();
+        final byte[] event1 = randomString().getBytes();
+        final byte[] event2 = randomString().getBytes();
         final int event1Offset = randomUInt();
         final int event2Offset = randomUInt();
-        final ConsumerRecords<String, String> consumerRecords = new ConsumerRecords<>(ImmutableMap.of(
+        final ConsumerRecords<String, byte[]> consumerRecords = new ConsumerRecords<>(ImmutableMap.of(
                     new TopicPartition(TOPIC, PARTITION),
                     ImmutableList.of(new ConsumerRecord<>(TOPIC, PARTITION, event1Offset, "k1", event1),
                         new ConsumerRecord<>(TOPIC, PARTITION, event2Offset, "k2", event2))));
         final Timeline timeline = createFakeTimeline(TOPIC);
-        final ConsumerRecords<String, String> emptyRecords = new ConsumerRecords<>(ImmutableMap.of());
+        final ConsumerRecords<String, byte[]> emptyRecords = new ConsumerRecords<>(ImmutableMap.of());
 
-        final KafkaConsumer<String, String> kafkaConsumerMock = mock(KafkaConsumer.class);
+        final KafkaConsumer<String, byte[]> kafkaConsumerMock = mock(KafkaConsumer.class);
         final ArgumentCaptor<Long> pollTimeoutCaptor = ArgumentCaptor.forClass(Long.class);
         when(kafkaConsumerMock.poll(pollTimeoutCaptor.capture())).thenReturn(consumerRecords, emptyRecords);
 
@@ -152,7 +152,7 @@ public class NakadiKafkaConsumerTest {
 
         int numberOfNakadiExceptions = 0;
         for (final Exception exception : exceptions) {
-            final KafkaConsumer<String, String> kafkaConsumerMock = mock(KafkaConsumer.class);
+            final KafkaConsumer<String, byte[]> kafkaConsumerMock = mock(KafkaConsumer.class);
             when(kafkaConsumerMock.poll(POLL_TIMEOUT)).thenThrow(exception);
 
             try {
@@ -177,7 +177,7 @@ public class NakadiKafkaConsumerTest {
     @SuppressWarnings("unchecked")
     public void whenCloseThenKafkaConsumerIsClosed() {
         // ARRANGE //
-        final KafkaConsumer<String, String> kafkaConsumerMock = mock(KafkaConsumer.class);
+        final KafkaConsumer<String, byte[]> kafkaConsumerMock = mock(KafkaConsumer.class);
         final NakadiKafkaConsumer nakadiKafkaConsumer = new NakadiKafkaConsumer(kafkaConsumerMock,
                 ImmutableList.of(), POLL_TIMEOUT, createFakeTimeline(TOPIC));
         // ACT //

--- a/src/test/java/org/zalando/nakadi/service/EventStreamTest.java
+++ b/src/test/java/org/zalando/nakadi/service/EventStreamTest.java
@@ -32,6 +32,7 @@ import org.zalando.nakadi.repository.kafka.NakadiKafkaConsumer;
 import org.zalando.nakadi.service.converter.CursorConverterImpl;
 import org.zalando.nakadi.service.timeline.TimelineService;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.nCopies;
 import static java.util.Optional.empty;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -49,7 +50,7 @@ import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 public class EventStreamTest {
 
     private static final String TOPIC = randomString();
-    private static final byte[] DUMMY = "DUMMY".getBytes();
+    private static final byte[] DUMMY = "DUMMY".getBytes(UTF_8);
     private static final Meter BYTES_FLUSHED_METER = new MetricRegistry().meter("mock");
 
     private static final Timeline TIMELINE = createFakeTimeline(TOPIC);
@@ -229,7 +230,7 @@ public class EventStreamTest {
                 .range(0, eventNum)
                 .boxed()
                 .map(index -> new ConsumedEvent(
-                        ("event" + index).getBytes(), new NakadiCursor(TIMELINE, "0",
+                        ("event" + index).getBytes(UTF_8), new NakadiCursor(TIMELINE, "0",
                         KafkaCursor.toNakadiOffset(index))))
                 .collect(Collectors.toList()));
 
@@ -248,7 +249,7 @@ public class EventStreamTest {
                         batches[index],
                         sameJSONAs(jsonBatch(
                                 "0", KafkaCursor.toNakadiOffset(index),
-                                Optional.of(nCopies(1, ("event" + index).getBytes()))))
+                                Optional.of(nCopies(1, ("event" + index).getBytes(UTF_8)))))
                 ));
     }
 
@@ -341,7 +342,7 @@ public class EventStreamTest {
         final String eventsStr = eventsOrNone
                 .map(events -> {
                     final StringBuilder builder = new StringBuilder(",\"events\":[");
-                    events.forEach(event -> builder.append("\"").append(new String(event)).append("\","));
+                    events.forEach(event -> builder.append("\"").append(new String(event, UTF_8)).append("\","));
                     builder.deleteCharAt(builder.length() - 1).append("]");
                     return builder.toString();
                 })

--- a/src/test/java/org/zalando/nakadi/service/subscription/StreamingContextTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/StreamingContextTest.java
@@ -10,6 +10,7 @@ import org.zalando.nakadi.service.subscription.state.DummyState;
 import org.zalando.nakadi.service.subscription.state.State;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -29,8 +30,8 @@ public class StreamingContextTest {
             }
 
             @Override
-            public void streamData(final byte[] data) throws IOException {
-
+            public OutputStream getOutputStream() {
+                return null;
             }
         };
         return new StreamingContext.Builder()

--- a/src/test/java/org/zalando/nakadi/service/subscription/state/PartitionDataTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/state/PartitionDataTest.java
@@ -1,10 +1,12 @@
 package org.zalando.nakadi.service.subscription.state;
 
-import java.util.SortedMap;
-import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+
 import static java.lang.System.currentTimeMillis;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -38,7 +40,7 @@ public class PartitionDataTest {
     public void normalOperationShouldNotReconfigureKafkaConsumer() {
         final PartitionData pd = new PartitionData(null, 100L);
         for (long i = 0; i < 100; ++i) {
-            pd.addEventFromKafka(100L + i + 1, "test_" + i);
+            pd.addEventFromKafka(100L + i + 1, ("test_" + i).getBytes());
         }
         // Now say to it that it was sent
         pd.takeEventsToStream(currentTimeMillis(), 1000, 0L);
@@ -55,24 +57,24 @@ public class PartitionDataTest {
     public void eventsMustBeReturnedInGuaranteedOrder() {
         final PartitionData pd = new PartitionData(null, 100L);
         for (long i = 0; i < 100; ++i) {
-            pd.addEventFromKafka(200L - i, "test_" + (200L - i));
+            pd.addEventFromKafka(200L - i, ("test_" + (200L - i)).getBytes());
         }
-        pd.addEventFromKafka(201L, "fake");
+        pd.addEventFromKafka(201L, "fake".getBytes());
         for (int i = 0; i < 10; ++i) {
-            final SortedMap<Long, String> data = pd.takeEventsToStream(currentTimeMillis(), 10, 0L);
+            final SortedMap<Long, byte[]> data = pd.takeEventsToStream(currentTimeMillis(), 10, 0L);
             assertNotNull(data);
             assertEquals(10, data.size());
             assertEquals((i + 1) * 10, pd.getUnconfirmed());
             assertEquals(0, pd.getKeepAliveInARow());
             assertEquals(100L + i * 10L + 1L, data.firstKey().longValue());
             assertEquals(100L + i * 10L + 10L, data.lastKey().longValue());
-            data.forEach((k, v) -> assertEquals("test_" + k, v));
+            data.forEach((k, v) -> assertArrayEquals(("test_" + k).getBytes(), v));
         }
-        final SortedMap<Long, String> data = pd.takeEventsToStream(currentTimeMillis(), 10, 0L);
+        final SortedMap<Long, byte[]> data = pd.takeEventsToStream(currentTimeMillis(), 10, 0L);
         assertNotNull(data);
         assertEquals(1, data.size());
         assertEquals(201L, data.firstKey().longValue());
-        assertEquals("fake", data.get(data.firstKey()));
+        assertArrayEquals("fake".getBytes(), data.get(data.firstKey()));
         assertEquals(0, pd.getKeepAliveInARow());
     }
 
@@ -83,7 +85,7 @@ public class PartitionDataTest {
             pd.takeEventsToStream(currentTimeMillis(), 10, 0L);
             assertEquals(i + 1, pd.getKeepAliveInARow());
         }
-        pd.addEventFromKafka(101L, "");
+        pd.addEventFromKafka(101L, new byte[0]);
         assertEquals(100, pd.getKeepAliveInARow());
         pd.takeEventsToStream(currentTimeMillis(), 10, 0L);
         assertEquals(0, pd.getKeepAliveInARow());
@@ -96,9 +98,9 @@ public class PartitionDataTest {
         final long timeout = TimeUnit.SECONDS.toMillis(1);
         final PartitionData pd = new PartitionData(null, 100L);
         for (int i = 0; i < 100; ++i) {
-            pd.addEventFromKafka(i + 100L + 1, "test");
+            pd.addEventFromKafka(i + 100L + 1, "test".getBytes());
         }
-        SortedMap<Long, String> data = pd.takeEventsToStream(currentTimeMillis(), 1000, timeout);
+        SortedMap<Long, byte[]> data = pd.takeEventsToStream(currentTimeMillis(), 1000, timeout);
         assertNull(data);
         assertEquals(0, pd.getKeepAliveInARow());
         Thread.sleep(timeout);
@@ -108,7 +110,7 @@ public class PartitionDataTest {
         assertEquals(100, data.size());
 
         for (int i = 100; i < 200; ++i) {
-            pd.addEventFromKafka(i + 100L + 1, "test");
+            pd.addEventFromKafka(i + 100L + 1, "test".getBytes());
         }
         data = pd.takeEventsToStream(currentTimeMillis(), 1000, timeout);
         assertNull(data);
@@ -125,10 +127,10 @@ public class PartitionDataTest {
         final long timeout = TimeUnit.SECONDS.toMillis(1);
         final PartitionData pd = new PartitionData(null, 100L);
         for (int i = 0; i < 100; ++i) {
-            pd.addEventFromKafka(i + 100L + 1, "test");
+            pd.addEventFromKafka(i + 100L + 1, "test".getBytes());
         }
         assertNull(pd.takeEventsToStream(currentTimeMillis(), 1000, timeout));
-        final SortedMap<Long, String> eventsToStream = pd.takeEventsToStream(currentTimeMillis(), 99, timeout);
+        final SortedMap<Long, byte[]> eventsToStream = pd.takeEventsToStream(currentTimeMillis(), 99, timeout);
         assertNotNull(eventsToStream);
         assertEquals(99, eventsToStream.size());
     }

--- a/src/test/java/org/zalando/nakadi/service/subscription/state/PartitionDataTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/state/PartitionDataTest.java
@@ -6,6 +6,7 @@ import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.System.currentTimeMillis;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -40,7 +41,7 @@ public class PartitionDataTest {
     public void normalOperationShouldNotReconfigureKafkaConsumer() {
         final PartitionData pd = new PartitionData(null, 100L);
         for (long i = 0; i < 100; ++i) {
-            pd.addEventFromKafka(100L + i + 1, ("test_" + i).getBytes());
+            pd.addEventFromKafka(100L + i + 1, ("test_" + i).getBytes(UTF_8));
         }
         // Now say to it that it was sent
         pd.takeEventsToStream(currentTimeMillis(), 1000, 0L);
@@ -57,9 +58,9 @@ public class PartitionDataTest {
     public void eventsMustBeReturnedInGuaranteedOrder() {
         final PartitionData pd = new PartitionData(null, 100L);
         for (long i = 0; i < 100; ++i) {
-            pd.addEventFromKafka(200L - i, ("test_" + (200L - i)).getBytes());
+            pd.addEventFromKafka(200L - i, ("test_" + (200L - i)).getBytes(UTF_8));
         }
-        pd.addEventFromKafka(201L, "fake".getBytes());
+        pd.addEventFromKafka(201L, "fake".getBytes(UTF_8));
         for (int i = 0; i < 10; ++i) {
             final SortedMap<Long, byte[]> data = pd.takeEventsToStream(currentTimeMillis(), 10, 0L);
             assertNotNull(data);
@@ -68,13 +69,13 @@ public class PartitionDataTest {
             assertEquals(0, pd.getKeepAliveInARow());
             assertEquals(100L + i * 10L + 1L, data.firstKey().longValue());
             assertEquals(100L + i * 10L + 10L, data.lastKey().longValue());
-            data.forEach((k, v) -> assertArrayEquals(("test_" + k).getBytes(), v));
+            data.forEach((k, v) -> assertArrayEquals(("test_" + k).getBytes(UTF_8), v));
         }
         final SortedMap<Long, byte[]> data = pd.takeEventsToStream(currentTimeMillis(), 10, 0L);
         assertNotNull(data);
         assertEquals(1, data.size());
         assertEquals(201L, data.firstKey().longValue());
-        assertArrayEquals("fake".getBytes(), data.get(data.firstKey()));
+        assertArrayEquals("fake".getBytes(UTF_8), data.get(data.firstKey()));
         assertEquals(0, pd.getKeepAliveInARow());
     }
 
@@ -98,7 +99,7 @@ public class PartitionDataTest {
         final long timeout = TimeUnit.SECONDS.toMillis(1);
         final PartitionData pd = new PartitionData(null, 100L);
         for (int i = 0; i < 100; ++i) {
-            pd.addEventFromKafka(i + 100L + 1, "test".getBytes());
+            pd.addEventFromKafka(i + 100L + 1, "test".getBytes(UTF_8));
         }
         SortedMap<Long, byte[]> data = pd.takeEventsToStream(currentTimeMillis(), 1000, timeout);
         assertNull(data);
@@ -110,7 +111,7 @@ public class PartitionDataTest {
         assertEquals(100, data.size());
 
         for (int i = 100; i < 200; ++i) {
-            pd.addEventFromKafka(i + 100L + 1, "test".getBytes());
+            pd.addEventFromKafka(i + 100L + 1, "test".getBytes(UTF_8));
         }
         data = pd.takeEventsToStream(currentTimeMillis(), 1000, timeout);
         assertNull(data);
@@ -127,7 +128,7 @@ public class PartitionDataTest {
         final long timeout = TimeUnit.SECONDS.toMillis(1);
         final PartitionData pd = new PartitionData(null, 100L);
         for (int i = 0; i < 100; ++i) {
-            pd.addEventFromKafka(i + 100L + 1, "test".getBytes());
+            pd.addEventFromKafka(i + 100L + 1, "test".getBytes(UTF_8));
         }
         assertNull(pd.takeEventsToStream(currentTimeMillis(), 1000, timeout));
         final SortedMap<Long, byte[]> eventsToStream = pd.takeEventsToStream(currentTimeMillis(), 99, timeout);


### PR DESCRIPTION
- currently consuming deserializes the payload to a `java.lang.String` instance. a `String` instance has to be converted back to a `byte[]` when it's sent to REST clients. 
- This PR uses `org.apache.kafka.common.serialization.ByteArrayDeserializer` as the `value.deserializer` so that the value returned by the consumer is a `byte[]` instead of a `java.lang.String`.
- Besides this change, it makes the writing of events to clients use a streaming approach in `org.zalando.nakadi.service.EventStream` and `org.zalando.nakadi.service.subscription.state.StreamingState`. 
  - Apache Commons IO's  `org.apache.commons.io.output.CountingOutputStream` is used to calculate the number of bytes written to the stream. `java.io.OutputStreamWriter` is used for writing String instances to the output stream. 