### PR TITLE
aruha-876: updated kafka client version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.1.2] - 2017-08-01
 
-### Added
+### Changed
 - Updated kafka client library to 0.10.1.0
 
 ## [1.1.1] - 2017-07-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.2] - 2017-08-01
+
+### Added
+- Updated kafka client library to 0.10.1.0
+
 ## [1.1.1] - 2017-07-26
 
 ### Fixed


### PR DESCRIPTION
Updated kafka client version due to migration

[ARUHA-876: Upgrade Nakadi Kafka client to 0.10.1.0](https://techjira.zalando.net/browse/ARUHA-876)

## Description
Updated kafka client due to migration 

## Review
- [x] CHANGELOG

