### PR TITLE
Add go-nakadi library to the list of Nakadi clients

### DIFF
--- a/docs/_documentation/using_clients.md
+++ b/docs/_documentation/using_clients.md
@@ -15,6 +15,7 @@ Nakadi does not ship with a client, but there are some open source clients avail
 | Fahrschein      | Java               | https://github.com/zalando-nakadi/fahrschein      |
 | Nakadion        | Rust               | https://github.com/chridou/nakadion               |
 | Peek            | Java/CLI tool      | https://github.com/bocytko/peek                   |
+| go-nakadi       | Go                 | https://github.com/stoewer/go-nakadi              |
 
 More Nakadi related projects can be found here [https://github.com/zalando-nakadi](https://github.com/zalando-nakadi)
 


### PR DESCRIPTION
## Description

The [`go-nakadi`](https://github.com/stoewer/go-nakadi) package provides a Nakadi client library for the Go programming language. Although the project is rather new, the client still provides a feature rich and well tested API. It would be great if the Nakadi maintainers could have a look at the `go-nakadi` package and add it to the list of available clients in Nakadi's documentation. Every feedback on `go-nakadi` is very welcome.

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
Just an amendment for the documentation, nothing special here.
