### PR TITLE
ARUHA-1203 Add delay (by default 2 seconds) between deletion of topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Committing with empty X-Nakadi-StreamId causes 503
+- Massive topic deletion while switching timelines is now made with small interval between deletions
 
 ## [2.2.2] - 2017-09-28
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,7 +88,9 @@ nakadi:
     maxPartitions: 100
   jobs:
     checkRunMs: 600000 # 10 min
-    timelineCleanup.runPeriodMs: 3600000 # 1 hour
+    timelineCleanup:
+      runPeriodMs: 3600000 # 1 hour
+      deletionDelayMs: 2000 # 2 seconds, to be on the safe side
     consumerNodesCleanup.runPeriodMs: 21600000 # 6 hours
 
 twintip:

--- a/src/test/java/org/zalando/nakadi/service/job/TimelineCleaningJobTest.java
+++ b/src/test/java/org/zalando/nakadi/service/job/TimelineCleaningJobTest.java
@@ -43,7 +43,7 @@ public class TimelineCleaningJobTest {
         when(jobWrapperFactory.createExclusiveJobWrapper(any(), anyLong())).thenReturn(jobWrapper);
 
         timelineCleanupJob = new TimelineCleanupJob(eventTypeCache, timelineDbRepository, timelineService,
-                jobWrapperFactory, 0);
+                jobWrapperFactory, 0, 0L);
     }
 
     @Test


### PR DESCRIPTION
[ARUHA-1203: Fix massive topic deletion]

## Description
Kafka may go down in case of deletion of many topics. 
To avoid that while switching timelines the timeout added between deletions

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
Just deploy it
