### PR TITLE
aruha-1083 change Tomcat by Jetty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Using Jetty instead of Tomcat as Servlet container.
+
+### Fixed
+- Using Jetty fixes a rare concurrency issue that could deliver messages to the wrong stream.
+
 ## [2.0.1] - 2017-08-11
 
 ### Fixed

--- a/build.gradle
+++ b/build.gradle
@@ -108,11 +108,13 @@ dependencies {
     compile("org.springframework.boot:spring-boot-starter-web:$springBootVersion") {
         exclude module: 'logback-classic'
         exclude module: 'log4j-over-slf4j'
+        exclude module: 'spring-boot-starter-tomcat'
     }
     compile "org.springframework:spring-context:$springFrameworkVersion"
     compile "org.springframework:spring-web:$springFrameworkVersion"
     compile "org.springframework:spring-webmvc:$springFrameworkVersion"
     compile "org.springframework.boot:spring-boot-test:$springBootVersion"
+    compile "org.springframework.boot:spring-boot-starter-jetty:$springBootVersion"
 
     // oauth
     compile 'org.springframework.security.oauth:spring-security-oauth2:2.1.0.RELEASE'

--- a/src/main/java/org/zalando/nakadi/config/JettyConfig.java
+++ b/src/main/java/org/zalando/nakadi/config/JettyConfig.java
@@ -15,7 +15,8 @@ public class JettyConfig {
             @Value("${jetty.threadPool.maxThreads:200}") final String maxThreads,
             @Value("${jetty.threadPool.minThreads:8}") final String minThreads,
             @Value("${jetty.threadPool.idleTimeout:60000}") final String idleTimeout) {
-        final JettyEmbeddedServletContainerFactory factory =  new JettyEmbeddedServletContainerFactory(Integer.valueOf(port));
+        final JettyEmbeddedServletContainerFactory factory =
+                new JettyEmbeddedServletContainerFactory(Integer.valueOf(port));
         factory.addServerCustomizers((JettyServerCustomizer) server -> {
             final QueuedThreadPool threadPool = server.getBean(QueuedThreadPool.class);
             threadPool.setMaxThreads(Integer.valueOf(maxThreads));

--- a/src/main/java/org/zalando/nakadi/config/JettyConfig.java
+++ b/src/main/java/org/zalando/nakadi/config/JettyConfig.java
@@ -1,0 +1,27 @@
+package org.zalando.nakadi.config;
+
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.embedded.jetty.JettyEmbeddedServletContainerFactory;
+import org.springframework.boot.context.embedded.jetty.JettyServerCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JettyConfig {
+    @Bean
+    public JettyEmbeddedServletContainerFactory jettyEmbeddedServletContainerFactory(
+            @Value("${server.port:8080}") final String port,
+            @Value("${jetty.threadPool.maxThreads:200}") final String maxThreads,
+            @Value("${jetty.threadPool.minThreads:8}") final String minThreads,
+            @Value("${jetty.threadPool.idleTimeout:60000}") final String idleTimeout) {
+        final JettyEmbeddedServletContainerFactory factory =  new JettyEmbeddedServletContainerFactory(Integer.valueOf(port));
+        factory.addServerCustomizers((JettyServerCustomizer) server -> {
+            final QueuedThreadPool threadPool = server.getBean(QueuedThreadPool.class);
+            threadPool.setMaxThreads(Integer.valueOf(maxThreads));
+            threadPool.setMinThreads(Integer.valueOf(minThreads));
+            threadPool.setIdleTimeout(Integer.valueOf(idleTimeout));
+        });
+        return factory;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,11 @@ logging:
     org.apache.kafka: WARN
     org.zalando.nakadi: DEBUG
     org.zalando.nakadi.config: INFO
+jetty:
+  threadPool:
+    maxThreads: 200
+    minThreads: 8
+    idleTimeout: 60000
 spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/local_nakadi_db


### PR DESCRIPTION
[ARUHA-1083: Deploy Nakadi with Jetty](https://techjira.zalando.net/browse/ARUHA-1083)

## Description
This PR replaces Tomcat by Jetty as the default servlet container. The main motivation is to solve a rare but critical concurrency bug that could lead to wrong event delivery. The investigation is detailed in this [postmortem](https://docs.google.com/document/d/1d1ryipAuUGUqOYAfZBhQZRiQTT5BnVce4BOiHJU61vM/edit).

As a positive side effect, we also observed much lower CPU usage with Jetty.

## Review
- [ ] Tests
- [ ] Documentation
- [x] CHANGELOG

## Deployment Notes
No special deployment instruction. But since it changes a significant component, we should first try it with a smaller part of traffic before shipping to all users.
