### PR TITLE
aruha-1242 add event type and application to SLO log

### DIFF
--- a/src/main/java/org/zalando/nakadi/controller/EventPublishingController.java
+++ b/src/main/java/org/zalando/nakadi/controller/EventPublishingController.java
@@ -71,7 +71,7 @@ public class EventPublishingController {
                     request, eventTypeMetrics, client);
             eventTypeMetrics.incrementResponseCount(response.getStatusCode().value());
             return response;
-        } catch (RuntimeException ex) {
+        } catch (final RuntimeException ex) {
             eventTypeMetrics.incrementResponseCount(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
             throw ex;
         }
@@ -91,7 +91,7 @@ public class EventPublishingController {
             final int totalSizeBytes = eventsAsString.getBytes(Charsets.UTF_8).length;
 
             reportMetrics(eventTypeMetrics, result, totalSizeBytes, eventCount);
-            reportSLOs(startingNanos, totalSizeBytes, eventCount, result);
+            reportSLOs(startingNanos, totalSizeBytes, eventCount, result, eventTypeName, client);
 
             return response(result);
         } catch (final JSONException e) {
@@ -109,10 +109,14 @@ public class EventPublishingController {
     }
 
     private void reportSLOs(final long startingNanos, final int totalSizeBytes, final int eventCount,
-                            final EventPublishResult eventPublishResult) {
+                            final EventPublishResult eventPublishResult, final String eventTypeName,
+                            final Client client) {
         if (eventPublishResult.getStatus() == EventPublishingStatus.SUBMITTED) {
             final long msSpent = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startingNanos);
-            LOG.info("[SLO] [publishing-latency] time={} size={} count={}", msSpent, totalSizeBytes, eventCount);
+            final String applicationName = client.getClientId();
+
+            LOG.info("[SLO] [publishing-latency] time={} size={} count={} eventTypeName={} app={}", msSpent,
+                    totalSizeBytes, eventCount, eventTypeName, applicationName);
         }
     }
 


### PR DESCRIPTION
This is part of https://techjira.zalando.net/browse/ARUHA-1242

## Description
By adding event type and the name of the "user" publishing, we are able
to easily identify top publishing applications using scalyr.

We already expose this data in our /metrics endpoint, but as we all know
very well, it has more than 2MB and zmon is just not able to handle it,
specially when running 400 instances for Black Friday.

On the other hand, scalyr, when properly used, is reliable and
performant.

I'm gonna use this new information to identify event types that would
require repartitioning for Black Friday.

## Deployment Notes
It will require a modification in scalyr parser in order to properly extract the new fields and make queries faster.
