### PR TITLE
aruha-984: create first timeline for event type by default

### DIFF
--- a/database/migration/aruha-984-remove-topic-from-et.sql
+++ b/database/migration/aruha-984-remove-topic-from-et.sql
@@ -1,0 +1,3 @@
+SET ROLE zalando_nakadi_data_owner;
+ALTER TABLE zn_data.event_type DROP COLUMN IF EXISTS et_topic;
+DROP INDEX zn_data.idx_et_topic;

--- a/database/nakadi/10_data/04_tables/01_event_type.sql
+++ b/database/nakadi/10_data/04_tables/01_event_type.sql
@@ -1,10 +1,7 @@
 CREATE TABLE IF NOT EXISTS zn_data.event_type (
   et_name varchar(255) NOT NULL PRIMARY KEY CHECK (et_name <> ''),
-  et_topic varchar(255) NOT NULL,
   et_event_type_object jsonb NOT NULL,
   CHECK (et_event_type_object->>'name' = et_name)
 );
 
 CREATE INDEX ON zn_data.event_type USING gin (et_event_type_object);
-
-CREATE UNIQUE INDEX idx_et_topic ON zn_data.event_type (et_topic);

--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -1675,42 +1675,6 @@ paths:
           schema:
             $ref: '#/definitions/Problem'
 
-  /event-types/{name}/timelines/{id}:
-    delete:
-      tags:
-        - timelines-api
-      description: |
-        Deletes a timeline if there is only one timeline.
-        The oauth resource owner username has to be equal to 'nakadi.oauth2.adminClientId' property
-        to be able to access this endpoint.
-      parameters:
-        - name: name
-          in: path
-          description: Name of the EventType.
-          type: string
-          required: true
-        - name: id
-          in: path
-          description: timeline id
-          type: string
-          format: uuid
-          required: true
-      responses:
-        '200':
-          description: Timeline was deleted
-        '404':
-          description: No such event type or timeline id
-          schema:
-            $ref: '#/definitions/Problem'
-        '422':
-          description: could not delete timeline, because there is more than one timeline
-          schema:
-            $ref: '#/definitions/Problem'
-        '403':
-          description: Access forbidden
-          schema:
-            $ref: '#/definitions/Problem'
-
 # ################################### #
 #                                     #
 #             Definitions             #

--- a/docs/_documentation/architecture_timelines.md
+++ b/docs/_documentation/architecture_timelines.md
@@ -10,28 +10,6 @@ This document covers Timelines internals. It's meant to explain how
 timelines work, to help you understand the code and what each part of
 it contributes to the overall picture.
 
-### Fake timeline: your first timeline
-
-Before timelines, Nakadi would connect to a single Kafka cluster,
-which used to be specified in the application yaml file. This was a
-static configuration loaded during boot time. Once timelines were
-introduced, in order to ease the migration process and remove special
-cases from the implementation, a fake timeline was introduced.
-
-Fake timelines ease the transition from existent event types. The
-migration process is as follow:
-
-0. Initial state: all event types are associated to a Fake timeline.
-1. Create first real timeline: this step creates an entry in the
-   timeline table. But this timeline is still bound to the existent
-   storage. The only difference from a Fake timeline to the first Real
-   timeline is in the cursor format. With a Fake timeline, the old
-   version is used, i.e. "0000000000000001". Once a Real timeline is
-   created, this offset is exposed as "001-0001-000000000000000001".
-2. A second timeline is created: this timeline should have a different
-   storage and different topic is going to be created by Nakadi for
-   this event type.
-
 ### Timeline creation
 
 Timeline creation is coordinated through a series of locks and

--- a/src/acceptance-test/java/org/zalando/nakadi/repository/db/EventTypeCacheTestAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/repository/db/EventTypeCacheTestAT.java
@@ -26,7 +26,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
@@ -152,21 +151,6 @@ public class EventTypeCacheTestAT {
                 },
                 new RetryForSpecifiedTimeStrategy<Void>(5000).withExceptionsThatForceRetry(AssertionError.class)
                         .withWaitBetweenEachTry(500));
-    }
-
-    @Test
-    public void testGetActiveTimeline() throws Exception {
-        final EventTypeCache etc = new RepositoriesConfig()
-                .eventTypeCache(client, eventTypeRepository, timelineRepository, timelineSync);
-        final EventType et = buildDefaultEventType();
-
-        Mockito.when(timelineRepository.listTimelinesOrdered(et.getName()))
-                .thenReturn(getMockedTimelines(et.getName()));
-        Mockito.doReturn(et).when(eventTypeRepository).findByName(et.getName());
-
-        etc.created(et.getName());
-        final Optional<Timeline> timeline = etc.getActiveTimeline(et.getName());
-        Assert.assertEquals(1, timeline.get().getOrder());
     }
 
     @Test

--- a/src/acceptance-test/java/org/zalando/nakadi/repository/db/SchemaRepositoryTest.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/repository/db/SchemaRepositoryTest.java
@@ -81,11 +81,10 @@ public class SchemaRepositoryTest extends AbstractDbRepositoryTest {
     }
 
     private void insertEventType(final EventType eventType) throws Exception {
-        final String insertSQL = "INSERT INTO zn_data.event_type (et_name, et_topic, et_event_type_object) " +
-                "VALUES (?, ?, to_json(?::json))";
+        final String insertSQL = "INSERT INTO zn_data.event_type (et_name, et_event_type_object) " +
+                "VALUES (?, to_json(?::json))";
         template.update(insertSQL,
                 eventType.getName(),
-                eventType.getTopic(),
                 TestUtils.OBJECT_MAPPER.writer().writeValueAsString(eventType));
     }
 

--- a/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaTestHelper.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaTestHelper.java
@@ -67,12 +67,12 @@ public class KafkaTestHelper {
                 .stream()
                 .map(cursor -> {
                     if ("0".equals(cursor.getOffset())) {
-                        return new Cursor(cursor.getPartition(), Cursor.BEFORE_OLDEST_OFFSET);
+                        return new Cursor(cursor.getPartition(), "001-0001--1");
                     }
                     else {
                         final long lastEventOffset = toKafkaOffset(cursor.getOffset()) - 1;
-                        return new Cursor(cursor.getPartition(),
-                                StringUtils.leftPad(toNakadiOffset(lastEventOffset), CURSOR_OFFSET_LENGTH, '0'));
+                        String offset = StringUtils.leftPad(toNakadiOffset(lastEventOffset), CURSOR_OFFSET_LENGTH, '0');
+                        return new Cursor(cursor.getPartition(), String.format("001-0001-%s", offset));
                     }
                 })
                 .collect(Collectors.toList());

--- a/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaTestHelper.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaTestHelper.java
@@ -71,7 +71,8 @@ public class KafkaTestHelper {
                     }
                     else {
                         final long lastEventOffset = toKafkaOffset(cursor.getOffset()) - 1;
-                        String offset = StringUtils.leftPad(toNakadiOffset(lastEventOffset), CURSOR_OFFSET_LENGTH, '0');
+                        final String offset = StringUtils.leftPad(toNakadiOffset(lastEventOffset),
+                                CURSOR_OFFSET_LENGTH, '0');
                         return new Cursor(cursor.getPartition(), String.format("001-0001-%s", offset));
                     }
                 })

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/BlockEventPublishingAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/BlockEventPublishingAT.java
@@ -10,12 +10,12 @@ import org.junit.Test;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.service.BlacklistService;
 import org.zalando.nakadi.utils.EventTypeTestBuilder;
+import org.zalando.nakadi.webservice.utils.NakadiTestUtils;
 
 import java.io.IOException;
 import java.text.MessageFormat;
 
 import static com.jayway.restassured.RestAssured.given;
-import static com.jayway.restassured.http.ContentType.JSON;
 import static org.zalando.nakadi.utils.TestUtils.waitFor;
 
 public class BlockEventPublishingAT extends BaseAT {
@@ -25,12 +25,7 @@ public class BlockEventPublishingAT extends BaseAT {
     @Before
     public void setUp() throws JsonProcessingException {
         eventType = EventTypeTestBuilder.builder().build();
-//        NakadiTestUtils.createEventTypeInNakadi(eventType);
-        given()
-                .body(MAPPER.writeValueAsString(eventType))
-                .contentType(JSON)
-                .post("/event-types")
-                .statusCode();
+        NakadiTestUtils.createEventTypeInNakadi(eventType);
     }
 
     @Test

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/BlockEventPublishingAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/BlockEventPublishingAT.java
@@ -10,12 +10,12 @@ import org.junit.Test;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.service.BlacklistService;
 import org.zalando.nakadi.utils.EventTypeTestBuilder;
-import org.zalando.nakadi.webservice.utils.NakadiTestUtils;
 
 import java.io.IOException;
 import java.text.MessageFormat;
 
 import static com.jayway.restassured.RestAssured.given;
+import static com.jayway.restassured.http.ContentType.JSON;
 import static org.zalando.nakadi.utils.TestUtils.waitFor;
 
 public class BlockEventPublishingAT extends BaseAT {
@@ -25,7 +25,12 @@ public class BlockEventPublishingAT extends BaseAT {
     @Before
     public void setUp() throws JsonProcessingException {
         eventType = EventTypeTestBuilder.builder().build();
-        NakadiTestUtils.createEventTypeInNakadi(eventType);
+//        NakadiTestUtils.createEventTypeInNakadi(eventType);
+        given()
+                .body(MAPPER.writeValueAsString(eventType))
+                .contentType(JSON)
+                .post("/event-types")
+                .statusCode();
     }
 
     @Test

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/CursorOperationsAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/CursorOperationsAT.java
@@ -35,8 +35,8 @@ public class CursorOperationsAT {
                 .then()
                 .statusCode(OK.value())
                 .body("size()", equalTo(1))
-                .body("newest_available_offset[0]", equalTo("BEGIN"))
-                .body("oldest_available_offset[0]", equalTo("000000000000000000"))
+                .body("newest_available_offset[0]", equalTo("001-0001--1"))
+                .body("oldest_available_offset[0]", equalTo("001-0001-000000000000000000"))
                 .body("unconsumed_events[0]", equalTo(0));
 
         postEvents(eventType.getName(), EVENT, EVENT);
@@ -49,8 +49,8 @@ public class CursorOperationsAT {
                 .then()
                 .statusCode(OK.value())
                 .body("size()", equalTo(1))
-                .body("newest_available_offset[0]", equalTo("000000000000000001"))
-                .body("oldest_available_offset[0]", equalTo("000000000000000000"))
+                .body("newest_available_offset[0]", equalTo("001-0001-000000000000000001"))
+                .body("oldest_available_offset[0]", equalTo("001-0001-000000000000000000"))
                 .body("unconsumed_events[0]", equalTo(2));
 
         NakadiTestUtils.switchTimelineDefaultStorage(eventType);
@@ -91,7 +91,7 @@ public class CursorOperationsAT {
                 .then()
                 .statusCode(OK.value())
                 .body("size()", equalTo(1))
-                .body("newest_available_offset[0]", equalTo("001-0002-000000000000000001"))
+                .body("newest_available_offset[0]", equalTo("001-0003-000000000000000001"))
                 .body("oldest_available_offset[0]", equalTo("001-0001-000000000000000000"))
                 .body("unconsumed_events[0]", equalTo(4));
 
@@ -105,7 +105,7 @@ public class CursorOperationsAT {
                 .then()
                 .statusCode(OK.value())
                 .body("size()", equalTo(1))
-                .body("newest_available_offset[0]", equalTo("001-0002-000000000000000001"))
+                .body("newest_available_offset[0]", equalTo("001-0003-000000000000000001"))
                 .body("oldest_available_offset[0]", equalTo("001-0001-000000000000000000"))
                 .body("unconsumed_events[0]", equalTo(4));
 
@@ -119,7 +119,7 @@ public class CursorOperationsAT {
                 .then()
                 .statusCode(OK.value())
                 .body("size()", equalTo(1))
-                .body("newest_available_offset[0]", equalTo("001-0003-000000000000000002"))
+                .body("newest_available_offset[0]", equalTo("001-0004-000000000000000002"))
                 .body("oldest_available_offset[0]", equalTo("001-0001-000000000000000000"))
                 .body("unconsumed_events[0]", equalTo(7));
 
@@ -131,7 +131,7 @@ public class CursorOperationsAT {
                 .then()
                 .statusCode(OK.value())
                 .body("size()", equalTo(1))
-                .body("newest_available_offset[0]", equalTo("001-0003-000000000000000002"))
+                .body("newest_available_offset[0]", equalTo("001-0004-000000000000000002"))
                 .body("oldest_available_offset[0]", equalTo("001-0001-000000000000000000"))
                 .body("unconsumed_events[0]", equalTo(6));
     }
@@ -146,7 +146,7 @@ public class CursorOperationsAT {
                 .then()
                 .statusCode(OK.value())
                 .body("size()", equalTo(1))
-                .body("offset[0]", equalTo("BEGIN"))
+                .body("offset[0]", equalTo("001-0001--1"))
                 .body("partition[0]", equalTo("0"));
 
         NakadiTestUtils.switchTimelineDefaultStorage(eventType);
@@ -180,7 +180,7 @@ public class CursorOperationsAT {
                 .then()
                 .statusCode(OK.value())
                 .body("size()", equalTo(1))
-                .body("offset[0]", equalTo("001-0001-000000000000000000"))
+                .body("offset[0]", equalTo("001-0002-000000000000000000"))
                 .body("partition[0]", equalTo("0"));
 
         RestAssured.given()
@@ -191,7 +191,7 @@ public class CursorOperationsAT {
                 .then()
                 .statusCode(OK.value())
                 .body("size()", equalTo(1))
-                .body("offset[0]", equalTo("001-0001-000000000000000001"))
+                .body("offset[0]", equalTo("001-0002-000000000000000001"))
                 .body("partition[0]", equalTo("0"));
 
         RestAssured.given()
@@ -202,7 +202,7 @@ public class CursorOperationsAT {
                 .then()
                 .statusCode(OK.value())
                 .body("size()", equalTo(1))
-                .body("offset[0]", equalTo("001-0001-000000000000000002"))
+                .body("offset[0]", equalTo("001-0002-000000000000000002"))
                 .body("partition[0]", equalTo("0"));
 
         NakadiTestUtils.switchTimelineDefaultStorage(eventType);
@@ -217,7 +217,7 @@ public class CursorOperationsAT {
                 .then()
                 .statusCode(OK.value())
                 .body("size()", equalTo(1))
-                .body("offset[0]", equalTo("001-0002-000000000000000000"))
+                .body("offset[0]", equalTo("001-0003-000000000000000000"))
                 .body("partition[0]", equalTo("0"));
 
         RestAssured.given()
@@ -228,12 +228,34 @@ public class CursorOperationsAT {
                 .then()
                 .statusCode(OK.value())
                 .body("size()", equalTo(1))
-                .body("offset[0]", equalTo("001-0002-000000000000000001"))
+                .body("offset[0]", equalTo("001-0003-000000000000000001"))
                 .body("partition[0]", equalTo("0"));
 
         RestAssured.given()
                 .contentType(ContentType.JSON)
-                .body("[{\"partition\": \"0\", \"offset\":\"001-0002-000000000000000001\", \"shift\":-1}]")
+                .body("[{\"partition\": \"0\", \"offset\":\"001-0003-000000000000000001\", \"shift\":-1}]")
+                .when()
+                .post("/event-types/" + eventType.getName() + "/shifted-cursors")
+                .then()
+                .statusCode(OK.value())
+                .body("size()", equalTo(1))
+                .body("offset[0]", equalTo("001-0003-000000000000000000"))
+                .body("partition[0]", equalTo("0"));
+
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("[{\"partition\": \"0\", \"offset\":\"001-0003-000000000000000001\", \"shift\":-2}]")
+                .when()
+                .post("/event-types/" + eventType.getName() + "/shifted-cursors")
+                .then()
+                .statusCode(OK.value())
+                .body("size()", equalTo(1))
+                .body("offset[0]", equalTo("001-0003--1"))
+                .body("partition[0]", equalTo("0"));
+
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body("[{\"partition\": \"0\", \"offset\":\"001-0003-000000000000000001\", \"shift\":-3}]")
                 .when()
                 .post("/event-types/" + eventType.getName() + "/shifted-cursors")
                 .then()
@@ -244,35 +266,13 @@ public class CursorOperationsAT {
 
         RestAssured.given()
                 .contentType(ContentType.JSON)
-                .body("[{\"partition\": \"0\", \"offset\":\"001-0002-000000000000000001\", \"shift\":-2}]")
+                .body("[{\"partition\": \"0\", \"offset\":\"001-0003-000000000000000001\", \"shift\":-4}]")
                 .when()
                 .post("/event-types/" + eventType.getName() + "/shifted-cursors")
                 .then()
                 .statusCode(OK.value())
                 .body("size()", equalTo(1))
-                .body("offset[0]", equalTo("001-0001-000000000000000001"))
-                .body("partition[0]", equalTo("0"));
-
-        RestAssured.given()
-                .contentType(ContentType.JSON)
-                .body("[{\"partition\": \"0\", \"offset\":\"001-0002-000000000000000001\", \"shift\":-3}]")
-                .when()
-                .post("/event-types/" + eventType.getName() + "/shifted-cursors")
-                .then()
-                .statusCode(OK.value())
-                .body("size()", equalTo(1))
-                .body("offset[0]", equalTo("001-0001-000000000000000000"))
-                .body("partition[0]", equalTo("0"));
-
-        RestAssured.given()
-                .contentType(ContentType.JSON)
-                .body("[{\"partition\": \"0\", \"offset\":\"001-0002-000000000000000001\", \"shift\":-4}]")
-                .when()
-                .post("/event-types/" + eventType.getName() + "/shifted-cursors")
-                .then()
-                .statusCode(OK.value())
-                .body("size()", equalTo(1))
-                .body("offset[0]", equalTo("001-0001--1"))
+                .body("offset[0]", equalTo("001-0002--1"))
                 .body("partition[0]", equalTo("0"));
     }
 }

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/CursorsServiceAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/CursorsServiceAT.java
@@ -26,6 +26,7 @@ import org.zalando.nakadi.service.timeline.TimelineService;
 import org.zalando.nakadi.view.SubscriptionCursorWithoutToken;
 import org.zalando.nakadi.webservice.utils.ZookeeperTestUtils;
 
+import java.util.Date;
 import java.util.List;
 
 import static com.google.common.base.Charsets.UTF_8;
@@ -39,7 +40,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.zalando.nakadi.utils.TestUtils.createFakeTimeline;
+import static org.zalando.nakadi.utils.TestUtils.buildTimeline;
 import static org.zalando.nakadi.utils.TestUtils.randomUUID;
 import static org.zalando.nakadi.utils.TestUtils.randomValidEventTypeName;
 
@@ -60,6 +61,7 @@ public class CursorsServiceAT extends BaseAT {
 
     private static final String P1 = "p1";
     private static final String P2 = "p2";
+    private static final Date CREATED_AT = new Date();
 
     private CursorConverter cursorConverter;
     private CursorsService cursorsService;
@@ -90,10 +92,9 @@ public class CursorsServiceAT extends BaseAT {
         etName = randomValidEventTypeName();
         topic = randomUUID();
         cursorConverter = mock(CursorConverter.class);
-        testCursors = ImmutableList.of(new NakadiCursor(createFakeTimeline(etName, topic), P1, NEW_OFFSET));
+        testCursors = ImmutableList.of(new NakadiCursor(buildTimeline(etName, topic, CREATED_AT), P1, NEW_OFFSET));
 
         final EventType eventType = mock(EventType.class);
-        when(eventType.getTopic()).thenReturn(topic);
         when(eventType.getName()).thenReturn(etName);
 
         eventTypeRepository = mock(EventTypeRepository.class);
@@ -106,8 +107,8 @@ public class CursorsServiceAT extends BaseAT {
         when(topicRepository.compareOffsets(any(), any())).thenAnswer(FAKE_OFFSET_COMPARATOR);
         final TimelineService timelineService = mock(TimelineService.class);
         when(timelineService.getTopicRepository((Timeline) any())).thenReturn(topicRepository);
-        timeline = createFakeTimeline(etName, topic);
-        when(timelineService.getTimeline(any())).thenReturn(timeline);
+        timeline = buildTimeline(etName, topic, CREATED_AT);
+        when(timelineService.getActiveTimeline(any())).thenReturn(timeline);
 
         final Subscription subscription = mock(Subscription.class);
         when(subscription.getId()).thenReturn(sid);
@@ -119,10 +120,10 @@ public class CursorsServiceAT extends BaseAT {
                 mock(NakadiSettings.class), zkSubscriptionFactory, cursorConverter);
 
         // Register cursors in converter
-        registerNakadiCursor(new NakadiCursor(createFakeTimeline(etName, topic), P1, NEW_OFFSET));
-        registerNakadiCursor(new NakadiCursor(createFakeTimeline(etName, topic), P1, OLD_OFFSET));
-        registerNakadiCursor(new NakadiCursor(createFakeTimeline(etName, topic), P2, NEW_OFFSET));
-        registerNakadiCursor(new NakadiCursor(createFakeTimeline(etName, topic), P2, OLD_OFFSET));
+        registerNakadiCursor(new NakadiCursor(buildTimeline(etName, topic, CREATED_AT), P1, NEW_OFFSET));
+        registerNakadiCursor(new NakadiCursor(buildTimeline(etName, topic, CREATED_AT), P1, OLD_OFFSET));
+        registerNakadiCursor(new NakadiCursor(buildTimeline(etName, topic, CREATED_AT), P2, NEW_OFFSET));
+        registerNakadiCursor(new NakadiCursor(buildTimeline(etName, topic, CREATED_AT), P2, OLD_OFFSET));
         // bootstrap data in ZK
         CURATOR.create().creatingParentsIfNeeded().forPath(offsetPath(P1), OLD_OFFSET.getBytes(UTF_8));
         CURATOR.create().creatingParentsIfNeeded().forPath(offsetPath(P2), OLD_OFFSET.getBytes(UTF_8));
@@ -165,7 +166,7 @@ public class CursorsServiceAT extends BaseAT {
 
     @Test
     public void whenCommitOldCursorsThenFalse() throws Exception {
-        final NakadiCursor cursor = new NakadiCursor(createFakeTimeline(etName, topic), P1, OLDEST_OFFSET);
+        final NakadiCursor cursor = new NakadiCursor(buildTimeline(etName, topic, CREATED_AT), P1, OLDEST_OFFSET);
         registerNakadiCursor(cursor);
         testCursors = ImmutableList.of(cursor);
         setPartitions(new Partition[]{new Partition(etName, P1, streamId, null, Partition.State.ASSIGNED)});

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/EventStreamReadingAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/EventStreamReadingAT.java
@@ -71,7 +71,8 @@ public class EventStreamReadingAT extends BaseAT {
                 .build();
         NakadiTestUtils.createEventTypeInNakadi(eventType);
         streamEndpoint = createStreamEndpointUrl(eventType.getName());
-        topicName = BaseAT.EVENT_TYPE_REPO.findByName(eventType.getName()).getTopic();
+        // expect only one timeline, because we just created event type
+        topicName = BaseAT.TIMELINE_REPOSITORY.listTimelinesOrdered(eventType.getName()).get(0).getTopic();
     }
 
     @Before
@@ -117,8 +118,8 @@ public class EventStreamReadingAT extends BaseAT {
                 .filter(cursor -> TEST_PARTITION.equals(cursor.getPartition()))
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("Failed to find cursor for needed partition"));
-        final String expectedOffset = String.format(
-                "%018d", Long.parseLong(partitionCursor.getOffset()) - 1 + eventsPushed);
+        final String expectedOffset = TestUtils.toTimelineOffset(Long.parseLong(partitionCursor.getOffset()) - 1 +
+                eventsPushed);
 
         // check that batch has offset, partition and events number we expect
         validateBatch(batchToCheck, TEST_PARTITION, expectedOffset, eventsPushed);
@@ -190,10 +191,10 @@ public class EventStreamReadingAT extends BaseAT {
                 .filter(cursor -> TEST_PARTITION.equals(cursor.getPartition()))
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("Failed to find cursor for needed partition"));
-        final String expectedOffset1 = String.format(
-                "%018d", Long.parseLong(partitionCursor.getOffset()) - 1 + batchLimit);
-        final String expectedOffset2 = String.format(
-                "%018d", Long.parseLong(partitionCursor.getOffset()) - 1 + eventsPushed);
+        final String expectedOffset1 =
+                TestUtils.toTimelineOffset(Long.parseLong(partitionCursor.getOffset()) - 1 + batchLimit);
+        final String expectedOffset2 =
+                TestUtils.toTimelineOffset(Long.parseLong(partitionCursor.getOffset()) - 1 + eventsPushed);
 
         // check that batches have offset, partition and events number we expect
         validateBatch(batchesToCheck.get(0), TEST_PARTITION, expectedOffset1, batchLimit);

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/EventTypeAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/EventTypeAT.java
@@ -332,9 +332,6 @@ public class EventTypeAT extends BaseAT {
                 .stream()
                 .map((Timeline t) -> t.getTopic())
                 .collect(Collectors.toList());
-        if (topics.isEmpty()) {
-            topics.add(EVENT_TYPE_REPO.findByName(eventType).getTopic());
-        }
         return topics;
     }
 }

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/TimelinesControllerAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/TimelinesControllerAT.java
@@ -1,7 +1,6 @@
 package org.zalando.nakadi.webservice;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.collect.ImmutableList;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.http.ContentType;
 import org.apache.http.HttpStatus;
@@ -38,21 +37,7 @@ public class TimelinesControllerAT extends BaseAT {
     }
 
     @Test
-    public void testCreateTimelineFromFake() throws Exception {
-        NakadiTestUtils.switchTimelineDefaultStorage(eventType);
-        RestAssured.given()
-                .contentType(ContentType.JSON)
-                .get("event-types/{et_name}/timelines", eventType.getName())
-                .then()
-                .statusCode(HttpStatus.SC_OK)
-                .body("[0].event_type", Matchers.equalTo(eventType.getName()))
-                .body("[0].order", Matchers.is(1))
-                .body("[0].storage_id", Matchers.equalTo("default"));
-    }
-
-    @Test
-    public void testCreateTimelineFromReal() throws Exception {
-        NakadiTestUtils.switchTimelineDefaultStorage(eventType);
+    public void testCreateNextTimeline() throws Exception {
         NakadiTestUtils.switchTimelineDefaultStorage(eventType);
         RestAssured.given()
                 .contentType(ContentType.JSON)
@@ -69,43 +54,6 @@ public class TimelinesControllerAT extends BaseAT {
                 .body("[1].storage_id", Matchers.equalTo("default"))
                 .body("[1].switched_at", dateWithin(1, MINUTES, new DateTime()))
                 .body("[1].cleaned_up_at", nullValue());
-    }
-
-    @Test
-    public void testDeleteTimelineWhenOnlyOneTimeline() throws Exception {
-        NakadiTestUtils.switchTimelineDefaultStorage(eventType);
-        final String uuid = RestAssured.given()
-                .contentType(ContentType.JSON)
-                .get("event-types/{et_name}/timelines", eventType.getName())
-                .then()
-                .statusCode(HttpStatus.SC_OK)
-                .extract().body().path("[0].id");
-
-        RestAssured.given()
-                .contentType(ContentType.JSON)
-                .delete("event-types/{et_name}/timelines/{uuid}", eventType.getName(), uuid)
-                .then()
-                .statusCode(HttpStatus.SC_OK);
-    }
-
-    @Test
-    public void testDeleteTimelineWhenMoreThanOneTimelineThenError() throws Exception {
-        NakadiTestUtils.switchTimelineDefaultStorage(eventType);
-        NakadiTestUtils.switchTimelineDefaultStorage(eventType);
-        final String uuid = RestAssured.given()
-                .contentType(ContentType.JSON)
-                .get("event-types/{et_name}/timelines", eventType.getName())
-                .then()
-                .statusCode(HttpStatus.SC_OK)
-                .extract().body().path("[0].id");
-
-        RestAssured.given()
-                .contentType(ContentType.JSON)
-                .delete("event-types/{et_name}/timelines/{uuid}", eventType.getName(), uuid)
-                .then()
-                .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
-                .body("detail", Matchers.stringContainsInOrder(ImmutableList.of("Timeline with id:",
-                        "could not be deleted. It is possible to delete a timeline if there is only one timeline")));
     }
 
 }

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/UserJourneyAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/UserJourneyAT.java
@@ -17,8 +17,8 @@ import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.StreamMetadata;
 import org.zalando.nakadi.domain.Subscription;
 import org.zalando.nakadi.domain.SubscriptionBase;
-import org.zalando.nakadi.repository.kafka.KafkaCursor;
 import org.zalando.nakadi.utils.RandomSubscriptionBuilder;
+import org.zalando.nakadi.utils.TestUtils;
 import org.zalando.nakadi.view.SubscriptionCursor;
 import org.zalando.nakadi.webservice.hila.StreamBatch;
 import org.zalando.nakadi.webservice.utils.TestStreamingClient;
@@ -57,6 +57,15 @@ public class UserJourneyAT extends RealEnvironmentAT {
 
     private String eventTypeBody;
     private String eventTypeBodyUpdate;
+
+    public static String getEventTypeJsonFromFile(final String resourceName, final String eventTypeName,
+                                                  final String owningApp)
+            throws IOException {
+        final String json = Resources.toString(Resources.getResource(resourceName), Charsets.UTF_8);
+        return json
+                .replace("NAME_PLACEHOLDER", eventTypeName)
+                .replace("OWNING_APP_PLACEHOLDER", owningApp);
+    }
 
     @Before
     public void before() throws IOException {
@@ -131,8 +140,8 @@ public class UserJourneyAT extends RealEnvironmentAT {
                 .then()
                 .statusCode(OK.value())
                 .body("partition", equalTo("0"))
-                .body("oldest_available_offset", equalTo("000000000000000000"))
-                .body("newest_available_offset", equalTo("000000000000000001"));
+                .body("oldest_available_offset", equalTo("001-0001-000000000000000000"))
+                .body("newest_available_offset", equalTo("001-0001-000000000000000001"));
 
         // get offsets for all partitions
         jsonRequestSpec()
@@ -153,46 +162,45 @@ public class UserJourneyAT extends RealEnvironmentAT {
                 .get("/event-types/" + eventTypeName + "/events")
                 .then()
                 .statusCode(OK.value())
-                .body(equalTo("{\"cursor\":{\"partition\":\"0\",\"offset\":\"000000000000000001\"},\"events\":"
-                        + "[" + EVENT1 + "," + EVENT2 + "]}\n"));
+                .body(equalTo("{\"cursor\":{\"partition\":\"0\",\"offset\":\"001-0001-000000000000000001\"}," +
+                        "\"events\":[" + EVENT1 + "," + EVENT2 + "]}\n"));
 
         // get distance between cursors
         jsonRequestSpec()
-                .body("[{\"initial_cursor\": {\"partition\": \"0\", \"offset\":\"000000000000000000\"}, " +
-                        "\"final_cursor\": {\"partition\": \"0\", \"offset\":\"000000000000000001\"}}]")
+                .body("[{\"initial_cursor\": {\"partition\": \"0\", \"offset\":\"001-0001-000000000000000000\"}, " +
+                        "\"final_cursor\": {\"partition\": \"0\", \"offset\":\"001-0001-000000000000000001\"}}]")
                 .when()
                 .post("/event-types/" + eventTypeName + "/cursor-distances")
                 .then()
                 .statusCode(OK.value())
                 .body("size()", equalTo(1))
-                .body("initial_cursor[0].offset", equalTo("000000000000000000"))
-                .body("final_cursor[0].offset", equalTo("000000000000000001"))
+                .body("initial_cursor[0].offset", equalTo("001-0001-000000000000000000"))
+                .body("final_cursor[0].offset", equalTo("001-0001-000000000000000001"))
                 .body("distance[0]", equalTo(1));
 
         // navigate between cursors
         jsonRequestSpec()
-                .body("[{\"partition\": \"0\", \"offset\":\"000000000000000000\", \"shift\": 1}, " +
-                        "{\"partition\": \"0\", \"offset\":\"000000000000000001\", \"shift\": -1}]")
+                .body("[{\"partition\": \"0\", \"offset\":\"001-0001-000000000000000000\", \"shift\": 1}, " +
+                        "{\"partition\": \"0\", \"offset\":\"001-0001-000000000000000001\", \"shift\": -1}]")
                 .when()
                 .post("/event-types/" + eventTypeName + "/shifted-cursors")
                 .then()
                 .statusCode(OK.value())
                 .body("size()", equalTo(2))
-                .body("offset[0]", equalTo("000000000000000001"))
-                .body("offset[1]", equalTo("000000000000000000"));
+                .body("offset[0]", equalTo("001-0001-000000000000000001"))
+                .body("offset[1]", equalTo("001-0001-000000000000000000"));
 
         // query for lag
         jsonRequestSpec()
-                .body("[{\"partition\": \"0\", \"offset\":\"000000000000000000\"}]")
+                .body("[{\"partition\": \"0\", \"offset\":\"001-0001-000000000000000000\"}]")
                 .when()
                 .post("/event-types/" + eventTypeName + "/cursors-lag")
                 .then()
                 .statusCode(OK.value())
                 .body("size()", equalTo(1))
-                .body("newest_available_offset[0]", equalTo("000000000000000001"))
-                .body("oldest_available_offset[0]", equalTo("000000000000000000"))
+                .body("newest_available_offset[0]", equalTo("001-0001-000000000000000001"))
+                .body("oldest_available_offset[0]", equalTo("001-0001-000000000000000000"))
                 .body("unconsumed_events[0]", equalTo(1));
-
     }
 
     @Test(timeout = 3000)
@@ -260,9 +268,8 @@ public class UserJourneyAT extends RealEnvironmentAT {
 
         // validate the content of events
         for (int i = 0; i < batches.size(); i++) {
-
-            final SubscriptionCursor cursor = new SubscriptionCursor(
-                    "0", KafkaCursor.toNakadiOffset(i), eventTypeName, "");
+            final SubscriptionCursor cursor = new SubscriptionCursor("0", TestUtils.toTimelineOffset(i),
+                    eventTypeName, "");
             final StreamBatch expectedBatch = new StreamBatch(cursor,
                     ImmutableList.of(ImmutableMap.of("foo", "bar" + i)),
                     i == 0 ? new StreamMetadata("Stream started") : null);
@@ -297,7 +304,7 @@ public class UserJourneyAT extends RealEnvironmentAT {
                 .then()
                 .statusCode(OK.value())
                 .body("items[0].partition", equalTo("0"))
-                .body("items[0].offset", equalTo(KafkaCursor.toNakadiOffset(3)));
+                .body("items[0].offset", equalTo("001-0001-000000000000000003"));
 
         // delete subscription
         jsonRequestSpec()
@@ -329,15 +336,6 @@ public class UserJourneyAT extends RealEnvironmentAT {
         return requestSpec()
                 .header("accept", "application/json")
                 .contentType(JSON);
-    }
-
-    public static String getEventTypeJsonFromFile(final String resourceName, final String eventTypeName,
-                                                  final String owningApp)
-            throws IOException {
-        final String json = Resources.toString(Resources.getResource(resourceName), Charsets.UTF_8);
-        return json
-                .replace("NAME_PLACEHOLDER", eventTypeName)
-                .replace("OWNING_APP_PLACEHOLDER", owningApp);
     }
 
 }

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaAT.java
@@ -108,10 +108,11 @@ public class HilaAT extends BaseAT {
                 .create(URL, subscription.getId(), "stream_limit=2")
                 .start();
         waitFor(() -> assertThat(client.getBatches(), hasSize(2)));
-        assertThat(client.getBatches().get(0), equalToBatchIgnoringToken(singleEventBatch("0", "0", eventType.getName(),
-                ImmutableMap.of("foo", "bar0"), "Stream started")));
-        assertThat(client.getBatches().get(1), equalToBatchIgnoringToken(singleEventBatch("0", "1", eventType.getName(),
-                ImmutableMap.of("foo", "bar1"))));
+        assertThat(client.getBatches().get(0), equalToBatchIgnoringToken(singleEventBatch("0",
+                "001-0001-000000000000000000", eventType.getName(), ImmutableMap.of("foo", "bar0"),
+                "Stream started")));
+        assertThat(client.getBatches().get(1), equalToBatchIgnoringToken(singleEventBatch("0",
+                "001-0001-000000000000000001", eventType.getName(), ImmutableMap.of("foo", "bar1"))));
 
         // commit offset that will also trigger session closing as we reached stream_limit and committed
         commitCursors(subscription.getId(), ImmutableList.of(client.getBatches().get(1).getCursor()),
@@ -123,10 +124,11 @@ public class HilaAT extends BaseAT {
         waitFor(() -> assertThat(client.getBatches(), hasSize(2)));
 
         // check that we have read the next two events with correct offsets
-        assertThat(client.getBatches().get(0), equalToBatchIgnoringToken(singleEventBatch("0", "2", eventType.getName(),
+        assertThat(client.getBatches().get(0), equalToBatchIgnoringToken(singleEventBatch("0",
+                "001-0001-000000000000000002", eventType.getName(),
                 ImmutableMap.of("foo", "bar2"), "Stream started")));
-        assertThat(client.getBatches().get(1), equalToBatchIgnoringToken(singleEventBatch("0", "3", eventType.getName(),
-                ImmutableMap.of("foo", "bar3"))));
+        assertThat(client.getBatches().get(1), equalToBatchIgnoringToken(singleEventBatch("0",
+                "001-0001-000000000000000003", eventType.getName(), ImmutableMap.of("foo", "bar3"))));
     }
 
 
@@ -136,7 +138,7 @@ public class HilaAT extends BaseAT {
                 .create(URL, subscription.getId(), "batch_flush_timeout=1")
                 .start();
         waitFor(() -> assertThat(client.getBatches(), not(empty())));
-        assertThat(client.getBatches().get(0).getCursor().getOffset(), equalTo(Cursor.BEFORE_OLDEST_OFFSET));
+        assertThat(client.getBatches().get(0).getCursor().getOffset(), equalTo("001-0001--1"));
     }
 
     @Test(timeout = 5000)
@@ -148,7 +150,7 @@ public class HilaAT extends BaseAT {
 
         when().get("/subscriptions/{sid}/cursors", subscription.getId())
                 .then()
-                .body("items[0].offset", equalTo(Cursor.BEFORE_OLDEST_OFFSET));
+                .body("items[0].offset", equalTo("001-0001--1"));
 
         final int commitResult = commitCursors(subscription.getId(),
                 ImmutableList.of(new SubscriptionCursor("0", Cursor.BEFORE_OLDEST_OFFSET, eventType.getName(), "abc")),
@@ -206,8 +208,8 @@ public class HilaAT extends BaseAT {
 
         waitFor(() -> assertThat(client.getBatches(), hasSize(2)), 10000);
         waitFor(() -> assertThat(client.isRunning(), is(false)), 10000);
-        assertThat(client.getBatches().get(1), equalToBatchIgnoringToken(singleEventBatch("0", "0", eventType.getName(),
-                ImmutableMap.of(), "Commit timeout reached")));
+        assertThat(client.getBatches().get(1), equalToBatchIgnoringToken(singleEventBatch("0",
+                "001-0001-000000000000000000", eventType.getName(), ImmutableMap.of(), "Commit timeout reached")));
     }
 
     @Test(timeout = 15000)
@@ -241,13 +243,13 @@ public class HilaAT extends BaseAT {
         waitFor(() -> assertThat(client.getBatches(), hasSize(3)));
 
         assertThat(client.getBatches().get(0).getEvents(), hasSize(5));
-        assertThat(client.getBatches().get(0).getCursor().getOffset(), is("000000000000000004"));
+        assertThat(client.getBatches().get(0).getCursor().getOffset(), is("001-0001-000000000000000004"));
 
         assertThat(client.getBatches().get(1).getEvents(), hasSize(5));
-        assertThat(client.getBatches().get(1).getCursor().getOffset(), is("000000000000000009"));
+        assertThat(client.getBatches().get(1).getCursor().getOffset(), is("001-0001-000000000000000009"));
 
         assertThat(client.getBatches().get(2).getEvents(), hasSize(2));
-        assertThat(client.getBatches().get(2).getCursor().getOffset(), is("000000000000000011"));
+        assertThat(client.getBatches().get(2).getCursor().getOffset(), is("001-0001-000000000000000011"));
     }
 
     @Test(timeout = 10000)
@@ -438,7 +440,7 @@ public class HilaAT extends BaseAT {
                 .start();
         waitFor(() -> assertThat(client2.getBatches(), hasSize(10)));
 
-        Assert.assertEquals("000000000000000005", client2.getBatches().get(0).getCursor().getOffset());
+        Assert.assertEquals("001-0001-000000000000000005", client2.getBatches().get(0).getCursor().getOffset());
     }
 
     @Test(timeout = 15000)

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/timelines/SubscriptionConsumptionTest.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/timelines/SubscriptionConsumptionTest.java
@@ -25,7 +25,6 @@ import java.util.stream.Stream;
 import static org.zalando.nakadi.webservice.utils.NakadiTestUtils.createEventType;
 import static org.zalando.nakadi.webservice.utils.NakadiTestUtils.createSubscription;
 import static org.zalando.nakadi.webservice.utils.NakadiTestUtils.createTimeline;
-import static org.zalando.nakadi.webservice.utils.NakadiTestUtils.deleteTimeline;
 import static org.zalando.nakadi.webservice.utils.NakadiTestUtils.publishEvents;
 
 public class SubscriptionConsumptionTest {
@@ -55,33 +54,6 @@ public class SubscriptionConsumptionTest {
         cursorsDuringPublish = inTimeCursors.get();
     }
 
-    @Test(timeout = 15000)
-    public void testTimelineDelete() throws IOException, InterruptedException {
-        final EventType eventType = createEventType();
-        final Subscription subscription = createSubscription(
-                RandomSubscriptionBuilder.builder().withEventType(eventType.getName()).build());
-
-        final CountDownLatch finished = new CountDownLatch(1);
-        final AtomicReference<String[]> inTimelineCursors = new AtomicReference<>();
-        createParallelConsumer(subscription, 6, finished, inTimelineCursors::set);
-        publishEvents(eventType.getName(), 2, i -> "{\"foo\":\"bar\"}");
-        createTimeline(eventType.getName());
-        publishEvents(eventType.getName(), 2, i -> "{\"foo\":\"bar\"}");
-        deleteTimeline(eventType.getName());
-        publishEvents(eventType.getName(), 2, i -> "{\"foo\":\"bar\"}");
-        finished.await();
-        Assert.assertArrayEquals(
-                new String[]{
-                        "000000000000000000",
-                        "000000000000000001",
-                        "001-0001-000000000000000002",
-                        "001-0001-000000000000000003",
-                        "000000000000000004",
-                        "000000000000000005"
-                },
-                inTimelineCursors.get());
-    }
-
     @Test(timeout = 60000)
     public void test2TimelinesInaRow() throws IOException, InterruptedException {
         final EventType eventType = createEventType();
@@ -101,11 +73,11 @@ public class SubscriptionConsumptionTest {
         finished.await();
         Assert.assertArrayEquals(
                 new String[]{
-                        "000000000000000000",
-                        "000000000000000001",
-                        "001-0003-000000000000000000",
-                        "001-0005-000000000000000000",
-                        "001-0005-000000000000000001"
+                        "001-0001-000000000000000000",
+                        "001-0001-000000000000000001",
+                        "001-0004-000000000000000000",
+                        "001-0006-000000000000000000",
+                        "001-0006-000000000000000001"
                 },
                 inTimelineCursors.get()
         );
@@ -121,9 +93,9 @@ public class SubscriptionConsumptionTest {
                 new String[]{
                         "001-0001-000000000000000000",
                         "001-0001-000000000000000001",
-                        "001-0003-000000000000000000",
-                        "001-0005-000000000000000000",
-                        "001-0005-000000000000000001"
+                        "001-0004-000000000000000000",
+                        "001-0006-000000000000000000",
+                        "001-0006-000000000000000001"
                 },
                 inTimelineCursors.get()
         );
@@ -145,8 +117,8 @@ public class SubscriptionConsumptionTest {
         finished.await();
         Assert.assertArrayEquals(
                 new String[]{
-                        "001-0003-000000000000000000",
-                        "001-0003-000000000000000001",
+                        "001-0004-000000000000000000",
+                        "001-0004-000000000000000001",
                 },
                 inTimelineCursors.get()
         );
@@ -160,8 +132,8 @@ public class SubscriptionConsumptionTest {
         finished2.await();
         Assert.assertArrayEquals(
                 new String[]{
-                        "001-0003-000000000000000000",
-                        "001-0003-000000000000000001",
+                        "001-0004-000000000000000000",
+                        "001-0004-000000000000000001",
                 },
                 inTimelineCursors2.get()
         );
@@ -171,14 +143,15 @@ public class SubscriptionConsumptionTest {
     public void testInTimeCursorsCorrect() {
         Assert.assertArrayEquals(
                 new String[]{
-                        "000000000000000000",
-                        "000000000000000001",
-                        "001-0001-000000000000000002",
-                        "001-0001-000000000000000003",
+                        "001-0001-000000000000000000",
+                        "001-0001-000000000000000001",
                         "001-0002-000000000000000000",
                         "001-0002-000000000000000001",
                         "001-0003-000000000000000000",
                         "001-0003-000000000000000001",
+                        "001-0004-000000000000000000",
+                        "001-0004-000000000000000001"
+
                 },
                 cursorsDuringPublish
         );
@@ -189,12 +162,12 @@ public class SubscriptionConsumptionTest {
         final String[] expected = new String[]{
                 "001-0001-000000000000000000",
                 "001-0001-000000000000000001",
-                "001-0001-000000000000000002",
-                "001-0001-000000000000000003",
                 "001-0002-000000000000000000",
                 "001-0002-000000000000000001",
                 "001-0003-000000000000000000",
                 "001-0003-000000000000000001",
+                "001-0004-000000000000000000",
+                "001-0004-000000000000000001"
         };
 
         // Do not test last case, because it makes no sense...

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/timelines/TimelineConsumptionTest.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/timelines/TimelineConsumptionTest.java
@@ -22,7 +22,6 @@ import java.util.function.Consumer;
 import static com.jayway.restassured.RestAssured.given;
 import static org.zalando.nakadi.webservice.utils.NakadiTestUtils.createEventType;
 import static org.zalando.nakadi.webservice.utils.NakadiTestUtils.createTimeline;
-import static org.zalando.nakadi.webservice.utils.NakadiTestUtils.deleteTimeline;
 import static org.zalando.nakadi.webservice.utils.NakadiTestUtils.publishEvents;
 
 public class TimelineConsumptionTest {
@@ -66,30 +65,6 @@ public class TimelineConsumptionTest {
     }
 
     @Test
-    public void testTimelineDelete() throws IOException, InterruptedException {
-        final EventType eventType = createEventType();
-        final CountDownLatch finished = new CountDownLatch(1);
-        final AtomicReference<String[]> inTimelineCursors = new AtomicReference<>();
-        createParallelConsumer(eventType.getName(), 6, finished, inTimelineCursors::set);
-        publishEvents(eventType.getName(), 2, i -> "{\"foo\":\"bar\"}");
-        createTimeline(eventType.getName());
-        publishEvents(eventType.getName(), 2, i -> "{\"foo\":\"bar\"}");
-        deleteTimeline(eventType.getName());
-        publishEvents(eventType.getName(), 2, i -> "{\"foo\":\"bar\"}");
-        finished.await();
-        Assert.assertArrayEquals(
-                new String[]{
-                        "000000000000000000",
-                        "000000000000000001",
-                        "001-0001-000000000000000002",
-                        "001-0001-000000000000000003",
-                        "000000000000000004",
-                        "000000000000000005"
-                },
-                inTimelineCursors.get());
-    }
-
-    @Test
     public void test2TimelinesInaRow() throws IOException, InterruptedException {
         final EventType eventType = createEventType();
         final CountDownLatch finished = new CountDownLatch(1);
@@ -106,11 +81,11 @@ public class TimelineConsumptionTest {
         finished.await();
         Assert.assertArrayEquals(
                 new String[]{
-                        "000000000000000000",
-                        "000000000000000001",
-                        "001-0003-000000000000000000",
-                        "001-0005-000000000000000000",
-                        "001-0005-000000000000000001"
+                        "001-0001-000000000000000000",
+                        "001-0001-000000000000000001",
+                        "001-0004-000000000000000000",
+                        "001-0006-000000000000000000",
+                        "001-0006-000000000000000001"
                 },
                 inTimelineCursors.get()
         );
@@ -120,9 +95,9 @@ public class TimelineConsumptionTest {
                 new String[]{
                         "001-0001-000000000000000000",
                         "001-0001-000000000000000001",
-                        "001-0003-000000000000000000",
-                        "001-0005-000000000000000000",
-                        "001-0005-000000000000000001"
+                        "001-0004-000000000000000000",
+                        "001-0006-000000000000000000",
+                        "001-0006-000000000000000001"
                 },
                 receivedOffsets
         );
@@ -141,16 +116,16 @@ public class TimelineConsumptionTest {
         finished.await();
         Assert.assertArrayEquals(
                 new String[]{
-                        "001-0003-000000000000000000",
-                        "001-0003-000000000000000001",
+                        "001-0004-000000000000000000",
+                        "001-0004-000000000000000001",
                 },
                 inTimelineCursors.get()
         );
         final String[] receivedOffsets = readCursors(eventType.getName(), "BEGIN", 2);
         Assert.assertArrayEquals(
                 new String[]{
-                        "001-0003-000000000000000000",
-                        "001-0003-000000000000000001",
+                        "001-0004-000000000000000000",
+                        "001-0004-000000000000000001",
                 },
                 receivedOffsets
         );
@@ -160,14 +135,14 @@ public class TimelineConsumptionTest {
     public void testInTimeCursorsCorrect() {
         Assert.assertArrayEquals(
                 new String[]{
-                        "000000000000000000",
-                        "000000000000000001",
-                        "001-0001-000000000000000002",
-                        "001-0001-000000000000000003",
+                        "001-0001-000000000000000000",
+                        "001-0001-000000000000000001",
                         "001-0002-000000000000000000",
                         "001-0002-000000000000000001",
                         "001-0003-000000000000000000",
                         "001-0003-000000000000000001",
+                        "001-0004-000000000000000000",
+                        "001-0004-000000000000000001"
                 },
                 cursorsDuringPublish
         );
@@ -178,12 +153,12 @@ public class TimelineConsumptionTest {
         final String[] expected = new String[]{
                 "001-0001-000000000000000000",
                 "001-0001-000000000000000001",
-                "001-0001-000000000000000002",
-                "001-0001-000000000000000003",
                 "001-0002-000000000000000000",
                 "001-0002-000000000000000001",
                 "001-0003-000000000000000000",
                 "001-0003-000000000000000001",
+                "001-0004-000000000000000000",
+                "001-0004-000000000000000001",
         };
 
         // Do not test last case, because it makes no sense...

--- a/src/main/java/org/zalando/nakadi/controller/EventStreamController.java
+++ b/src/main/java/org/zalando/nakadi/controller/EventStreamController.java
@@ -146,7 +146,7 @@ public class EventStreamController {
                 }
             }
         }
-        final Timeline latestTimeline = timelineService.getTimeline(eventType);
+        final Timeline latestTimeline = timelineService.getActiveTimeline(eventType);
         final TopicRepository latestTopicRepository = timelineService.getTopicRepository(latestTimeline);
         if (null != cursors) {
             final List<NakadiCursor> result = new ArrayList<>();

--- a/src/main/java/org/zalando/nakadi/controller/EventTypeController.java
+++ b/src/main/java/org/zalando/nakadi/controller/EventTypeController.java
@@ -198,25 +198,25 @@ public class EventTypeController {
         return Responses.create(exception.asProblem(), request);
     }
 
-//    @ExceptionHandler(NoSuchPartitionStrategyException.class)
-//    public ResponseEntity<Problem> noSuchPartitionStrategyException(final NakadiException exception,
-//                                                                    final NativeWebRequest request) {
-//        LOG.debug(exception.getMessage(), exception);
-//        return Responses.create(exception.asProblem(), request);
-//    }
-//
-//    @ExceptionHandler(DuplicatedEventTypeNameException.class)
-//    public ResponseEntity<Problem> duplicatedEventTypeNameException(final DuplicatedEventTypeNameException exception,
-//                                                                    final NativeWebRequest request) {
-//        LOG.debug(exception.getMessage(), exception);
-//        return Responses.create(exception.asProblem(), request);
-//    }
-//
-//    @ExceptionHandler(InvalidEventTypeException.class)
-//    public ResponseEntity<Problem> invalidEventTypeException(final InvalidEventTypeException exception,
-//                                                             final NativeWebRequest request) {
-//        LOG.debug(exception.getMessage(), exception);
-//        return Responses.create(exception.asProblem(), request);
-//    }
+    @ExceptionHandler(NoSuchPartitionStrategyException.class)
+    public ResponseEntity<Problem> noSuchPartitionStrategyException(final NakadiException exception,
+                                                                    final NativeWebRequest request) {
+        LOG.debug(exception.getMessage(), exception);
+        return Responses.create(exception.asProblem(), request);
+    }
+
+    @ExceptionHandler(DuplicatedEventTypeNameException.class)
+    public ResponseEntity<Problem> duplicatedEventTypeNameException(final DuplicatedEventTypeNameException exception,
+                                                                    final NativeWebRequest request) {
+        LOG.debug(exception.getMessage(), exception);
+        return Responses.create(exception.asProblem(), request);
+    }
+
+    @ExceptionHandler(InvalidEventTypeException.class)
+    public ResponseEntity<Problem> invalidEventTypeException(final InvalidEventTypeException exception,
+                                                             final NativeWebRequest request) {
+        LOG.debug(exception.getMessage(), exception);
+        return Responses.create(exception.asProblem(), request);
+    }
 
 }

--- a/src/main/java/org/zalando/nakadi/controller/TimelinesController.java
+++ b/src/main/java/org/zalando/nakadi/controller/TimelinesController.java
@@ -53,13 +53,6 @@ public class TimelinesController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @RequestMapping(value = "{id}", method = RequestMethod.DELETE)
-    public ResponseEntity<?> deleteTimeline(@PathVariable("name") final String eventTypeName,
-                                            @PathVariable("id") final String timelineId) {
-        timelineService.delete(eventTypeName, timelineId);
-        return ResponseEntity.ok().build();
-    }
-
     @RequestMapping(method = RequestMethod.GET)
     public ResponseEntity<?> getTimelines(@PathVariable("name") final String eventTypeName) {
         return ResponseEntity.ok(timelineService.getTimelines(eventTypeName).stream()

--- a/src/main/java/org/zalando/nakadi/domain/EventTypeBase.java
+++ b/src/main/java/org/zalando/nakadi/domain/EventTypeBase.java
@@ -23,9 +23,6 @@ public class EventTypeBase {
     @Size(min = 1, max = 255, message = "the length of the name must be >= 1 and <= 255")
     private String name;
 
-    @JsonIgnore
-    private String topic;
-
     @NotNull
     private String owningApplication;
 
@@ -67,7 +64,7 @@ public class EventTypeBase {
         this.compatibilityMode = CompatibilityMode.FORWARD;
     }
 
-    public EventTypeBase(final String name, final String topic, final String owningApplication,
+    public EventTypeBase(final String name, final String owningApplication,
                      final EventCategory category,
                      final List<ValidationStrategyConfiguration> validationStrategies,
                      final List<EnrichmentStrategyDescriptor> enrichmentStrategies,
@@ -77,7 +74,6 @@ public class EventTypeBase {
                      final EventTypeOptions options,
                      final CompatibilityMode compatibilityMode) {
         this.name = name;
-        this.topic = topic;
         this.owningApplication = owningApplication;
         this.category = category;
         this.validationStrategies = validationStrategies;
@@ -92,7 +88,6 @@ public class EventTypeBase {
 
     public EventTypeBase(final EventTypeBase eventType) {
         this.setName(eventType.getName());
-        this.setTopic(eventType.getTopic());
         this.setOwningApplication(eventType.getOwningApplication());
         this.setCategory(eventType.getCategory());
         this.setValidationStrategies(eventType.getValidationStrategies());
@@ -172,14 +167,6 @@ public class EventTypeBase {
 
     public void setEnrichmentStrategies(final List<EnrichmentStrategyDescriptor> enrichmentStrategies) {
         this.enrichmentStrategies = enrichmentStrategies;
-    }
-
-    public String getTopic() {
-        return topic;
-    }
-
-    public void setTopic(final String topic) {
-        this.topic = topic;
     }
 
     public EventTypeOptions getOptions() {

--- a/src/main/java/org/zalando/nakadi/domain/NakadiCursor.java
+++ b/src/main/java/org/zalando/nakadi/domain/NakadiCursor.java
@@ -82,10 +82,6 @@ public class NakadiCursor implements Comparable<NakadiCursor> {
 
     @Override
     public int compareTo(final NakadiCursor other) {
-        if ((other.getTimeline().isFake() && this.getTimeline().isFirstAfterFake())
-                || (this.getTimeline().isFake() && other.getTimeline().isFirstAfterFake())) {
-            return this.getOffset().compareTo(other.getOffset());
-        }
         final int orderDiffers = Integer.compare(this.getTimeline().getOrder(), other.getTimeline().getOrder());
         if (0 != orderDiffers) {
             return orderDiffers;

--- a/src/main/java/org/zalando/nakadi/partitioning/PartitionResolver.java
+++ b/src/main/java/org/zalando/nakadi/partitioning/PartitionResolver.java
@@ -67,7 +67,7 @@ public class PartitionResolver {
         }
 
         final List<String> partitions = timelineService.getTopicRepository(eventType)
-                .listPartitionNames(timelineService.getTimeline(eventType).getTopic());
+                .listPartitionNames(timelineService.getActiveTimeline(eventType).getTopic());
         return partitionStrategy.calculatePartition(eventType, eventAsJson, partitions);
     }
 

--- a/src/main/java/org/zalando/nakadi/repository/MultiTimelineEventConsumer.java
+++ b/src/main/java/org/zalando/nakadi/repository/MultiTimelineEventConsumer.java
@@ -154,14 +154,7 @@ public class MultiTimelineEventConsumer implements EventConsumer.ReassignableEve
         final TopicRepository result = timelineService.getTopicRepository(electedTimeline);
         if (electedTimeline.getOrder() != cursor.getTimeline().getOrder()) {
             // It seems that cursor jumped to different timeline. One need to fetch very first cursor in timeline.
-            final NakadiCursor replacement;
-            if (electedTimeline.isFake() || (cursor.getTimeline().isFake() && electedTimeline.isFirstAfterFake())) {
-                // There should be special treatment when there is a jump from fake timeline to first one, cause
-                // in this case consumption should start from the same offset, instead of starting from before first
-                replacement = new NakadiCursor(electedTimeline, cursor.getPartition(), cursor.getOffset());
-            } else {
-                replacement = getBeforeFirstCursor(result, electedTimeline, cursor.getPartition());
-            }
+            final NakadiCursor replacement = getBeforeFirstCursor(result, electedTimeline, cursor.getPartition());
             LOG.info("Replacing cursor because of jumping between timelines from {} to {}", cursor, replacement);
             cursorReplacer.accept(replacement);
         }

--- a/src/main/java/org/zalando/nakadi/repository/db/EventTypeCache.java
+++ b/src/main/java/org/zalando/nakadi/repository/db/EventTypeCache.java
@@ -23,9 +23,9 @@ import org.zalando.nakadi.service.timeline.TimelineSync;
 import org.zalando.nakadi.validation.EventTypeValidator;
 import org.zalando.nakadi.validation.EventValidation;
 
+import javax.annotation.Nonnull;
 import java.util.Iterator;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -180,22 +180,6 @@ public class EventTypeCache {
                 .orElseThrow(() -> new NoSuchEventTypeException("Event type " + name + " does not exists"));
     }
 
-    public Optional<Timeline> getActiveTimeline(final String name) throws InternalNakadiException,
-            NoSuchEventTypeException {
-        final List<Timeline> timelines = getTimelinesOrdered(name);
-        if (timelines == null) {
-            return Optional.empty();
-        }
-        final ListIterator<Timeline> rIterator = timelines.listIterator(timelines.size());
-        while (rIterator.hasPrevious()) {
-            final Timeline toCheck = rIterator.previous();
-            if (toCheck.getSwitchedAt() != null) {
-                return Optional.of(toCheck);
-            }
-        }
-        return Optional.empty();
-    }
-
     public List<Timeline> getTimelinesOrdered(final String name) throws InternalNakadiException,
             NoSuchEventTypeException {
         return getCached(name)
@@ -253,6 +237,7 @@ public class EventTypeCache {
     private static class CachedValue {
         private final EventType eventType;
         private final EventTypeValidator eventTypeValidator;
+        @Nonnull
         private final List<Timeline> timelines;
 
         CachedValue(final EventType eventType,

--- a/src/main/java/org/zalando/nakadi/repository/db/EventTypeDbRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/db/EventTypeDbRepository.java
@@ -42,9 +42,8 @@ public class EventTypeDbRepository extends AbstractDbRepository implements Event
             final DateTime now = new DateTime(DateTimeZone.UTC);
             final EventType eventType = new EventType(eventTypeBase, "1.0.0", now, now);
             jdbcTemplate.update(
-                    "INSERT INTO zn_data.event_type (et_name, et_topic, et_event_type_object) VALUES (?, ?, ?::jsonb)",
+                    "INSERT INTO zn_data.event_type (et_name, et_event_type_object) VALUES (?, ?::jsonb)",
                     eventTypeBase.getName(),
-                    eventTypeBase.getTopic(),
                     jsonMapper.writer().writeValueAsString(eventType));
             insertEventTypeSchema(eventType);
             return eventType;
@@ -57,7 +56,7 @@ public class EventTypeDbRepository extends AbstractDbRepository implements Event
 
     @Override
     public EventType findByName(final String name) throws NoSuchEventTypeException {
-        final String sql = "SELECT et_topic, et_event_type_object FROM zn_data.event_type WHERE et_name = ?";
+        final String sql = "SELECT et_event_type_object FROM zn_data.event_type WHERE et_name = ?";
 
         try {
             return jdbcTemplate.queryForObject(sql, new Object[]{name}, new EventTypeMapper());
@@ -97,9 +96,7 @@ public class EventTypeDbRepository extends AbstractDbRepository implements Event
         @Override
         public EventType mapRow(final ResultSet rs, final int rowNum) throws SQLException {
             try {
-                final EventType eventType = jsonMapper.readValue(rs.getString("et_event_type_object"), EventType.class);
-                eventType.setTopic(rs.getString("et_topic"));
-                return eventType;
+                return jsonMapper.readValue(rs.getString("et_event_type_object"), EventType.class);
             } catch (IOException e) {
                 throw new SQLException(e);
             }
@@ -109,7 +106,7 @@ public class EventTypeDbRepository extends AbstractDbRepository implements Event
     @Override
     public List<EventType> list() {
         return jdbcTemplate.query(
-                "SELECT et_topic, et_event_type_object FROM zn_data.event_type",
+                "SELECT et_event_type_object FROM zn_data.event_type",
                 new EventTypeMapper());
     }
 

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -132,7 +132,7 @@ public class KafkaTopicRepository implements TopicRepository {
                 topicConfig.setProperty("retention.ms", Long.toString(retentionMs));
                 topicConfig.setProperty("segment.ms", Long.toString(rotationMs));
                 AdminUtils.createTopic(zkUtils, topic, partitionsNum, replicaFactor, topicConfig,
-                        RackAwareMode.Enforced$.MODULE$);
+                        RackAwareMode.Safe$.MODULE$);
             });
         } catch (final TopicExistsException e) {
             throw new TopicCreationException("Topic with name " + topic +
@@ -155,6 +155,7 @@ public class KafkaTopicRepository implements TopicRepository {
         if (!Boolean.TRUE.equals(allowsConsumption)) {
             throw new TopicCreationException("Failed to confirm topic creation within " + timeoutMillis + " millis");
         }
+
     }
 
     @Override

--- a/src/main/java/org/zalando/nakadi/service/CursorOperationsService.java
+++ b/src/main/java/org/zalando/nakadi/service/CursorOperationsService.java
@@ -47,9 +47,7 @@ public class CursorOperationsService {
         long result = numberOfEventsBeforeCursor(finalCursor) - numberOfEventsBeforeCursor(initialCursor);
         final int initialOrder = initialCursor.getTimeline().getOrder();
         final int finalOrder = finalCursor.getTimeline().getOrder();
-
-        // In case when fake timeline is still there, one should count it only once.
-        // eg. in case of offset 1234 it should be treated as 0001-0001-000...1234
+        
         int startOrder = Math.min(initialOrder, finalOrder);
         if (startOrder == Timeline.STARTING_ORDER) {
             startOrder += 1;
@@ -174,8 +172,7 @@ public class CursorOperationsService {
 
                 // Next case is a special one. User must have ability to move to the begin (actually - position before
                 // begin event that is not within limits)
-                if ((currentCursor.getTimeline().isFirstAfterFake() || currentCursor.getTimeline().isFake())
-                        && toMoveBack == 0) {
+                if (toMoveBack == 0) {
                     toMoveBack += totalBefore + 1;
                     break;
                 }

--- a/src/main/java/org/zalando/nakadi/service/EventPublisher.java
+++ b/src/main/java/org/zalando/nakadi/service/EventPublisher.java
@@ -164,7 +164,7 @@ public class EventPublisher {
     }
 
     private void submit(final List<BatchItem> batch, final EventType eventType) throws EventPublishingException {
-        final Timeline activeTimeline = timelineService.getTimeline(eventType);
+        final Timeline activeTimeline = timelineService.getActiveTimeline(eventType);
         timelineService.getTopicRepository(eventType).syncPostBatch(activeTimeline.getTopic(), batch);
     }
 

--- a/src/main/java/org/zalando/nakadi/service/converter/CursorConverterImpl.java
+++ b/src/main/java/org/zalando/nakadi/service/converter/CursorConverterImpl.java
@@ -33,7 +33,7 @@ public class CursorConverterImpl implements CursorConverter {
     @Autowired
     public CursorConverterImpl(final EventTypeCache eventTypeCache, final TimelineService timelineService) {
         registerConverter(new VersionOneConverter(eventTypeCache, timelineService));
-        registerConverter(new VersionZeroConverter(eventTypeCache, timelineService));
+        registerConverter(new VersionZeroConverter(timelineService));
     }
 
     private void registerConverter(final VersionedConverter converter) {
@@ -93,11 +93,9 @@ public class CursorConverterImpl implements CursorConverter {
     }
 
     public Cursor convert(final NakadiCursor nakadiCursor) {
-        final Version version = nakadiCursor.getTimeline().isFake() ? CursorConverter.Version.ZERO
-                : CursorConverter.Version.ONE;
         return new Cursor(
                 nakadiCursor.getPartition(),
-                converters.get(version).formatOffset(nakadiCursor));
+                converters.get(CursorConverter.Version.ONE).formatOffset(nakadiCursor));
     }
 
     public SubscriptionCursor convert(final NakadiCursor position, final String token) {

--- a/src/main/java/org/zalando/nakadi/service/converter/VersionOneConverter.java
+++ b/src/main/java/org/zalando/nakadi/service/converter/VersionOneConverter.java
@@ -1,9 +1,6 @@
 package org.zalando.nakadi.service.converter;
 
-import com.google.common.base.Preconditions;
-import org.apache.commons.lang3.StringUtils;
 import org.zalando.nakadi.domain.CursorError;
-import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.NakadiCursor;
 import org.zalando.nakadi.domain.Timeline;
 import org.zalando.nakadi.exceptions.InternalNakadiException;
@@ -74,18 +71,6 @@ class VersionOneConverter implements VersionedConverter {
             throw new InvalidCursorException(CursorError.INVALID_OFFSET);
         }
         final List<Timeline> timelines = eventTypeCache.getTimelinesOrdered(eventTypeStr);
-        if (timelines.isEmpty()) {
-            // Timeline probably was there some time ago, but now it is rolled back.
-            // Therefore one should create NakadiCursor with version zero, checking that order is almost default one.
-            Preconditions.checkArgument(
-                    order == (Timeline.STARTING_ORDER + 1), "Fallback supported only for order next after initial");
-            final EventType eventType = eventTypeCache.getEventType(eventTypeStr);
-            return new NakadiCursor(
-                    timelineService.getFakeTimeline(eventType),
-                    cursor.getPartition(),
-                    StringUtils.leftPad(offsetStr, VersionZeroConverter.VERSION_ZERO_MIN_OFFSET_LENGTH, '0')
-            );
-        }
         final Timeline timeline = timelines.stream()
                 .filter(t -> t.getOrder() == order)
                 .findAny()

--- a/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionService.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionService.java
@@ -219,7 +219,7 @@ public class SubscriptionService {
         final List<PartitionEndStatistics> topicPartitions = new ArrayList<>();
 
         final Map<TopicRepository, List<Timeline>> timelinesByRepo = eventTypes.stream()
-                .map(timelineService::getTimeline)
+                .map(timelineService::getActiveTimeline)
                 .collect(Collectors.groupingBy(timelineService::getTopicRepository));
 
         for (final Map.Entry<TopicRepository, List<Timeline>> repoEntry : timelinesByRepo.entrySet()) {

--- a/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionValidationService.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionValidationService.java
@@ -113,7 +113,7 @@ public class SubscriptionValidationService {
 
     private List<EventTypePartition> getAllPartitions(final List<EventType> eventTypes) {
         return eventTypes.stream()
-                .map(timelineService::getTimeline)
+                .map(timelineService::getActiveTimeline)
                 .flatMap(timeline -> timelineService.getTopicRepository(timeline)
                         .listPartitionNames(timeline.getTopic())
                         .stream()

--- a/src/main/java/org/zalando/nakadi/util/FeatureToggleServiceDefault.java
+++ b/src/main/java/org/zalando/nakadi/util/FeatureToggleServiceDefault.java
@@ -12,7 +12,8 @@ import java.util.Set;
 public class FeatureToggleServiceDefault implements FeatureToggleService {
     private static final Set<Feature> DEPRECATED_FEATURES = ImmutableSet.of(
             Feature.DISABLE_EVENT_TYPE_CREATION,
-            Feature.DISABLE_SUBSCRIPTION_CREATION
+            Feature.DISABLE_SUBSCRIPTION_CREATION,
+            Feature.CONNECTION_CLOSE_CRUTCH
     );
 
     @Override

--- a/src/main/java/org/zalando/nakadi/util/FeatureToggleServiceDefault.java
+++ b/src/main/java/org/zalando/nakadi/util/FeatureToggleServiceDefault.java
@@ -12,8 +12,7 @@ import java.util.Set;
 public class FeatureToggleServiceDefault implements FeatureToggleService {
     private static final Set<Feature> DEPRECATED_FEATURES = ImmutableSet.of(
             Feature.DISABLE_EVENT_TYPE_CREATION,
-            Feature.DISABLE_SUBSCRIPTION_CREATION,
-            Feature.CONNECTION_CLOSE_CRUTCH
+            Feature.DISABLE_SUBSCRIPTION_CREATION
     );
 
     @Override

--- a/src/test/java/org/zalando/nakadi/controller/CursorsControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/CursorsControllerTest.java
@@ -50,7 +50,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 import static org.zalando.nakadi.util.FeatureToggleService.Feature.HIGH_LEVEL_API;
 import static org.zalando.nakadi.utils.TestUtils.buildDefaultEventType;
-import static org.zalando.nakadi.utils.TestUtils.createFakeTimeline;
+import static org.zalando.nakadi.utils.TestUtils.buildTimelineWithTopic;
 import static org.zalando.nakadi.utils.TestUtils.invalidProblem;
 import static org.zalando.problem.MoreStatus.UNPROCESSABLE_ENTITY;
 
@@ -62,7 +62,7 @@ public class CursorsControllerTest {
     private static final String MY_ET = "my-et";
     private static final String TOKEN = "cursor-token";
 
-    private static final Timeline TIMELINE = createFakeTimeline(MY_ET);
+    private static final Timeline TIMELINE = buildTimelineWithTopic(MY_ET);
 
     private static final ImmutableList<NakadiCursor> DUMMY_NAKADI_CURSORS = ImmutableList.of(
             new NakadiCursor(TIMELINE, "0", "000000000000000010"),

--- a/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
@@ -94,7 +94,6 @@ public class EventTypeControllerTestCase {
                 NAKADI_SUBSCRIPTION_MAX_PARTITIONS, "service", "nakadi");
         final PartitionsCalculator partitionsCalculator = new KafkaConfig().createPartitionsCalculator(
                 "t2.large", TestUtils.OBJECT_MAPPER, nakadiSettings);
-        when(timelineService.getDefaultTopicRepository()).thenReturn(topicRepository);
         when(timelineService.getTopicRepository((Timeline) any())).thenReturn(topicRepository);
         when(timelineService.getTopicRepository((EventTypeBase) any())).thenReturn(topicRepository);
         when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
@@ -109,13 +108,10 @@ public class EventTypeControllerTestCase {
         final EventTypeOptionsValidator eventTypeOptionsValidator =
                 new EventTypeOptionsValidator(TOPIC_RETENTION_MIN_MS, TOPIC_RETENTION_MAX_MS);
         final EventTypeController controller = new EventTypeController(eventTypeService,
-                featureToggleService, eventTypeOptionsValidator, applicationService, nakadiSettings, settings,
-                adminService);
+                featureToggleService, eventTypeOptionsValidator, applicationService, adminService);
         doReturn(randomUUID).when(uuid).randomUUID();
 
         doReturn(true).when(applicationService).exists(any());
-        doReturn(SecuritySettings.AuthMode.OFF).when(settings).getAuthMode();
-        doReturn("nakadi").when(settings).getAdminClientId();
         doReturn(true).when(featureToggleService).isFeatureEnabled(CHECK_PARTITIONS_KEYS);
 
         mockMvc = standaloneSetup(controller)

--- a/src/test/java/org/zalando/nakadi/controller/PartitionsControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/PartitionsControllerTest.java
@@ -47,7 +47,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
-import static org.zalando.nakadi.utils.TestUtils.createFakeTimeline;
+import static org.zalando.nakadi.utils.TestUtils.buildTimeline;
 import static org.zalando.nakadi.utils.TestUtils.mockAccessDeniedException;
 
 public class PartitionsControllerTest {
@@ -59,37 +59,28 @@ public class PartitionsControllerTest {
     private static final String UNKNOWN_PARTITION = "unknown-partition";
 
     private static final EventTypePartitionView TEST_TOPIC_PARTITION_0 =
-            new EventTypePartitionView(TEST_EVENT_TYPE, "0", "000000000000000012", "000000000000000067");
+            new EventTypePartitionView(TEST_EVENT_TYPE, "0", "001-0000-000000000000000012", "001-0000-000000000000000067");
     private static final EventTypePartitionView TEST_TOPIC_PARTITION_1 =
-            new EventTypePartitionView(TEST_EVENT_TYPE, "1", "000000000000000043", "000000000000000098");
+            new EventTypePartitionView(TEST_EVENT_TYPE, "1", "001-0000-000000000000000043", "001-0000-000000000000000098");
 
     private static final List<EventTypePartitionView> TEST_TOPIC_PARTITIONS = ImmutableList.of(
             TEST_TOPIC_PARTITION_0,
             TEST_TOPIC_PARTITION_1);
 
     private static final EventType EVENT_TYPE = TestUtils.buildDefaultEventType();
-    private static final Timeline TIMELINE = createFakeTimeline(EVENT_TYPE.getTopic());
+    private static final Timeline TIMELINE = buildTimeline(EVENT_TYPE.getName());
 
     private static final List<PartitionStatistics> TEST_POSITION_STATS = ImmutableList.of(
             new KafkaPartitionStatistics(TIMELINE, 0, 12, 67),
             new KafkaPartitionStatistics(TIMELINE, 1, 43, 98));
-
-
-    private EventTypeRepository eventTypeRepositoryMock;
-
-    private TopicRepository topicRepositoryMock;
-
-    private EventTypeCache eventTypeCache;
-
-    private TimelineService timelineService;
-
-    private CursorOperationsService cursorOperationsService;
-
-    private MockMvc mockMvc;
-
-    private SecuritySettings settings;
-
     private final AuthorizationValidator authorizationValidator = mock(AuthorizationValidator.class);
+    private EventTypeRepository eventTypeRepositoryMock;
+    private TopicRepository topicRepositoryMock;
+    private EventTypeCache eventTypeCache;
+    private TimelineService timelineService;
+    private CursorOperationsService cursorOperationsService;
+    private MockMvc mockMvc;
+    private SecuritySettings settings;
 
     @Before
     public void before() throws InternalNakadiException, NoSuchEventTypeException {
@@ -101,6 +92,8 @@ public class PartitionsControllerTest {
         when(timelineService.getActiveTimelinesOrdered(eq(UNKNOWN_EVENT_TYPE)))
                 .thenThrow(NoSuchEventTypeException.class);
         when(timelineService.getActiveTimelinesOrdered(eq(TEST_EVENT_TYPE)))
+                .thenReturn(Collections.singletonList(TIMELINE));
+        when(timelineService.getAllTimelinesOrdered(eq(TEST_EVENT_TYPE)))
                 .thenReturn(Collections.singletonList(TIMELINE));
         when(timelineService.getTopicRepository((Timeline) any())).thenReturn(topicRepositoryMock);
         final CursorConverter cursorConverter = new CursorConverterImpl(eventTypeCache, timelineService);
@@ -121,7 +114,7 @@ public class PartitionsControllerTest {
     @Test
     public void whenListPartitionsThenOk() throws Exception {
         when(eventTypeRepositoryMock.findByName(TEST_EVENT_TYPE)).thenReturn(EVENT_TYPE);
-        when(topicRepositoryMock.topicExists(eq(EVENT_TYPE.getTopic()))).thenReturn(true);
+        when(topicRepositoryMock.topicExists(eq(EVENT_TYPE.getName()))).thenReturn(true);
         when(topicRepositoryMock.loadTopicStatistics(
                 eq(Collections.singletonList(TIMELINE))))
                 .thenReturn(TEST_POSITION_STATS);
@@ -157,7 +150,7 @@ public class PartitionsControllerTest {
     @Test
     public void whenGetPartitionThenOk() throws Exception {
         when(eventTypeRepositoryMock.findByName(TEST_EVENT_TYPE)).thenReturn(EVENT_TYPE);
-        when(topicRepositoryMock.topicExists(eq(EVENT_TYPE.getTopic()))).thenReturn(true);
+        when(topicRepositoryMock.topicExists(eq(EVENT_TYPE.getName()))).thenReturn(true);
         when(topicRepositoryMock.loadPartitionStatistics(eq(TIMELINE), eq(TEST_PARTITION)))
                 .thenReturn(Optional.of(TEST_POSITION_STATS.get(0)));
 
@@ -192,7 +185,7 @@ public class PartitionsControllerTest {
     @Test
     public void whenGetPartitionWithConsumedOffsetThenOk() throws Exception {
         when(eventTypeRepositoryMock.findByName(TEST_EVENT_TYPE)).thenReturn(EVENT_TYPE);
-        when(topicRepositoryMock.topicExists(eq(EVENT_TYPE.getTopic()))).thenReturn(true);
+        when(topicRepositoryMock.topicExists(eq(EVENT_TYPE.getName()))).thenReturn(true);
         when(topicRepositoryMock.loadPartitionStatistics(eq(TIMELINE), eq(TEST_PARTITION)))
                 .thenReturn(Optional.of(TEST_POSITION_STATS.get(0)));
         final List<NakadiCursorLag> lags = mockCursorLag();
@@ -235,7 +228,7 @@ public class PartitionsControllerTest {
     @Test
     public void whenGetPartitionForWrongPartitionThenNotFound() throws Exception {
         when(eventTypeRepositoryMock.findByName(TEST_EVENT_TYPE)).thenReturn(EVENT_TYPE);
-        when(topicRepositoryMock.topicExists(eq(EVENT_TYPE.getTopic()))).thenReturn(true);
+        when(topicRepositoryMock.topicExists(eq(EVENT_TYPE.getName()))).thenReturn(true);
         when(topicRepositoryMock.loadPartitionStatistics(
                 eq(TIMELINE), eq(UNKNOWN_PARTITION)))
                 .thenReturn(Optional.empty());

--- a/src/test/java/org/zalando/nakadi/controller/PartitionsControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/PartitionsControllerTest.java
@@ -59,9 +59,11 @@ public class PartitionsControllerTest {
     private static final String UNKNOWN_PARTITION = "unknown-partition";
 
     private static final EventTypePartitionView TEST_TOPIC_PARTITION_0 =
-            new EventTypePartitionView(TEST_EVENT_TYPE, "0", "001-0000-000000000000000012", "001-0000-000000000000000067");
+            new EventTypePartitionView(TEST_EVENT_TYPE, "0", "001-0000-000000000000000012",
+                    "001-0000-000000000000000067");
     private static final EventTypePartitionView TEST_TOPIC_PARTITION_1 =
-            new EventTypePartitionView(TEST_EVENT_TYPE, "1", "001-0000-000000000000000043", "001-0000-000000000000000098");
+            new EventTypePartitionView(TEST_EVENT_TYPE, "1", "001-0000-000000000000000043",
+                    "001-0000-000000000000000098");
 
     private static final List<EventTypePartitionView> TEST_TOPIC_PARTITIONS = ImmutableList.of(
             TEST_TOPIC_PARTITION_0,

--- a/src/test/java/org/zalando/nakadi/controller/SubscriptionControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/SubscriptionControllerTest.java
@@ -74,7 +74,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 import static org.zalando.nakadi.util.SubscriptionsUriHelper.createSubscriptionListUri;
 import static org.zalando.nakadi.utils.RandomSubscriptionBuilder.builder;
-import static org.zalando.nakadi.utils.TestUtils.createFakeTimeline;
+import static org.zalando.nakadi.utils.TestUtils.buildTimelineWithTopic;
 import static org.zalando.nakadi.utils.TestUtils.createRandomSubscriptions;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 
@@ -90,7 +90,7 @@ public class SubscriptionControllerTest {
     private final CursorConverter cursorConverter;
     private final CursorOperationsService cursorOperationsService;
     private static final int PARTITIONS_PER_SUBSCRIPTION = 5;
-    private static final Timeline TIMELINE = createFakeTimeline("topic");
+    private static final Timeline TIMELINE = buildTimelineWithTopic("topic");
 
     public SubscriptionControllerTest() throws Exception {
         final FeatureToggleService featureToggleService = mock(FeatureToggleService.class);
@@ -103,7 +103,7 @@ public class SubscriptionControllerTest {
         zkSubscriptionClient = mock(ZkSubscriptionClient.class);
         when(zkSubscriptionClientFactory.createClient(any(), any())).thenReturn(zkSubscriptionClient);
         final TimelineService timelineService = mock(TimelineService.class);
-        when(timelineService.getTimeline(any())).thenReturn(TIMELINE);
+        when(timelineService.getActiveTimeline(any())).thenReturn(TIMELINE);
         when(timelineService.getTopicRepository((EventTypeBase) any())).thenReturn(topicRepository);
         when(timelineService.getTopicRepository((Timeline) any())).thenReturn(topicRepository);
         final NakadiSettings settings = mock(NakadiSettings.class);

--- a/src/test/java/org/zalando/nakadi/controller/TimelinesControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/TimelinesControllerTest.java
@@ -11,26 +11,15 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.zalando.nakadi.config.SecuritySettings;
-import org.zalando.nakadi.domain.EventType;
-import org.zalando.nakadi.domain.EventTypeResource;
 import org.zalando.nakadi.domain.Storage;
 import org.zalando.nakadi.domain.Timeline;
-import org.zalando.nakadi.exceptions.NotFoundException;
-import org.zalando.nakadi.exceptions.UnableProcessException;
-import org.zalando.nakadi.exceptions.runtime.AccessDeniedException;
-import org.zalando.nakadi.plugin.api.authz.AuthorizationService;
-import org.zalando.nakadi.plugin.api.authz.Resource;
 import org.zalando.nakadi.security.ClientResolver;
 import org.zalando.nakadi.service.timeline.TimelineService;
 import org.zalando.nakadi.util.FeatureToggleService;
 import org.zalando.nakadi.util.PrincipalMockFactory;
-import org.zalando.nakadi.utils.EventTypeTestBuilder;
 import org.zalando.nakadi.utils.TestUtils;
 import org.zalando.nakadi.view.TimelineView;
-import org.zalando.problem.MoreStatus;
-import org.zalando.problem.Problem;
 
-import javax.ws.rs.core.Response;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -82,55 +71,6 @@ public class TimelinesControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().json(
                         TestUtils.OBJECT_MAPPER.writeValueAsString(timelineViews)));
-    }
-
-    @Test
-    public void whenDeleteTimelineThenOk() throws Exception {
-        Mockito.doNothing().when(timelineService).delete(Mockito.any(), Mockito.any());
-        mockMvc.perform(MockMvcRequestBuilders.delete("/event-types/event_type/timelines/timeli-uuid")
-                .contentType(MediaType.APPLICATION_JSON)
-                .principal(PrincipalMockFactory.mockPrincipal("nakadi")))
-                .andExpect(MockMvcResultMatchers.status().isOk());
-    }
-
-    @Test
-    public void whenAccessDeniedExceptionThen403() throws Exception {
-        final EventType eventType = EventTypeTestBuilder.builder().build();
-        final Resource resource = new EventTypeResource(eventType.getName(), eventType.getAuthorization());
-
-        Mockito.doThrow(new AccessDeniedException(AuthorizationService.Operation.ADMIN, resource))
-                .when(timelineService).delete(Mockito.any(), Mockito.any());
-        mockMvc.perform(MockMvcRequestBuilders.delete("/event-types/event_type/timelines/timeli-uuid")
-                .contentType(MediaType.APPLICATION_JSON)
-                .principal(PrincipalMockFactory.mockPrincipal("nakadi")))
-                .andExpect(MockMvcResultMatchers.status().isForbidden())
-                .andExpect(MockMvcResultMatchers.content().json(TestUtils.OBJECT_MAPPER.writeValueAsString(
-                        Problem.valueOf(Response.Status.FORBIDDEN,
-                                "Access on ADMIN event-type:" + eventType.getName()+ " denied"))));
-    }
-
-    @Test
-    public void whenNotFoundExceptionThen404() throws Exception {
-        Mockito.doThrow(new NotFoundException("whenNotFoundExceptionThen404"))
-                .when(timelineService).delete(Mockito.any(), Mockito.any());
-        mockMvc.perform(MockMvcRequestBuilders.delete("/event-types/event_type/timelines/timeli-uuid")
-                .contentType(MediaType.APPLICATION_JSON)
-                .principal(PrincipalMockFactory.mockPrincipal("nakadi")))
-                .andExpect(MockMvcResultMatchers.status().isNotFound())
-                .andExpect(MockMvcResultMatchers.content().json(TestUtils.OBJECT_MAPPER.writeValueAsString(
-                        Problem.valueOf(Response.Status.NOT_FOUND, "whenNotFoundExceptionThen404"))));
-    }
-
-    @Test
-    public void whenUnableProcessExceptionThen422() throws Exception {
-        Mockito.doThrow(new UnableProcessException("whenUnableProcessExceptionThen422"))
-                .when(timelineService).delete(Mockito.any(), Mockito.any());
-        mockMvc.perform(MockMvcRequestBuilders.delete("/event-types/event_type/timelines/timeli-uuid")
-                .contentType(MediaType.APPLICATION_JSON)
-                .principal(PrincipalMockFactory.mockPrincipal("nakadi")))
-                .andExpect(MockMvcResultMatchers.status().isUnprocessableEntity())
-                .andExpect(MockMvcResultMatchers.content().json(TestUtils.OBJECT_MAPPER.writeValueAsString(
-                        Problem.valueOf(MoreStatus.UNPROCESSABLE_ENTITY, "whenUnableProcessExceptionThen422"))));
     }
 
 }

--- a/src/test/java/org/zalando/nakadi/partitioning/PartitionResolverTest.java
+++ b/src/test/java/org/zalando/nakadi/partitioning/PartitionResolverTest.java
@@ -47,7 +47,7 @@ public class PartitionResolverTest {
         final EventType eventType = new EventType();
         eventType.setPartitionStrategy(RANDOM_STRATEGY);
 
-        when(timelineService.getTimeline(eq(eventType))).thenReturn(mock(Timeline.class));
+        when(timelineService.getActiveTimeline(eq(eventType))).thenReturn(mock(Timeline.class));
 
         final JSONObject event = new JSONObject();
         event.put("abc", "blah");

--- a/src/test/java/org/zalando/nakadi/repository/kafka/KafkaCursorTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/kafka/KafkaCursorTest.java
@@ -12,13 +12,13 @@ public class KafkaCursorTest {
     @Test
     public void testFromNakadiCursorCorrect() throws InvalidCursorException {
         Assert.assertEquals(new KafkaCursor("t1", 1, 123L),
-                KafkaCursor.fromNakadiCursor(new NakadiCursor(TestUtils.createFakeTimeline("t1"), "1", "123")));
+                KafkaCursor.fromNakadiCursor(new NakadiCursor(TestUtils.buildTimelineWithTopic("t1"), "1", "123")));
     }
 
     @Test
     public void testFromNakadiCursorBadPartition() {
         try {
-            KafkaCursor.fromNakadiCursor(new NakadiCursor(TestUtils.createFakeTimeline("t1"), "x", "123"));
+            KafkaCursor.fromNakadiCursor(new NakadiCursor(TestUtils.buildTimelineWithTopic("t1"), "x", "123"));
             Assert.fail("Cursor should not be parsed");
         } catch (final InvalidCursorException ex) {
             Assert.assertEquals(ex.getError(), CursorError.PARTITION_NOT_FOUND);
@@ -28,7 +28,7 @@ public class KafkaCursorTest {
     @Test
     public void testFromNakadiCursorBadOffset() {
         try {
-            KafkaCursor.fromNakadiCursor(new NakadiCursor(TestUtils.createFakeTimeline("t1"), "0", "x"));
+            KafkaCursor.fromNakadiCursor(new NakadiCursor(TestUtils.buildTimelineWithTopic("t1"), "0", "x"));
             Assert.fail("Cursor should not be parsed");
         } catch (final InvalidCursorException ex) {
             Assert.assertEquals(ex.getError(), CursorError.INVALID_FORMAT);

--- a/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Matchers.anyVararg;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.zalando.nakadi.utils.TestUtils.createFakeTimeline;
+import static org.zalando.nakadi.utils.TestUtils.buildTimelineWithTopic;
 
 public class KafkaTopicRepositoryTest {
 
@@ -130,7 +130,7 @@ public class KafkaTopicRepositoryTest {
 
     private static List<NakadiCursor> asTopicPosition(final String topic, final List<Cursor> cursors) {
         return cursors.stream()
-                .map(c -> new NakadiCursor(createFakeTimeline(topic), c.getPartition(), c.getOffset()))
+                .map(c -> new NakadiCursor(buildTimelineWithTopic(topic), c.getPartition(), c.getOffset()))
                 .collect(toList());
     }
 
@@ -304,7 +304,7 @@ public class KafkaTopicRepositoryTest {
 
     @Test
     public void whenValidateCommitCursorsThenOk() throws InvalidCursorException {
-        kafkaTopicRepository.validateCommitCursor(new NakadiCursor(createFakeTimeline(MY_TOPIC), "0", "23"));
+        kafkaTopicRepository.validateCommitCursor(new NakadiCursor(buildTimelineWithTopic(MY_TOPIC), "0", "23"));
     }
 
     @Test
@@ -317,7 +317,7 @@ public class KafkaTopicRepositoryTest {
                     try {
                         kafkaTopicRepository.validateCommitCursor(
                                 new NakadiCursor(
-                                        createFakeTimeline(MY_TOPIC),
+                                        buildTimelineWithTopic(MY_TOPIC),
                                         testCase.getKey().getPartition(),
                                         testCase.getKey().getOffset()));
                     } catch (final InvalidCursorException e) {

--- a/src/test/java/org/zalando/nakadi/repository/kafka/NakadiKafkaConsumerTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/kafka/NakadiKafkaConsumerTest.java
@@ -15,6 +15,7 @@ import org.zalando.nakadi.domain.ConsumedEvent;
 import org.zalando.nakadi.domain.Timeline;
 import org.zalando.nakadi.utils.TestUtils;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -33,7 +34,7 @@ import static org.zalando.nakadi.repository.kafka.KafkaCursor.toKafkaOffset;
 import static org.zalando.nakadi.repository.kafka.KafkaCursor.toKafkaPartition;
 import static org.zalando.nakadi.repository.kafka.KafkaCursor.toNakadiOffset;
 import static org.zalando.nakadi.repository.kafka.KafkaCursor.toNakadiPartition;
-import static org.zalando.nakadi.utils.TestUtils.createFakeTimeline;
+import static org.zalando.nakadi.utils.TestUtils.buildTimeline;
 import static org.zalando.nakadi.utils.TestUtils.randomString;
 import static org.zalando.nakadi.utils.TestUtils.randomUInt;
 import static org.zalando.nakadi.utils.TestUtils.randomULong;
@@ -43,13 +44,14 @@ public class NakadiKafkaConsumerTest {
     private static final String TOPIC = TestUtils.randomValidEventTypeName();
     private static final int PARTITION = randomUInt();
     private static final long POLL_TIMEOUT = randomULong();
+    private static final Date CREATED_AT = new Date();
 
     private static KafkaCursor kafkaCursor(final String topic, final int partition, final long offset) {
         return new KafkaCursor(topic, partition, offset);
     }
 
     private static Map<TopicPartition, Timeline> createTpTimelineMap() {
-        final Timeline timeline = createFakeTimeline(TOPIC);
+        final Timeline timeline = buildTimeline(TOPIC, TOPIC, CREATED_AT);
         final Map<TopicPartition, Timeline> mockMap = mock(Map.class);
         when(mockMap.get(any())).thenReturn(timeline);
         return mockMap;
@@ -115,7 +117,7 @@ public class NakadiKafkaConsumerTest {
                 new TopicPartition(TOPIC, PARTITION),
                 ImmutableList.of(new ConsumerRecord<>(TOPIC, PARTITION, event1Offset, "k1".getBytes(), event1),
                         new ConsumerRecord<>(TOPIC, PARTITION, event2Offset, "k2".getBytes(), event2))));
-        final Timeline timeline = createFakeTimeline(TOPIC);
+        final Timeline timeline = buildTimeline(TOPIC, TOPIC, CREATED_AT);
         final ConsumerRecords<byte[], byte[]> emptyRecords = new ConsumerRecords<>(ImmutableMap.of());
 
         final KafkaConsumer<byte[], byte[]> kafkaConsumerMock = mock(KafkaConsumer.class);

--- a/src/test/java/org/zalando/nakadi/service/CursorOperationsServiceTest.java
+++ b/src/test/java/org/zalando/nakadi/service/CursorOperationsServiceTest.java
@@ -313,8 +313,6 @@ public class CursorOperationsServiceTest {
                     Collections.singletonList(latestOffset)));
         }
         when(timeline.isActive()).thenReturn(null == latestOffset);
-        when(timeline.isFake()).thenReturn(order == 0);
-        when(timeline.isFirstAfterFake()).thenReturn(order == 1);
 
         final TopicRepository repository = new KafkaTopicRepository(
                 mock(ZooKeeperHolder.class),

--- a/src/test/java/org/zalando/nakadi/service/EventPublisherTest.java
+++ b/src/test/java/org/zalando/nakadi/service/EventPublisherTest.java
@@ -88,7 +88,7 @@ public class EventPublisherTest {
         Mockito.when(ts.getTopicRepository((Timeline) any())).thenReturn(topicRepository);
         Mockito.when(ts.getTopicRepository((EventTypeBase) any())).thenReturn(topicRepository);
         final Timeline timeline = Mockito.mock(Timeline.class);
-        Mockito.when(ts.getTimeline(any())).thenReturn(timeline);
+        Mockito.when(ts.getActiveTimeline(any())).thenReturn(timeline);
 
         publisher = new EventPublisher(ts, cache, partitionResolver, enrichment, nakadiSettings, timelineSync,
                 authzValidator);

--- a/src/test/java/org/zalando/nakadi/service/EventStreamTest.java
+++ b/src/test/java/org/zalando/nakadi/service/EventStreamTest.java
@@ -56,7 +56,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.zalando.nakadi.service.EventStreamWriter.BATCH_SEPARATOR;
-import static org.zalando.nakadi.utils.TestUtils.createFakeTimeline;
+import static org.zalando.nakadi.utils.TestUtils.buildTimelineWithTopic;
 import static org.zalando.nakadi.utils.TestUtils.waitFor;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 
@@ -66,7 +66,7 @@ public class EventStreamTest {
     private static final byte[] DUMMY = "DUMMY".getBytes(UTF_8);
     private static final Meter BYTES_FLUSHED_METER = new MetricRegistry().meter("mock");
 
-    private static final Timeline TIMELINE = createFakeTimeline(TOPIC);
+    private static final Timeline TIMELINE = buildTimelineWithTopic(TOPIC);
     private static CursorConverter cursorConverter;
     private static EventStreamWriterProvider writerProvider;
 
@@ -255,7 +255,7 @@ public class EventStreamTest {
         Arrays
                 .stream(batches)
                 .forEach(batch ->
-                        assertThat(batch, sameJSONAs(jsonBatch("0", "000000000000000000", empty()))));
+                        assertThat(batch, sameJSONAs(jsonBatch("0", "001-0000-000000000000000000", empty()))));
     }
 
     @Test(timeout = 10000)
@@ -279,11 +279,11 @@ public class EventStreamTest {
         final String[] batches = out.toString().split(BATCH_SEPARATOR);
 
         assertThat(batches, arrayWithSize(3));
-        assertThat(batches[0], sameJSONAs(jsonBatch("0", "000000000000000000",
+        assertThat(batches[0], sameJSONAs(jsonBatch("0", "001-0000-000000000000000000",
                 Optional.of(nCopies(5, new String(DUMMY))))));
-        assertThat(batches[1], sameJSONAs(jsonBatch("0", "000000000000000000",
+        assertThat(batches[1], sameJSONAs(jsonBatch("0", "001-0000-000000000000000000",
                 Optional.of(nCopies(5, new String(DUMMY))))));
-        assertThat(batches[2], sameJSONAs(jsonBatch("0", "000000000000000000",
+        assertThat(batches[2], sameJSONAs(jsonBatch("0", "001-0000-000000000000000000",
                 Optional.of(nCopies(2, new String(DUMMY))))));
     }
 
@@ -322,7 +322,7 @@ public class EventStreamTest {
                 .forEach(index -> assertThat(
                         batches[index],
                         sameJSONAs(jsonBatch(
-                                "0", KafkaCursor.toNakadiOffset(index), Optional.of(nCopies(1, "event" + index))))
+                                "0", String.format("001-0000-%018d", index), Optional.of(nCopies(1, "event" + index))))
                 ));
     }
 
@@ -360,11 +360,11 @@ public class EventStreamTest {
         final String[] batches = out.toString().split(BATCH_SEPARATOR);
 
         assertThat(batches, arrayWithSize(3));
-        assertThat(batches[0], sameJSONAs(jsonBatch("0", "000000000000000000",
+        assertThat(batches[0], sameJSONAs(jsonBatch("0", "001-0000-000000000000000000",
                 Optional.of(nCopies(2, new String(DUMMY))))));
-        assertThat(batches[1], sameJSONAs(jsonBatch("1", "000000000000000000",
+        assertThat(batches[1], sameJSONAs(jsonBatch("1", "001-0000-000000000000000000",
                 Optional.of(nCopies(2, new String(DUMMY))))));
-        assertThat(batches[2], sameJSONAs(jsonBatch("2", "000000000000000000",
+        assertThat(batches[2], sameJSONAs(jsonBatch("2", "001-0000-000000000000000000",
                 Optional.of(nCopies(2, new String(DUMMY))))));
     }
 

--- a/src/test/java/org/zalando/nakadi/service/SubscriptionValidationServiceTest.java
+++ b/src/test/java/org/zalando/nakadi/service/SubscriptionValidationServiceTest.java
@@ -72,7 +72,6 @@ public class SubscriptionValidationServiceTest {
         for (final String etName : new String[]{ET1, ET2, ET3}) {
             final EventType eventType = new EventType();
             eventType.setName(etName);
-            eventType.setTopic(topicForET(etName));
             eventTypes.put(etName, eventType);
         }
         when(etRepo.findByNameO(any()))
@@ -81,9 +80,9 @@ public class SubscriptionValidationServiceTest {
         final TimelineService timelineService = mock(TimelineService.class);
         for (final EventType et : eventTypes.values()) {
             final Timeline timeline = mock(Timeline.class);
-            when(timeline.getTopic()).thenReturn(et.getTopic());
+            when(timeline.getTopic()).thenReturn(topicForET(et.getName()));
             when(timeline.getEventType()).thenReturn(et.getName());
-            when(timelineService.getTimeline(eq(et))).thenReturn(timeline);
+            when(timelineService.getActiveTimeline(eq(et))).thenReturn(timeline);
         }
         when(timelineService.getTopicRepository((Timeline) any())).thenReturn(topicRepository);
         when(timelineService.getTopicRepository((EventType) any())).thenReturn(topicRepository);

--- a/src/test/java/org/zalando/nakadi/service/converter/VersionOneConverterTest.java
+++ b/src/test/java/org/zalando/nakadi/service/converter/VersionOneConverterTest.java
@@ -9,7 +9,6 @@ import org.zalando.nakadi.domain.NakadiCursor;
 import org.zalando.nakadi.domain.Timeline;
 import org.zalando.nakadi.exceptions.InvalidCursorException;
 import org.zalando.nakadi.repository.db.EventTypeCache;
-import org.zalando.nakadi.repository.kafka.KafkaCursor;
 import org.zalando.nakadi.service.timeline.TimelineService;
 import org.zalando.nakadi.view.Cursor;
 
@@ -29,21 +28,6 @@ public class VersionOneConverterTest {
         timelineService = mock(TimelineService.class);
         eventTypeCache = mock(EventTypeCache.class);
         converter = new VersionOneConverter(eventTypeCache, timelineService);
-    }
-
-    @Test
-    public void testVZeroFallbackOnEmptyTimelines() throws Exception {
-        final Cursor cursor = new Cursor("1", "001-0001-012345");
-        final String eventTypeName = "my_et";
-        final Timeline fakeTimeline = mock(Timeline.class);
-        final EventType eventType = mock(EventType.class);
-        when(eventTypeCache.getEventType(eq(eventTypeName))).thenReturn(eventType);
-        when(timelineService.getFakeTimeline(eq(eventType))).thenReturn(fakeTimeline);
-
-        final NakadiCursor nakadiCursor = converter.convert(eventTypeName, cursor);
-        Assert.assertEquals(fakeTimeline, nakadiCursor.getTimeline());
-        Assert.assertEquals("1", nakadiCursor.getPartition());
-        Assert.assertEquals(KafkaCursor.toNakadiOffset(12345), nakadiCursor.getOffset());
     }
 
     @Test

--- a/src/test/java/org/zalando/nakadi/service/converter/VersionZeroConverterTest.java
+++ b/src/test/java/org/zalando/nakadi/service/converter/VersionZeroConverterTest.java
@@ -6,7 +6,6 @@ import org.zalando.nakadi.exceptions.InternalNakadiException;
 import org.zalando.nakadi.exceptions.InvalidCursorException;
 import org.zalando.nakadi.exceptions.NoSuchEventTypeException;
 import org.zalando.nakadi.exceptions.ServiceUnavailableException;
-import org.zalando.nakadi.repository.db.EventTypeCache;
 import org.zalando.nakadi.service.timeline.TimelineService;
 import org.zalando.nakadi.view.Cursor;
 
@@ -15,14 +14,12 @@ import static org.mockito.Mockito.mock;
 public class VersionZeroConverterTest {
 
     private TimelineService timelineService;
-    private EventTypeCache eventTypeCache;
     private VersionedConverter converter;
 
     @Before
     public void setupMocks() {
         timelineService = mock(TimelineService.class);
-        eventTypeCache = mock(EventTypeCache.class);
-        converter = new VersionZeroConverter(eventTypeCache, timelineService);
+        converter = new VersionZeroConverter(timelineService);
     }
 
     @Test(expected = InvalidCursorException.class)

--- a/src/test/java/org/zalando/nakadi/service/subscription/state/PartitionDataTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/state/PartitionDataTest.java
@@ -18,10 +18,10 @@ import static org.mockito.Mockito.mock;
 
 public class PartitionDataTest {
 
-    private static Timeline fakeTimeline = mock(Timeline.class);
+    private static Timeline firstTimeline = mock(Timeline.class);
 
     private static NakadiCursor createCursor(final long offset) {
-        return new KafkaCursor("x", 0, offset).toNakadiCursor(fakeTimeline);
+        return new KafkaCursor("x", 0, offset).toNakadiCursor(firstTimeline);
     }
 
     @Test

--- a/src/test/java/org/zalando/nakadi/utils/EventTypeTestBuilder.java
+++ b/src/test/java/org/zalando/nakadi/utils/EventTypeTestBuilder.java
@@ -27,7 +27,6 @@ public class EventTypeTestBuilder {
     private static final String DEFAULT_SCHEMA = "{ \"properties\": { \"foo\": { \"type\": \"string\" } } }";
     private final List<ValidationStrategyConfiguration> validationStrategies;
     private String name;
-    private String topic;
     private String owningApplication;
     private EventCategory category;
     private List<EnrichmentStrategyDescriptor> enrichmentStrategies;
@@ -44,7 +43,6 @@ public class EventTypeTestBuilder {
 
     public EventTypeTestBuilder() {
         this.name = TestUtils.randomValidEventTypeName();
-        this.topic = TestUtils.randomUUID();
         this.owningApplication = DEFAULT_OWNING_APPLICATION;
         this.category = EventCategory.UNDEFINED;
         this.validationStrategies = Lists.newArrayList();
@@ -67,11 +65,6 @@ public class EventTypeTestBuilder {
 
     public EventTypeTestBuilder name(final String name) {
         this.name = name;
-        return this;
-    }
-
-    public EventTypeTestBuilder topic(final String topic) {
-        this.topic = topic;
         return this;
     }
 
@@ -148,7 +141,7 @@ public class EventTypeTestBuilder {
     }
 
     public EventType build() {
-        final EventTypeBase eventTypeBase = new EventTypeBase(name, topic, owningApplication, category,
+        final EventTypeBase eventTypeBase = new EventTypeBase(name, owningApplication, category,
                 validationStrategies, enrichmentStrategies, partitionStrategy, partitionKeyFields, schema,
                 defaultStatistic, options, compatibilityMode);
         eventTypeBase.setAuthorization(authorization);

--- a/src/test/java/org/zalando/nakadi/utils/TestUtils.java
+++ b/src/test/java/org/zalando/nakadi/utils/TestUtils.java
@@ -16,7 +16,6 @@ import org.springframework.validation.FieldError;
 import org.zalando.nakadi.config.JsonConfig;
 import org.zalando.nakadi.domain.BatchItem;
 import org.zalando.nakadi.domain.EventType;
-import org.zalando.nakadi.domain.EventTypeBase;
 import org.zalando.nakadi.domain.Storage;
 import org.zalando.nakadi.domain.Subscription;
 import org.zalando.nakadi.domain.Timeline;
@@ -214,15 +213,15 @@ public class TestUtils {
         return new Timeline(etName, 0, new Storage(), randomUUID(), new Date());
     }
 
-    public static Timeline createFakeTimeline(final String topicName) {
-        return createFakeTimeline(topicName, topicName);
+    public static Timeline buildTimeline(final String etName, final String topic, final Date cratedAt) {
+        return new Timeline(etName, 0, new Storage(), topic, cratedAt);
     }
 
-    public static Timeline createFakeTimeline(final String eventType, final String topicName) {
-        final Storage storage = new Storage();
-        final EventTypeBase eventTypeBase = mock(EventTypeBase.class);
-        when(eventTypeBase.getTopic()).thenReturn(topicName);
-        when(eventTypeBase.getName()).thenReturn(eventType);
-        return Timeline.createFakeTimeline(eventTypeBase, storage);
+    public static Timeline buildTimelineWithTopic(final String topic) {
+        return new Timeline(randomUUID(), 0, new Storage(), topic, new Date());
+    }
+
+    public static String toTimelineOffset(final long offset) {
+        return String.format("001-0001-%018d", offset);
     }
 }


### PR DESCRIPTION
[aruha-984: Create first timeline for event type by default](https://techjira.zalando.net/browse/ARUHA-984)

## Description
Remove topic from event type + remove fake timeline

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
Block creation of event types during rollout 