### PR TITLE
Do not override flow_id when present

### DIFF
--- a/src/main/java/org/zalando/nakadi/enrichment/MetadataEnrichmentStrategy.java
+++ b/src/main/java/org/zalando/nakadi/enrichment/MetadataEnrichmentStrategy.java
@@ -30,7 +30,7 @@ public class MetadataEnrichmentStrategy implements EnrichmentStrategy {
     }
 
     private void setFlowId(final JSONObject metadata) {
-        if (metadata.optString("flow_id") == null || "".equals(metadata.optString("flow_id"))) {
+        if ("".equals(metadata.optString("flow_id"))) {
             metadata.put("flow_id", FlowIdUtils.peek());
         }
     }

--- a/src/main/java/org/zalando/nakadi/enrichment/MetadataEnrichmentStrategy.java
+++ b/src/main/java/org/zalando/nakadi/enrichment/MetadataEnrichmentStrategy.java
@@ -30,7 +30,9 @@ public class MetadataEnrichmentStrategy implements EnrichmentStrategy {
     }
 
     private void setFlowId(final JSONObject metadata) {
-        metadata.put("flow_id", FlowIdUtils.peek());
+        if (metadata.optString("flow_id") == null || "".equals(metadata.optString("flow_id"))) {
+            metadata.put("flow_id", FlowIdUtils.peek());
+        }
     }
 
     private void setEventTypeName(final JSONObject metadata, final EventType eventType) {

--- a/src/test/java/org/zalando/nakadi/enrichment/MetadataEnrichmentStrategyTest.java
+++ b/src/test/java/org/zalando/nakadi/enrichment/MetadataEnrichmentStrategyTest.java
@@ -91,6 +91,34 @@ public class MetadataEnrichmentStrategyTest {
     }
 
     @Test
+    public void whenFlowIdIsPresentDoNotOverride() throws Exception {
+        final EventType eventType = buildDefaultEventType();
+        final JSONObject event = buildBusinessEvent();
+        event.getJSONObject("metadata").put("flow_id", "something");
+        final BatchItem batch = createBatchItem(event);
+
+        final String flowId = randomString();
+        FlowIdUtils.push(flowId);
+        strategy.enrich(batch, eventType);
+
+        assertThat(batch.getEvent().getJSONObject("metadata").getString("flow_id"), equalTo("something"));
+    }
+
+    @Test
+    public void whenFlowIsEmptyStringOverrideIt() throws Exception {
+        final EventType eventType = buildDefaultEventType();
+        final JSONObject event = buildBusinessEvent();
+        event.getJSONObject("metadata").put("flow_id", "");
+        final BatchItem batch = createBatchItem(event);
+
+        final String flowId = randomString();
+        FlowIdUtils.push(flowId);
+        strategy.enrich(batch, eventType);
+
+        assertThat(batch.getEvent().getJSONObject("metadata").getString("flow_id"), equalTo(flowId));
+    }
+
+    @Test
     public void setPartition() throws Exception {
         final EventType eventType = buildDefaultEventType();
         final JSONObject event = buildBusinessEvent();

--- a/src/test/java/org/zalando/nakadi/enrichment/MetadataEnrichmentStrategyTest.java
+++ b/src/test/java/org/zalando/nakadi/enrichment/MetadataEnrichmentStrategyTest.java
@@ -119,6 +119,20 @@ public class MetadataEnrichmentStrategyTest {
     }
 
     @Test
+    public void whenFlowIsNullOverrideIt() throws Exception {
+        final EventType eventType = buildDefaultEventType();
+        final JSONObject event = buildBusinessEvent();
+        event.getJSONObject("metadata").put("flow_id", (Object)null);
+        final BatchItem batch = createBatchItem(event);
+
+        final String flowId = randomString();
+        FlowIdUtils.push(flowId);
+        strategy.enrich(batch, eventType);
+
+        assertThat(batch.getEvent().getJSONObject("metadata").getString("flow_id"), equalTo(flowId));
+    }
+
+    @Test
     public void setPartition() throws Exception {
         final EventType eventType = buildDefaultEventType();
         final JSONObject event = buildBusinessEvent();

--- a/src/test/java/org/zalando/nakadi/enrichment/MetadataEnrichmentStrategyTest.java
+++ b/src/test/java/org/zalando/nakadi/enrichment/MetadataEnrichmentStrategyTest.java
@@ -97,8 +97,7 @@ public class MetadataEnrichmentStrategyTest {
         event.getJSONObject("metadata").put("flow_id", "something");
         final BatchItem batch = createBatchItem(event);
 
-        final String flowId = randomString();
-        FlowIdUtils.push(flowId);
+        FlowIdUtils.push("something-else");
         strategy.enrich(batch, eventType);
 
         assertThat(batch.getEvent().getJSONObject("metadata").getString("flow_id"), equalTo("something"));


### PR DESCRIPTION
Nakadi used to expect the flow_id to be taken from a header but not even
a single user was happy that their flow_id has been
overriten. E.g. users do not expect their event to be changed if they
are sending something already.

It's also a general guideline from Nakadi, not to "enrich" events,
always favoring user defined data. We do not change users data and this
bug broke this commitment.

Fixes #391