### PR TITLE
aruha-667 fix schema versioning of composed types

### DIFF
--- a/src/main/java/org/zalando/nakadi/validation/schema/diff/CombinedSchemaDiff.java
+++ b/src/main/java/org/zalando/nakadi/validation/schema/diff/CombinedSchemaDiff.java
@@ -17,8 +17,7 @@ class CombinedSchemaDiff {
     static void recursiveCheck(final CombinedSchema combinedSchemaOriginal, final CombinedSchema combinedSchemaUpdate,
                                        final Stack<String> jsonPath,
                                        final List<SchemaChange> changes) {
-        if(!(combinedSchemaOriginal.getSubschemas().containsAll(combinedSchemaUpdate.getSubschemas())
-                && combinedSchemaUpdate.getSubschemas().containsAll(combinedSchemaOriginal.getSubschemas()))) {
+        if(combinedSchemaOriginal.getSubschemas().size() != combinedSchemaUpdate.getSubschemas().size()) {
             SchemaDiff.addChange(SUB_SCHEMA_CHANGED, jsonPath, changes);
         } else {
             if (!combinedSchemaOriginal.getCriterion().equals(combinedSchemaUpdate.getCriterion())) {

--- a/src/test/resources/org/zalando/nakadi/validation/invalid-schema-evolution-examples.json
+++ b/src/test/resources/org/zalando/nakadi/validation/invalid-schema-evolution-examples.json
@@ -161,6 +161,27 @@
         }
       ]
     },
+    "errors": ["TYPE_CHANGED #/anyOf/0"]
+  },
+  {
+    "description": "Do not allow changes to number of sub schemas",
+    "original_schema": {
+      "anyOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "update_schema": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
     "errors": ["SUB_SCHEMA_CHANGED #/"]
   },
   {


### PR DESCRIPTION
Previous to this PR, changing the number of itens in a composed
schema (anyOf, oneOf, allOf) was possible due to an error in how
comparisons are made.

I replacing containsAll by a simple size comparison, so to be sure that
the number of items remain the same. Checks for changes in the items
themselves is done correctly, as demoed in the tests.