### PR TITLE
aruha-1083 fix gzip flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Sync flush batches when using gzip streams.
+
 ## [2.1.0] - 2017-08-21
 
 ### Changed

--- a/src/main/java/org/zalando/nakadi/config/JettyConfig.java
+++ b/src/main/java/org/zalando/nakadi/config/JettyConfig.java
@@ -1,5 +1,6 @@
 package org.zalando.nakadi.config;
 
+import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.embedded.jetty.JettyEmbeddedServletContainerFactory;
@@ -22,6 +23,11 @@ public class JettyConfig {
             threadPool.setMaxThreads(Integer.valueOf(maxThreads));
             threadPool.setMinThreads(Integer.valueOf(minThreads));
             threadPool.setIdleTimeout(Integer.valueOf(idleTimeout));
+
+            final GzipHandler gzipHandler = new GzipHandler();
+            gzipHandler.setHandler(server.getHandler());
+            gzipHandler.setSyncFlush(true);
+            server.setHandler(gzipHandler);
         });
         return factory;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,5 @@
 server:
   port: 8080
-  compression:
-    enabled: true
-    mime-types: text/plain,application/x-json-stream
 management:
   port: 7979
 logging:


### PR DESCRIPTION
## Description
This is a continuation from https://github.com/zalando/nakadi/pull/732

By default, Jetty output stream flushing behaves differently from Tomcat
when using compression. Calling flush would not cause the actual bytes
to be immediately flushed. This change in behaviour introduced a
problem, where subscription consumers would not get batches on time in
order to commit them. This way, their connections would be constantly
closed and they were not able to make progress.

With this change, all batches are flushed to the wire at the exact same
time as they used to be before switching to Jetty.

## Review
- [ ] Tests
- [ ] Documentation
- [x] CHANGELOG

