### PR TITLE
Update Maintainers list and provide information for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing to Nakadi
+
+**Thank you for your interest in Nakadi. Your contributions are highly welcome.**
+
+There are multiple ways of getting involved:
+
+- [Report a bug](#report-a-bug) 
+- [Suggest a feature] (#suggest-a-feature) 
+- [Contribute code] (#contribute-code) 
+
+Below are a few guidelines we would like you to follow.
+If you need help, please reach out to us by opening an issue.
+
+## Report a bug 
+Reporting bugs is one of the best ways to contribute. Before creating a bug report, please check that an [issue] (https://github.com/zalando/nakadi/issues) reporting the same problem does not already exist. If there is an such an issue, you may add your information as a comment.
+
+To report a new bug you should open an issue that summarizes the bug and set the label to "bug".
+
+If you want to provide a fix along with your bug report: That is great! In this case please send us a pull request as described in section [Contribute Code] (#contribute-code).
+
+## Suggest a feature
+To request a new feature you should open an [issue] (https://github.com/zalando/nakadi/issues/new) and summarize the desired functionality and its use case. Set the issue label to "feature".  
+
+## Contribute code
+This is a rough outline of what the workflow for code contributions looks like:
+- Check the list of open [issues] (https://github.com/zalando/nakadi/issues). Either assign an existing issue to yourself, or create a new one that you would like work on and discuss your ideas and use cases. It is always best to discuss your plans beforehand, to ensure that your contribution is in line with our goals for Nakadi.
+- Fork the repository on GitHub
+- Create a topic branch from where you want to base your work. This is usually master.
+- Make commits of logical units.
+- Write good commit messages (see below).
+- Push your changes to a topic branch in your fork of the repository.
+- Submit a pull request to [zalando/nakadi] (https://github.com/zalando/nakadi)
+- Your pull request must receive a :thumbsup: from two [Maintainers] (https://github.com/zalando/nakadi/blob/master/MAINTAINERS)
+
+Thanks for your contributions!
+
+### Commit messages
+Your commit messages ideally can answer two questions: what changed and why. The subject line should feature the “what” and the body of the commit should describe the “why”.  
+
+When creating a pull request, its comment should reference the corresponding issue id.
+
+**Have fun, and happy hacking!**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Below are a few guidelines we would like you to follow.
 If you need help, please reach out to us by opening an issue.
 
 ## Report a bug 
-Reporting bugs is one of the best ways to contribute. Before creating a bug report, please check that an [issue](https://github.com/zalando/nakadi/issues) reporting the same problem does not already exist. If there is an such an issue, you may add your information as a comment.
+Reporting bugs is one of the best ways to contribute. Before creating a bug report, please check that an [issue](https://github.com/zalando/nakadi/issues) reporting the same problem does not already exist. If there is such an issue, you may add your information as a comment.
 
 To report a new bug you should open an issue that summarizes the bug and set the label to "bug".
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,32 +5,32 @@
 There are multiple ways of getting involved:
 
 - [Report a bug](#report-a-bug) 
-- [Suggest a feature] (#suggest-a-feature) 
-- [Contribute code] (#contribute-code) 
+- [Suggest a feature](#suggest-a-feature) 
+- [Contribute code](#contribute-code) 
 
 Below are a few guidelines we would like you to follow.
 If you need help, please reach out to us by opening an issue.
 
 ## Report a bug 
-Reporting bugs is one of the best ways to contribute. Before creating a bug report, please check that an [issue] (https://github.com/zalando/nakadi/issues) reporting the same problem does not already exist. If there is an such an issue, you may add your information as a comment.
+Reporting bugs is one of the best ways to contribute. Before creating a bug report, please check that an [issue](https://github.com/zalando/nakadi/issues) reporting the same problem does not already exist. If there is an such an issue, you may add your information as a comment.
 
 To report a new bug you should open an issue that summarizes the bug and set the label to "bug".
 
-If you want to provide a fix along with your bug report: That is great! In this case please send us a pull request as described in section [Contribute Code] (#contribute-code).
+If you want to provide a fix along with your bug report: That is great! In this case please send us a pull request as described in section [Contribute Code](#contribute-code).
 
 ## Suggest a feature
-To request a new feature you should open an [issue] (https://github.com/zalando/nakadi/issues/new) and summarize the desired functionality and its use case. Set the issue label to "feature".  
+To request a new feature you should open an [issue](https://github.com/zalando/nakadi/issues/new) and summarize the desired functionality and its use case. Set the issue label to "feature".  
 
 ## Contribute code
 This is a rough outline of what the workflow for code contributions looks like:
-- Check the list of open [issues] (https://github.com/zalando/nakadi/issues). Either assign an existing issue to yourself, or create a new one that you would like work on and discuss your ideas and use cases. It is always best to discuss your plans beforehand, to ensure that your contribution is in line with our goals for Nakadi.
+- Check the list of open [issues](https://github.com/zalando/nakadi/issues). Either assign an existing issue to yourself, or create a new one that you would like work on and discuss your ideas and use cases. It is always best to discuss your plans beforehand, to ensure that your contribution is in line with our goals for Nakadi.
 - Fork the repository on GitHub
 - Create a topic branch from where you want to base your work. This is usually master.
 - Make commits of logical units.
 - Write good commit messages (see below).
 - Push your changes to a topic branch in your fork of the repository.
-- Submit a pull request to [zalando/nakadi] (https://github.com/zalando/nakadi)
-- Your pull request must receive a :thumbsup: from two [Maintainers] (https://github.com/zalando/nakadi/blob/master/MAINTAINERS)
+- Submit a pull request to [zalando/nakadi](https://github.com/zalando/nakadi)
+- Your pull request must receive a :thumbsup: from two [Maintainers](https://github.com/zalando/nakadi/blob/master/MAINTAINERS)
 
 Thanks for your contributions!
 
@@ -40,3 +40,4 @@ Your commit messages ideally can answer two questions: what changed and why. The
 When creating a pull request, its comment should reference the corresponding issue id.
 
 **Have fun, and happy hacking!**
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ This is a rough outline of what the workflow for code contributions looks like:
 - Write good commit messages (see below).
 - Push your changes to a topic branch in your fork of the repository.
 - Submit a pull request to [zalando/nakadi](https://github.com/zalando/nakadi)
-- Your pull request must receive a :thumbsup: from two [Maintainers](https://github.com/zalando/nakadi/blob/master/MAINTAINERS)
+- Your pull request must receive a :thumbsup: from two [maintainers](https://github.com/zalando/nakadi/blob/master/MAINTAINERS)
 
 Thanks for your contributions!
 

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -4,3 +4,5 @@ Ricardo De Cillo <ricardo.de.cillo@zalando.de>
 Valentine Gogichashvili <valentine.gogichashvili@zalando.de>
 Viktor Buldakov <viktor.buldakov@zalando.de>
 Vyacheslav Stepanov <vyacheslav.stepanov@zalando.de>
+Lionel Montrieux <lionel.montrieux@zalando.de>
+Robert Garrett <robert.garrett@zalando.de>

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2,7 +2,6 @@ Andrey Dyachkov <andrey.dyachkov@zalando.de>
 Dmitry Sorokin <dmitriy.sorokin@zalando.de>
 Ricardo De Cillo <ricardo.de.cillo@zalando.de>
 Valentine Gogichashvili <valentine.gogichashvili@zalando.de>
-Viktor Buldakov <viktor.buldakov@zalando.de>
 Vyacheslav Stepanov <vyacheslav.stepanov@zalando.de>
 Lionel Montrieux <lionel.montrieux@zalando.de>
 Robert Garrett <robert.garrett@zalando.de>


### PR DESCRIPTION
This PR adds a new CONTRIBUTING.md file, which provides information
for new contributors on how to get started. This file is adapted from
Skipper's version
(https://github.com/zalando/skipper/blob/master/CONTRIBUTING.md)

This PR also updates the list of contributors.