### PR TITLE
Aruha 732 dont delete event types

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -278,8 +278,8 @@ paths:
 
          * Events in the stream may be visible for a short period of time before being removed.
 
-         On nakadi-live, the oauth resource owner username has to be equal to 'nakadi.oauth2.adminClientId' property
-         to be able to access this endpoint.
+         Depending on the Nakadi configuration, the oauth resource owner username may have to be equal to
+         'nakadi.oauth2.adminClientId' property to be able to access this endpoint.
 
       parameters:
         - name: name

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -278,6 +278,9 @@ paths:
 
          * Events in the stream may be visible for a short period of time before being removed.
 
+         On nakadi-live, the oauth resource owner username has to be equal to 'nakadi.oauth2.adminClientId' property
+         to be able to access this endpoint.
+
       parameters:
         - name: name
           in: path
@@ -295,6 +298,10 @@ paths:
           description: EventType is successfuly removed
         '401':
           description: Client is not authenticated
+          schema:
+            $ref: '#/definitions/Problem'
+        '403':
+          description: Access forbidden
           schema:
             $ref: '#/definitions/Problem'
 

--- a/src/main/java/org/zalando/nakadi/controller/EventTypeController.java
+++ b/src/main/java/org/zalando/nakadi/controller/EventTypeController.java
@@ -118,7 +118,7 @@ public class EventTypeController {
     public ResponseEntity<?> delete(@PathVariable("name") final String eventTypeName,
                                     final NativeWebRequest request,
                                     final Client client) {
-        if (featureToggleService.isFeatureEnabled(DISABLE_EVENT_TYPE_DELETION) && isNotAdmin(client)) {
+        if (featureToggleService.isFeatureEnabled(DISABLE_EVENT_TYPE_DELETION) && !isAdmin(client)) {
             return new ResponseEntity<>(HttpStatus.FORBIDDEN);
         }
 
@@ -190,8 +190,8 @@ public class EventTypeController {
         return Responses.create(Response.Status.SERVICE_UNAVAILABLE, exception.getMessage(), request);
     }
 
-    private boolean isNotAdmin(final Client client) {
-        return !client.getClientId().equals(securitySettings.getAdminClientId());
+    private boolean isAdmin(final Client client) {
+        return client.getClientId().equals(securitySettings.getAdminClientId());
     }
 
 }

--- a/src/main/java/org/zalando/nakadi/controller/EventTypeController.java
+++ b/src/main/java/org/zalando/nakadi/controller/EventTypeController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.zalando.nakadi.config.NakadiSettings;
+import org.zalando.nakadi.config.SecuritySettings;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeBase;
 import org.zalando.nakadi.domain.EventTypeOptions;
@@ -54,18 +55,21 @@ public class EventTypeController {
     private final EventTypeOptionsValidator eventTypeOptionsValidator;
     private final ApplicationService applicationService;
     private final NakadiSettings nakadiSettings;
+    private final SecuritySettings securitySettings;
 
     @Autowired
     public EventTypeController(final EventTypeService eventTypeService,
                                final FeatureToggleService featureToggleService,
                                final EventTypeOptionsValidator eventTypeOptionsValidator,
                                final ApplicationService applicationService,
-                               final NakadiSettings nakadiSettings) {
+                               final NakadiSettings nakadiSettings,
+                               final SecuritySettings securitySettings) {
         this.eventTypeService = eventTypeService;
         this.featureToggleService = featureToggleService;
         this.eventTypeOptionsValidator = eventTypeOptionsValidator;
         this.applicationService = applicationService;
         this.nakadiSettings = nakadiSettings;
+        this.securitySettings = securitySettings;
     }
 
     @RequestMapping(method = RequestMethod.GET)
@@ -114,8 +118,8 @@ public class EventTypeController {
     public ResponseEntity<?> delete(@PathVariable("name") final String eventTypeName,
                                     final NativeWebRequest request,
                                     final Client client) {
-        if (featureToggleService.isFeatureEnabled(DISABLE_EVENT_TYPE_DELETION)) {
-            return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+        if (featureToggleService.isFeatureEnabled(DISABLE_EVENT_TYPE_DELETION) && isNotAdmin(client)) {
+            return new ResponseEntity<>(HttpStatus.FORBIDDEN);
         }
 
         eventTypeService.delete(eventTypeName, client);
@@ -184,6 +188,10 @@ public class EventTypeController {
                                                         final NativeWebRequest request) {
         LOG.debug(exception.getMessage(), exception);
         return Responses.create(Response.Status.SERVICE_UNAVAILABLE, exception.getMessage(), request);
+    }
+
+    private boolean isNotAdmin(final Client client) {
+        return !client.getClientId().equals(securitySettings.getAdminClientId());
     }
 
 }

--- a/src/main/java/org/zalando/nakadi/util/FeatureToggleServiceDefault.java
+++ b/src/main/java/org/zalando/nakadi/util/FeatureToggleServiceDefault.java
@@ -12,7 +12,6 @@ import java.util.Set;
 public class FeatureToggleServiceDefault implements FeatureToggleService {
     private static final Set<Feature> DEPRECATED_FEATURES = ImmutableSet.of(
             Feature.DISABLE_EVENT_TYPE_CREATION,
-            Feature.DISABLE_EVENT_TYPE_DELETION,
             Feature.DISABLE_SUBSCRIPTION_CREATION
     );
 

--- a/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
@@ -487,6 +487,8 @@ public class EventTypeControllerTest {
 
         final EventType eventType = buildDefaultEventType();
 
+        doReturn(Optional.of(eventType)).when(eventTypeRepository).findByNameO(eventType.getName());
+
         postEventType(eventType);
         disableETDeletionFeature();
 

--- a/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
@@ -476,16 +476,8 @@ public class EventTypeControllerTest {
     public void whenDeleteEventTypeNotAdminAndDeletionDeactivatedThenForbidden() throws Exception {
         final EventType eventType = buildDefaultEventType();
 
-        doReturn(eventType).when(eventTypeRepository).findByName(eventType.getName());
-        doReturn(Optional.of(eventType)).when(eventTypeRepository).findByNameO(eventType.getName());
-
-        doReturn(SecuritySettings.AuthMode.BASIC).when(settings).getAuthMode();
-        doReturn(true).when(featureToggleService).isFeatureEnabled(CHECK_APPLICATION_LEVEL_PERMISSIONS);
-        doReturn(true).when(featureToggleService).isFeatureEnabled(DISABLE_EVENT_TYPE_DELETION);
-
-        final Multimap<TopicRepository, String> topicsToDelete = ArrayListMultimap.create();
-        topicsToDelete.put(topicRepository, eventType.getTopic());
-        doReturn(topicsToDelete).when(timelineService).deleteAllTimelinesForEventType(eventType.getName());
+        postEventType(eventType);
+        disableETDeletionFeature();
 
         deleteEventType(eventType.getName(), "somebody").andExpect(status().isForbidden());
     }
@@ -495,16 +487,8 @@ public class EventTypeControllerTest {
 
         final EventType eventType = buildDefaultEventType();
 
-        doReturn(eventType).when(eventTypeRepository).findByName(eventType.getName());
-        doReturn(Optional.of(eventType)).when(eventTypeRepository).findByNameO(eventType.getName());
-
-        doReturn(SecuritySettings.AuthMode.BASIC).when(settings).getAuthMode();
-        doReturn(true).when(featureToggleService).isFeatureEnabled(CHECK_APPLICATION_LEVEL_PERMISSIONS);
-        doReturn(true).when(featureToggleService).isFeatureEnabled(DISABLE_EVENT_TYPE_DELETION);
-
-        final Multimap<TopicRepository, String> topicsToDelete = ArrayListMultimap.create();
-        topicsToDelete.put(topicRepository, eventType.getTopic());
-        doReturn(topicsToDelete).when(timelineService).deleteAllTimelinesForEventType(eventType.getName());
+        postEventType(eventType);
+        disableETDeletionFeature();
 
         deleteEventType(eventType.getName(), "nakadi").andExpect(status().isOk()).andExpect(content().string(""));
     }
@@ -1039,5 +1023,11 @@ public class EventTypeControllerTest {
 
     private String asJsonString(final Object object) throws JsonProcessingException {
         return objectMapper.writeValueAsString(object);
+    }
+
+    private void disableETDeletionFeature() {
+        doReturn(SecuritySettings.AuthMode.BASIC).when(settings).getAuthMode();
+        doReturn(true).when(featureToggleService).isFeatureEnabled(CHECK_APPLICATION_LEVEL_PERMISSIONS);
+        doReturn(true).when(featureToggleService).isFeatureEnabled(DISABLE_EVENT_TYPE_DELETION);
     }
 }

--- a/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
@@ -159,7 +159,7 @@ public class EventTypeControllerTest {
         final EventTypeOptionsValidator eventTypeOptionsValidator =
                 new EventTypeOptionsValidator(TOPIC_RETENTION_MIN_MS, TOPIC_RETENTION_MAX_MS);
         final EventTypeController controller = new EventTypeController(eventTypeService,
-                featureToggleService, eventTypeOptionsValidator, applicationService, nakadiSettings);
+                featureToggleService, eventTypeOptionsValidator, applicationService, nakadiSettings, settings);
         doReturn(randomUUID).when(uuid).randomUUID();
 
         final MappingJackson2HttpMessageConverter jackson2HttpMessageConverter =


### PR DESCRIPTION
[ARUHA-732
](https://techjira.zalando.net/browse/ARUHA-732)
* everyone should be able to delete events on staging
* only Aruha team should be able to delete events on live
* the API definition should reflect this
* this should be under a feature flag