### PR TITLE
#751 Mention nakadi-client for Haskell in the manual

### DIFF
--- a/docs/_documentation/using_clients.md
+++ b/docs/_documentation/using_clients.md
@@ -15,6 +15,7 @@ Nakadi does not ship with a client, but there are some open source clients avail
 | Fahrschein      | Java               | https://github.com/zalando-nakadi/fahrschein      |
 | Nakadion        | Rust               | https://github.com/chridou/nakadion               |
 | Peek            | Java/CLI tool      | https://github.com/bocytko/peek                   |
+| nakadi-client   | Haskell            | https://hackage.haskell.org/package/nakadi-client |
 
 More Nakadi related projects can be found here [https://github.com/zalando-nakadi](https://github.com/zalando-nakadi)
 


### PR DESCRIPTION
[ARUHA-751: Add Nakadi Client Library for Haskell to the Manual](https://github.com/zalando/nakadi/issues/751)

## Description

Documentation improvement. Mentions another Nakadi client library.

## Review
- [x] ~Tests~
- [x] Documentation
- [x] CHANGELOG

## Deployment Notes
n/a
