### PR TITLE
Eliminate high number of unnecessary java.io.IOExceptions

### DIFF
--- a/api-consumption/src/main/java/org/zalando/nakadi/service/ClosedConnectionsCrutch.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/ClosedConnectionsCrutch.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.net.InetAddresses;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,6 +19,7 @@ import org.zalando.nakadi.domain.Feature;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -194,7 +196,10 @@ public class ClosedConnectionsCrutch {
     @VisibleForTesting
     Map<ConnectionInfo, ConnectionState> getCurrentConnections(final InputStream in) throws IOException {
         final Map<ConnectionInfo, ConnectionState> connectionToState = new HashMap<>();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
+        // Linux proc filesystem files aren't ordinary files and have problems with readLine method
+        // workaround problem by reading the contents to memory before processing
+        final ByteArrayInputStream fullyReadInput = new ByteArrayInputStream(IOUtils.toByteArray(in));
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(fullyReadInput))) {
             // /proc/net/tcp[6]
             // idx, local_address, remote_address, status, ...
 


### PR DESCRIPTION
While profiling, I noticed a high number of IOExceptions. Exception rate was over 300 exceptions per second for the duration of the profiling.

```
  java.io.IOException.<init>(String)	42,562
   java.io.FileInputStream.available()	42,499
    sun.nio.cs.StreamDecoder.inReady()	42,499
     sun.nio.cs.StreamDecoder.implRead(char[], int, int)	42,499
      sun.nio.cs.StreamDecoder.read(char[], int, int)	42,499
       java.io.InputStreamReader.read(char[], int, int)	42,499
        java.io.BufferedReader.fill()	42,499
         java.io.BufferedReader.readLine(boolean)	42,499
          java.io.BufferedReader.readLine()	42,499
           org.zalando.nakadi.service.ClosedConnectionsCrutch.getCurrentConnections(InputStream)	42,499
```

- read Linux /proc/net/* files fully before processing
- proc files aren't ordinary files and fail when reading
  line-by-line with BufferedReader.readLine method
  - internally causes IOException with message "Invalid argument"
  - workaround is to read whole file to memory before processing

After making these changes, the exceptions don't show up anymore in profiling.