### PR TITLE
ARUHA-654: Fix swagger format to build manual

### DIFF
--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -666,7 +666,7 @@ paths:
           schema:
             type: array
             items:
-              - $ref: '#/definitions/Cursor'
+              $ref: '#/definitions/Cursor'
       responses:
         '200':
           description: OK
@@ -836,7 +836,7 @@ paths:
             schema:
               type: array
               items:
-                - $ref: '#/definitions/ShiftedCursor'
+                $ref: '#/definitions/ShiftedCursor'
         responses:
           '200':
             description: OK


### PR DESCRIPTION
[ARUHA-654: Update API documentation in nakadi-manual](https://techjira.zalando.net/browse/ARUHA-654)

## Description
The was some errors in Nakdi Open API(swagger) file 
that prevent building API part of Nakadi manual.
The command  `swagger2markup-cli` was failing with the exception:
```
Exception in thread "main" java.lang.NullPointerException: property must not be null
	at org.apache.commons.lang3.Validate.notNull(Validate.java:222)
	at io.github.swagger2markup.internal.adapter.PropertyAdapter.<init>(PropertyAdapter.java:40)
	at io.github.swagger2markup.internal.utils.ModelUtils.getType(ModelUtils.java:120)
	at io.github.swagger2markup.internal.adapter.ParameterAdapter.getType(ParameterAdapter.java:163)
	at io.github.swagger2markup.internal.adapter.ParameterAdapter.<init>(ParameterAdapter.java:57)
	at ...
``` 

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
None
