### PR TITLE
aruha-1247: increased minimum fetch bytes

### DIFF
--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -101,6 +101,7 @@ public class KafkaLocationManager {
                 "org.apache.kafka.common.serialization.ByteArrayDeserializer");
         properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
                 "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+        properties.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, kafkaSettings.getFetchMinBytes());
         return properties;
     }
 

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSettings.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSettings.java
@@ -17,16 +17,19 @@ public class KafkaSettings {
     private final int batchSize;
     private final long lingerMs;
     private final boolean enableAutoCommit;
+    private final int fetchMinBytes;
 
     @Autowired
     public KafkaSettings(@Value("${nakadi.kafka.request.timeout.ms}") final int requestTimeoutMs,
                          @Value("${nakadi.kafka.batch.size}") final int batchSize,
                          @Value("${nakadi.kafka.linger.ms}") final long lingerMs,
-                         @Value("${nakadi.kafka.enable.auto.commit}") final boolean enableAutoCommit) {
+                         @Value("${nakadi.kafka.enable.auto.commit}") final boolean enableAutoCommit,
+                         @Value("${nakadi.kafka.fetch.min.bytes}") final int fetchMinBytes) {
         this.requestTimeoutMs = requestTimeoutMs;
         this.batchSize = batchSize;
         this.lingerMs = lingerMs;
         this.enableAutoCommit = enableAutoCommit;
+        this.fetchMinBytes = fetchMinBytes;
     }
 
     public int getRequestTimeoutMs() {
@@ -43,5 +46,9 @@ public class KafkaSettings {
 
     public boolean getEnableAutoCommit() {
         return enableAutoCommit;
+    }
+
+    public int getFetchMinBytes() {
+        return fetchMinBytes;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,6 +60,7 @@ nakadi:
     batch.size: 5242880
     linger.ms: 0
     enable.auto.commit: false
+    fetch.min.bytes: 1024 # bytes
   zookeeper:
     kafkaNamespace:
     brokers: 127.0.0.1:2181


### PR DESCRIPTION
[ARUHA-1247: Adjust params Kafka params](https://techjira.zalando.net/browse/ARUHA-1247)

## Description
Kafka broker sends data to consumer once it received 1 byte of data or 500ms passed by default. This PR changes the default behaviour of that.

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG
