### PR TITLE
aruha-840 use Kafka byte array deserializer

### DIFF
--- a/src/main/java/org/zalando/nakadi/domain/ConsumedEvent.java
+++ b/src/main/java/org/zalando/nakadi/domain/ConsumedEvent.java
@@ -6,15 +6,15 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public class ConsumedEvent {
 
-    private final String event;
+    private final byte[] event;
     private final NakadiCursor position;
 
-    public ConsumedEvent(final String event, final NakadiCursor position) {
+    public ConsumedEvent(final byte[] event, final NakadiCursor position) {
         this.event = event;
         this.position = position;
     }
 
-    public String getEvent() {
+    public byte[] getEvent() {
         return event;
     }
 

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
@@ -131,16 +131,19 @@ public class KafkaFactory {
         }
     }
 
-    public Consumer<String, String> getConsumer(final Properties properties) {
+    public Consumer<byte[], byte[]> getConsumer(final Properties properties) {
         return new KafkaConsumer<>(properties);
     }
 
-    public Consumer<String, String> getConsumer() {
+    public Consumer<byte[], byte[]> getConsumer() {
         return getConsumer(kafkaLocationManager.getKafkaConsumerProperties());
     }
 
-    public Consumer<String, String> getConsumer(@Nullable final String clientId) {
+    public Consumer<byte[], byte[]> getConsumer(@Nullable final String clientId) {
         final Properties properties = kafkaLocationManager.getKafkaConsumerProperties();
+        // TODO: the line bellow has been commented after a bug in Kafka's 0.9.x throttling feature has been detected.
+        // once Kafka is upgraded, we are going to enable it back. More on how it works can be found at
+        // https://docs.google.com/document/d/1JDgsBemNqS0SrNpWUL90205u0MFmSMnOqrC-ENAb6TM/edit
         // properties.put("client.id", clientId);
         return this.getConsumer(properties);
     }

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -57,11 +57,11 @@ public class KafkaLocationManager {
                 try {
                     final byte[] brokerData = curator.getData().forPath(BROKERS_IDS_PATH + "/" + brokerId);
                     brokers.add(Broker.fromByteJson(brokerData));
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     LOG.info(String.format("Failed to fetch connection string for broker %s", brokerId), e);
                 }
             }
-        } catch (Exception e) {
+        } catch (final Exception e) {
             LOG.error("Failed to fetch list of brokers from ZooKeeper", e);
         }
 
@@ -95,6 +95,8 @@ public class KafkaLocationManager {
     public Properties getKafkaConsumerProperties() {
         final Properties properties = (Properties) kafkaProperties.clone();
         properties.put("enable.auto.commit", kafkaSettings.getEnableAutoCommit());
+        properties.put("key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+        properties.put("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
         return properties;
     }
 

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -288,7 +288,7 @@ public class KafkaTopicRepository implements TopicRepository {
     @Override
     public Optional<PartitionStatistics> loadPartitionStatistics(final Timeline timeline, final String partition)
             throws ServiceUnavailableException {
-        try (Consumer<String, String> consumer = kafkaFactory.getConsumer()) {
+        try (Consumer<byte[], byte[]> consumer = kafkaFactory.getConsumer()) {
             final Optional<PartitionInfo> tp = consumer.partitionsFor(timeline.getTopic()).stream()
                     .filter(p -> KafkaCursor.toNakadiPartition(p.partition()).equals(partition))
                     .findAny();
@@ -312,7 +312,7 @@ public class KafkaTopicRepository implements TopicRepository {
     @Override
     public List<PartitionStatistics> loadTopicStatistics(final Collection<Timeline> timelines)
             throws ServiceUnavailableException {
-        try (Consumer<String, String> consumer = kafkaFactory.getConsumer()) {
+        try (Consumer<byte[], byte[]> consumer = kafkaFactory.getConsumer()) {
             final Map<TopicPartition, Timeline> backMap = new HashMap<>();
             for (final Timeline timeline : timelines) {
                 consumer.partitionsFor(timeline.getTopic())
@@ -343,7 +343,7 @@ public class KafkaTopicRepository implements TopicRepository {
     @Override
     public List<PartitionEndStatistics> loadTopicEndStatistics(final Collection<Timeline> timelines)
             throws ServiceUnavailableException {
-        try (Consumer<String, String> consumer = kafkaFactory.getConsumer()) {
+        try (Consumer<byte[], byte[]> consumer = kafkaFactory.getConsumer()) {
             final Map<TopicPartition, Timeline> backMap = new HashMap<>();
             for (final Timeline timeline : timelines) {
                 consumer.partitionsFor(timeline.getTopic())

--- a/src/main/java/org/zalando/nakadi/repository/kafka/NakadiKafkaConsumer.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/NakadiKafkaConsumer.java
@@ -16,12 +16,12 @@ import org.zalando.nakadi.repository.EventConsumer;
 
 public class NakadiKafkaConsumer implements EventConsumer.LowLevelConsumer {
 
-    private final Consumer<String, String> kafkaConsumer;
+    private final Consumer<byte[], byte[]> kafkaConsumer;
     private final long pollTimeout;
     private final Map<TopicPartition, Timeline> timelineMap;
 
     public NakadiKafkaConsumer(
-            final Consumer<String, String> kafkaConsumer,
+            final Consumer<byte[], byte[]> kafkaConsumer,
             final List<KafkaCursor> kafkaCursors,
             final Map<TopicPartition, Timeline> timelineMap,
             final long pollTimeout) {
@@ -50,12 +50,12 @@ public class NakadiKafkaConsumer implements EventConsumer.LowLevelConsumer {
 
     @Override
     public List<ConsumedEvent> readEvents() {
-        final ConsumerRecords<String, String> records = kafkaConsumer.poll(pollTimeout);
+        final ConsumerRecords<byte[], byte[]> records = kafkaConsumer.poll(pollTimeout);
         if (records.isEmpty()) {
             return Collections.emptyList();
         }
         final ArrayList<ConsumedEvent> result = new ArrayList<>(records.count());
-        for (final ConsumerRecord<String, String> record : records) {
+        for (final ConsumerRecord<byte[], byte[]> record : records) {
             final KafkaCursor cursor = new KafkaCursor(record.topic(), record.partition(), record.offset());
             final Timeline timeline = timelineMap.get(new TopicPartition(record.topic(), record.partition()));
             result.add(new ConsumedEvent(record.value(), cursor.toNakadiCursor(timeline)));

--- a/src/main/java/org/zalando/nakadi/service/EventStream.java
+++ b/src/main/java/org/zalando/nakadi/service/EventStream.java
@@ -52,7 +52,7 @@ public class EventStream {
             int messagesRead = 0;
             final Map<String, Integer> keepAliveInARow = createMapWithPartitionKeys(partition -> 0);
 
-            final Map<String, List<String>> currentBatches =
+            final Map<String, List<byte[]>> currentBatches =
                     createMapWithPartitionKeys(partition -> Lists.newArrayList());
             // Partition to NakadiCursor.
             final Map<String, NakadiCursor> latestOffsets = config.getCursors().stream().collect(
@@ -146,7 +146,7 @@ public class EventStream {
                 .collect(Collectors.toMap(identity(), valueFunction));
     }
 
-    private void sendBatch(final NakadiCursor topicPosition, final List<String> currentBatch)
+    private void sendBatch(final NakadiCursor topicPosition, final List<byte[]> currentBatch)
             throws IOException {
         final int bytesWritten = writer.getWriter()
                 .writeBatch(outputStream, cursorConverter.convert(topicPosition), currentBatch);

--- a/src/main/java/org/zalando/nakadi/service/EventStreamWriter.java
+++ b/src/main/java/org/zalando/nakadi/service/EventStreamWriter.java
@@ -21,7 +21,7 @@ public interface EventStreamWriter {
      * @param events Events in batch
      * @return count of bytes written
      */
-    int writeBatch(OutputStream os, Cursor cursor, List<String> events) throws IOException;
+    int writeBatch(OutputStream os, Cursor cursor, List<byte[]> events) throws IOException;
 
     int writeSubscriptionBatch(OutputStream os, SubscriptionCursor cursor, List<ConsumedEvent> events,
                                Optional<String> metadata) throws IOException;

--- a/src/main/java/org/zalando/nakadi/service/EventStreamWriterBinary.java
+++ b/src/main/java/org/zalando/nakadi/service/EventStreamWriterBinary.java
@@ -52,7 +52,7 @@ class EventStreamWriterBinary implements EventStreamWriter {
             + 1; //B_BATCH_SEPARATOR
 
     @Override
-    public int writeBatch(final OutputStream os, final Cursor cursor, final List<String> events) throws IOException {
+    public int writeBatch(final OutputStream os, final Cursor cursor, final List<byte[]> events) throws IOException {
         int byteCount = B_FIXED_BYTE_COUNT;
 
         os.write(B_CURSOR_PARTITION_BEGIN);
@@ -68,7 +68,7 @@ class EventStreamWriterBinary implements EventStreamWriter {
         if (!events.isEmpty()) {
             os.write(B_EVENTS_ARRAY_BEGIN);
             for (int i = 0; i < events.size(); i++) {
-                final byte[] event = events.get(i).getBytes(StandardCharsets.UTF_8);
+                final byte[] event = events.get(i);
                 os.write(event);
                 byteCount += event.length;
                 if (i < (events.size() - 1)) {
@@ -115,7 +115,7 @@ class EventStreamWriterBinary implements EventStreamWriter {
         if (!events.isEmpty()) {
             os.write(B_EVENTS_ARRAY_BEGIN);
             for (int i = 0; i < events.size(); i++) {
-                final byte[] event = events.get(i).getEvent().getBytes(StandardCharsets.UTF_8);
+                final byte[] event = events.get(i).getEvent();
                 os.write(event);
                 byteCount += event.length;
                 if (i < (events.size() - 1)) {

--- a/src/main/java/org/zalando/nakadi/service/EventStreamWriterString.java
+++ b/src/main/java/org/zalando/nakadi/service/EventStreamWriterString.java
@@ -29,7 +29,7 @@ public class EventStreamWriterString implements EventStreamWriter {
                 .append("\"}");
         if (!events.isEmpty()) {
             builder.append(",\"events\":[");
-            events.forEach(event -> builder.append(event.getEvent()).append(","));
+            events.forEach(event -> builder.append(new String(event.getEvent())).append(","));
             builder.deleteCharAt(builder.length() - 1).append("]");
         }
         metadata.ifPresent(s -> builder.append(",\"info\":{\"debug\":\"").append(s).append("\"}"));
@@ -46,13 +46,13 @@ public class EventStreamWriterString implements EventStreamWriter {
     }
 
     @Override
-    public int writeBatch(final OutputStream os, final Cursor cursor, final List<String> events) throws IOException {
+    public int writeBatch(final OutputStream os, final Cursor cursor, final List<byte[]> events) throws IOException {
         final StringBuilder builder = new StringBuilder()
                 .append("{\"cursor\":{\"partition\":\"").append(cursor.getPartition())
                 .append("\",\"offset\":\"").append(cursor.getOffset()).append("\"}");
         if (!events.isEmpty()) {
             builder.append(",\"events\":[");
-            events.forEach(event -> builder.append(event).append(","));
+            events.forEach(event -> builder.append(new String(event)).append(","));
             builder.deleteCharAt(builder.length() - 1).append("]");
         }
 

--- a/src/test/java/org/zalando/nakadi/repository/kafka/NakadiKafkaConsumerTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/kafka/NakadiKafkaConsumerTest.java
@@ -58,7 +58,7 @@ public class NakadiKafkaConsumerTest {
     public void whenCreateConsumerThenKafkaConsumerConfiguredCorrectly() {
 
         // ARRANGE //
-        final KafkaConsumer<String, String> kafkaConsumerMock = mock(KafkaConsumer.class);
+        final KafkaConsumer<byte[], byte[]> kafkaConsumerMock = mock(KafkaConsumer.class);
 
         final Class<List<TopicPartition>> topicPartitionListClass = (Class) List.class;
         final ArgumentCaptor<List<TopicPartition>> partitionsCaptor = ArgumentCaptor.forClass(topicPartitionListClass);
@@ -105,18 +105,18 @@ public class NakadiKafkaConsumerTest {
     public void whenReadEventsThenGetRightEvents() {
 
         // ARRANGE //
-        final String event1 = randomString();
-        final String event2 = randomString();
+        final byte[] event1 = randomString().getBytes();
+        final byte[] event2 = randomString().getBytes();
         final int event1Offset = randomUInt();
         final int event2Offset = randomUInt();
-        final ConsumerRecords<String, String> consumerRecords = new ConsumerRecords<>(ImmutableMap.of(
+        final ConsumerRecords<byte[], byte[]> consumerRecords = new ConsumerRecords<>(ImmutableMap.of(
                 new TopicPartition(TOPIC, PARTITION),
-                ImmutableList.of(new ConsumerRecord<>(TOPIC, PARTITION, event1Offset, "k1", event1),
-                        new ConsumerRecord<>(TOPIC, PARTITION, event2Offset, "k2", event2))));
+                ImmutableList.of(new ConsumerRecord<>(TOPIC, PARTITION, event1Offset, "k1".getBytes(), event1),
+                        new ConsumerRecord<>(TOPIC, PARTITION, event2Offset, "k2".getBytes(), event2))));
         final Timeline timeline = createFakeTimeline(TOPIC);
-        final ConsumerRecords<String, String> emptyRecords = new ConsumerRecords<>(ImmutableMap.of());
+        final ConsumerRecords<byte[], byte[]> emptyRecords = new ConsumerRecords<>(ImmutableMap.of());
 
-        final KafkaConsumer<String, String> kafkaConsumerMock = mock(KafkaConsumer.class);
+        final KafkaConsumer<byte[], byte[]> kafkaConsumerMock = mock(KafkaConsumer.class);
         final ArgumentCaptor<Long> pollTimeoutCaptor = ArgumentCaptor.forClass(Long.class);
         when(kafkaConsumerMock.poll(pollTimeoutCaptor.capture())).thenReturn(consumerRecords, emptyRecords);
 
@@ -154,7 +154,7 @@ public class NakadiKafkaConsumerTest {
 
         int numberOfNakadiExceptions = 0;
         for (final Exception exception : exceptions) {
-            final KafkaConsumer<String, String> kafkaConsumerMock = mock(KafkaConsumer.class);
+            final KafkaConsumer<byte[], byte[]> kafkaConsumerMock = mock(KafkaConsumer.class);
             when(kafkaConsumerMock.poll(POLL_TIMEOUT)).thenThrow(exception);
 
             try {
@@ -179,7 +179,7 @@ public class NakadiKafkaConsumerTest {
     @SuppressWarnings("unchecked")
     public void whenCloseThenKafkaConsumerIsClosed() {
         // ARRANGE //
-        final KafkaConsumer<String, String> kafkaConsumerMock = mock(KafkaConsumer.class);
+        final KafkaConsumer<byte[], byte[]> kafkaConsumerMock = mock(KafkaConsumer.class);
         final NakadiKafkaConsumer nakadiKafkaConsumer = new NakadiKafkaConsumer(kafkaConsumerMock,
                 ImmutableList.of(), createTpTimelineMap(), POLL_TIMEOUT);
         // ACT //

--- a/src/test/java/org/zalando/nakadi/service/EventStreamTest.java
+++ b/src/test/java/org/zalando/nakadi/service/EventStreamTest.java
@@ -234,9 +234,12 @@ public abstract class EventStreamTest {
         final String[] batches = out.toString().split(BATCH_SEPARATOR);
 
         assertThat(batches, arrayWithSize(3));
-        assertThat(batches[0], sameJSONAs(jsonBatch("0", "000000000000000000", Optional.of(nCopies(5, new String(DUMMY))))));
-        assertThat(batches[1], sameJSONAs(jsonBatch("0", "000000000000000000", Optional.of(nCopies(5, new String(DUMMY))))));
-        assertThat(batches[2], sameJSONAs(jsonBatch("0", "000000000000000000", Optional.of(nCopies(2, new String(DUMMY))))));
+        assertThat(batches[0], sameJSONAs(jsonBatch("0", "000000000000000000",
+                Optional.of(nCopies(5, new String(DUMMY))))));
+        assertThat(batches[1], sameJSONAs(jsonBatch("0", "000000000000000000",
+                Optional.of(nCopies(5, new String(DUMMY))))));
+        assertThat(batches[2], sameJSONAs(jsonBatch("0", "000000000000000000",
+                Optional.of(nCopies(2, new String(DUMMY))))));
     }
 
     @Test(timeout = 10000)
@@ -255,7 +258,8 @@ public abstract class EventStreamTest {
                 .range(0, eventNum)
                 .boxed()
                 .map(index -> new ConsumedEvent(
-                        ("event" + index).getBytes(UTF_8), new NakadiCursor(TIMELINE, "0", KafkaCursor.toNakadiOffset(index))))
+                        ("event" + index).getBytes(UTF_8), new NakadiCursor(TIMELINE, "0",
+                        KafkaCursor.toNakadiOffset(index))))
                 .collect(Collectors.toList()));
 
         final EventStream eventStream =
@@ -309,9 +313,12 @@ public abstract class EventStreamTest {
         final String[] batches = out.toString().split(BATCH_SEPARATOR);
 
         assertThat(batches, arrayWithSize(3));
-        assertThat(batches[0], sameJSONAs(jsonBatch("0", "000000000000000000", Optional.of(nCopies(2, new String(DUMMY))))));
-        assertThat(batches[1], sameJSONAs(jsonBatch("1", "000000000000000000", Optional.of(nCopies(2, new String(DUMMY))))));
-        assertThat(batches[2], sameJSONAs(jsonBatch("2", "000000000000000000", Optional.of(nCopies(2, new String(DUMMY))))));
+        assertThat(batches[0], sameJSONAs(jsonBatch("0", "000000000000000000",
+                Optional.of(nCopies(2, new String(DUMMY))))));
+        assertThat(batches[1], sameJSONAs(jsonBatch("1", "000000000000000000",
+                Optional.of(nCopies(2, new String(DUMMY))))));
+        assertThat(batches[2], sameJSONAs(jsonBatch("2", "000000000000000000",
+                Optional.of(nCopies(2, new String(DUMMY))))));
     }
 
     private static NakadiKafkaConsumer emptyConsumer() throws NakadiException {

--- a/src/test/java/org/zalando/nakadi/service/subscription/state/PartitionDataTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/state/PartitionDataTest.java
@@ -48,7 +48,7 @@ public class PartitionDataTest {
     public void normalOperationShouldNotReconfigureKafkaConsumer() {
         final PartitionData pd = new PartitionData(null, createCursor(100L));
         for (long i = 0; i < 100; ++i) {
-            pd.addEvent(new ConsumedEvent("test_" + i, createCursor(100L + i + 1)));
+            pd.addEvent(new ConsumedEvent(("test_" + i).getBytes(), createCursor(100L + i + 1)));
         }
         // Now say to it that it was sent
         pd.takeEventsToStream(currentTimeMillis(), 1000, 0L);
@@ -68,7 +68,7 @@ public class PartitionDataTest {
             pd.takeEventsToStream(currentTimeMillis(), 10, 0L);
             assertEquals(i + 1, pd.getKeepAliveInARow());
         }
-        pd.addEvent(new ConsumedEvent("", createCursor(101L)));
+        pd.addEvent(new ConsumedEvent("".getBytes(), createCursor(101L)));
         assertEquals(100, pd.getKeepAliveInARow());
         pd.takeEventsToStream(currentTimeMillis(), 10, 0L);
         assertEquals(0, pd.getKeepAliveInARow());
@@ -81,7 +81,7 @@ public class PartitionDataTest {
         final long timeout = TimeUnit.SECONDS.toMillis(1);
         final PartitionData pd = new PartitionData(null, createCursor(100L));
         for (int i = 0; i < 100; ++i) {
-            pd.addEvent(new ConsumedEvent("test", createCursor(i + 100L + 1)));
+            pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i + 100L + 1)));
         }
         List<ConsumedEvent> data = pd.takeEventsToStream(currentTimeMillis(), 1000, timeout);
         assertNull(data);
@@ -93,7 +93,7 @@ public class PartitionDataTest {
         assertEquals(100, data.size());
 
         for (int i = 100; i < 200; ++i) {
-            pd.addEvent(new ConsumedEvent("test", createCursor(i + 100L + 1)));
+            pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i + 100L + 1)));
         }
         data = pd.takeEventsToStream(currentTimeMillis(), 1000, timeout);
         assertNull(data);
@@ -110,7 +110,7 @@ public class PartitionDataTest {
         final long timeout = TimeUnit.SECONDS.toMillis(1);
         final PartitionData pd = new PartitionData(null, createCursor(100L));
         for (int i = 0; i < 100; ++i) {
-            pd.addEvent(new ConsumedEvent("test", createCursor(i + 100L + 1)));
+            pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i + 100L + 1)));
         }
         assertNull(pd.takeEventsToStream(currentTimeMillis(), 1000, timeout));
         final List<ConsumedEvent> eventsToStream = pd.takeEventsToStream(currentTimeMillis(), 99, timeout);


### PR DESCRIPTION
*This is a complimentary PR. It was not implemented in the original one and is out of the scope of the task. But I felt like it would be a valuable contribution.*

In order to reduce the unecessary allocation of String objects, we are
going to adopt Kafka byte array deserializer on the consumption path.

We expect to alleviate GC with this change.