### PR TITLE
ARUHA-654: Fix. OpenAPI creates broken link in the Nakadi manual.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `Nakadi` will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- The metrics endpoint documentation key "summary" changed to "description" in Open API file.
+
 ## [1.0.1] - 2017-07-14
 
 ### Fixed

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -103,7 +103,7 @@ paths:
     get:
       tags:
         - monitoring
-      summary: Get monitoring metrics
+      description: Get monitoring metrics
       responses:
         '200':
           description: Ok


### PR DESCRIPTION
ARUHA-654:Update API documentation in nakadi-manual

## Description
If summary present in the OpenAPI file the swagger2markdown uses the summary instead of endpoint name as an anchor.
The script that generates Index files uses only the endpoint name.
It is better to unify the API and use "description" everywhere.

## Review
- [x] Tests
- [x] Documentation
- [x] CHANGELOG
