### PR TITLE
Code style diff file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,11 @@ hs_err_pid*
 *.iml
 
 ## Directory-based project format:
-.idea/
+.idea/*
 # if you remove the above rule, at least ignore the following:
+
+# exclude code style diff
+!.idea/codeStyleSettings.xml
 
 # User-specific stuff:
 # .idea/workspace.xml

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectCodeStyleSettingsManager">
+    <option name="PER_PROJECT_SETTINGS">
+      <value>
+        <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999999999" />
+        <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999999999" />
+        <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true" />
+        <XML>
+          <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+        </XML>
+      </value>
+    </option>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="nakadi" />
+  </component>
+</project>


### PR DESCRIPTION
Looking at many PRs in our repo, there is a lot of unnecessary movements of imports. IDEA allows to export code style difference between your settings and IDEA. I decided to finish it exporting my idea code style diff.
So lets try to adopt that format to avoid huge import movements.