### PR TITLE
ARUHA-906: Fix wrong formatting in swagger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - The metrics endpoint documentation key "summary" changed to "description" in Open API file.
 
+### Fixed
+- Fixed formatting of CursorDistanceResult in Open API file.
+
 ## [1.0.1] - 2017-07-14
 
 ### Fixed

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1947,7 +1947,7 @@ definitions:
   CursorDistanceResult:
     allOf:
       - $ref: '#/definitions/CursorDistanceQuery'
-      - type: Object        
+      - type: object        
         properties:
           distance:
             type: number

--- a/api/nakadi-event-bus-api.yaml
+++ b/api/nakadi-event-bus-api.yaml
@@ -1947,16 +1947,16 @@ definitions:
   CursorDistanceResult:
     allOf:
       - $ref: '#/definitions/CursorDistanceQuery'
-    required:
-      - distance
-    properties:
-      distance:
-        type: number
-        format: int64
-        description: |
-          Number of events between two offsets. Initial offset is exclusive. It's only zero when both provided offsets
-          are equal.
-
+      - type: Object        
+        properties:
+          distance:
+            type: number
+            format: int64
+            description: |
+              Number of events between two offsets. Initial offset is exclusive. It's only zero when both provided offsets
+              are equal.
+        required:
+          - distance
   Cursor:
     required:
       - partition


### PR DESCRIPTION
ARUHA-906: Merge Documentation
https://techjira.zalando.net/browse/ARUHA-906


## Description
Tha parser was failing to parse this part of swagger in CursorDistanceResult.
The ident level was wrong.

## Review
- [x] Tests
- [x] Documentation
- [x] CHANGELOG
