### PR TITLE
ARUHA-1316: added default stream_timeout;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Limited stream_timeout for consumption to 1h ± 10min
+
 ## [2.2.8] - 2017-11-01
 
 ### Fixed

--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -2640,16 +2640,20 @@ parameters:
     in: query
     description: |
       Maximum time in seconds a stream will live before connection is closed by the server.
-      If 0 or unspecified will stream indefinitely.
+      If 0 or unspecified will stream for 1h ±10min.
 
       If this timeout is reached, any pending messages (in the sense of `stream_limit`) will be flushed
       to the client.
 
       Stream initialization will fail if `stream_timeout` is lower than `batch_flush_timeout`.
+      If the `stream_timeout` is greater than max value (4200 seconds) - Nakadi will treat this as not
+      specifying `stream_timeout` (this is done due to backwards compatibility).
     type: number
     format: int32
     required: false
     default: 0
+    minimum: 0
+    maximum: 4200
 
   SubscriptionId:
     name: subscription_id

--- a/src/main/java/org/zalando/nakadi/service/EventStreamConfig.java
+++ b/src/main/java/org/zalando/nakadi/service/EventStreamConfig.java
@@ -6,15 +6,18 @@ import org.zalando.nakadi.exceptions.UnprocessableEntityException;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import java.util.List;
+import java.util.Random;
 
 @Immutable
 public class EventStreamConfig {
 
+    public static final int MAX_STREAM_TIMEOUT = 3600 + 600; // 1h 10m
+
     private static final int BATCH_LIMIT_DEFAULT = 1;
     private static final int STREAM_LIMIT_DEFAULT = 0;
     private static final int BATCH_FLUSH_TIMEOUT_DEFAULT = 30;
-    private static final int STREAM_TIMEOUT_DEFAULT = 0;
     private static final int STREAM_KEEP_ALIVE_LIMIT_DEFAULT = 0;
+    private static final Random RANDOM = new Random();
 
     private final List<NakadiCursor> cursors;
     private final int batchLimit;
@@ -108,13 +111,17 @@ public class EventStreamConfig {
         return new Builder();
     }
 
+    public static int generateDefaultStreamTimeout() {
+        return 3600 + RANDOM.nextInt(1200) - 600; // 1h ± 10min
+    }
+
     public static class Builder {
 
         private List<NakadiCursor> cursors = null;
         private int batchLimit = BATCH_LIMIT_DEFAULT;
         private int streamLimit = STREAM_LIMIT_DEFAULT;
         private int batchTimeout = BATCH_FLUSH_TIMEOUT_DEFAULT;
-        private int streamTimeout = STREAM_TIMEOUT_DEFAULT;
+        private int streamTimeout = generateDefaultStreamTimeout();
         private int streamKeepAliveLimit = STREAM_KEEP_ALIVE_LIMIT_DEFAULT;
         private String etName;
         private String consumingAppId;
@@ -150,7 +157,7 @@ public class EventStreamConfig {
         }
 
         public Builder withStreamTimeout(@Nullable final Integer streamTimeout) {
-            if (streamTimeout != null) {
+            if (streamTimeout != null && streamTimeout <= MAX_STREAM_TIMEOUT && streamTimeout > 0) {
                 this.streamTimeout = streamTimeout;
             }
             return this;

--- a/src/main/java/org/zalando/nakadi/service/subscription/StreamParameters.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/StreamParameters.java
@@ -1,6 +1,7 @@
 package org.zalando.nakadi.service.subscription;
 
 import org.zalando.nakadi.exceptions.UnprocessableEntityException;
+import org.zalando.nakadi.service.EventStreamConfig;
 
 import javax.annotation.Nullable;
 import java.util.Optional;
@@ -24,7 +25,7 @@ public class StreamParameters {
     /**
      * Stream time to live
      */
-    public final Optional<Long> streamTimeoutMillis;
+    public final long streamTimeoutMillis;
     /**
      * If count of keepAliveIterations in a row for each batch is reached - stream is closed.
      * Works only if set.
@@ -51,8 +52,10 @@ public class StreamParameters {
         }
         this.streamLimitEvents = Optional.ofNullable(streamLimitEvents).filter(v -> v != 0);
         this.batchTimeoutMillis = batchTimeoutMillis;
-        this.streamTimeoutMillis = Optional.ofNullable(streamTimeoutSeconds)
-                .map(TimeUnit.SECONDS::toMillis).filter(timeout -> timeout.longValue() != 0);
+        this.streamTimeoutMillis = TimeUnit.SECONDS.toMillis(
+                Optional.ofNullable(streamTimeoutSeconds)
+                        .filter(timeout -> timeout > 0 && timeout <= EventStreamConfig.MAX_STREAM_TIMEOUT)
+                        .orElse((long) EventStreamConfig.generateDefaultStreamTimeout()));
         this.batchKeepAliveIterations = Optional.ofNullable(batchKeepAliveIterations);
         this.maxUncommittedMessages = maxUncommittedMessages;
         this.commitTimeoutMillis = commitTimeoutMillis;

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -83,13 +83,12 @@ class StreamingState extends State {
         addTask(this::pollDataFromKafka);
         scheduleTask(this::checkBatchTimeouts, getParameters().batchTimeoutMillis, TimeUnit.MILLISECONDS);
 
-        getParameters().streamTimeoutMillis.ifPresent(
-                timeout -> scheduleTask(() -> {
-                            final String debugMessage = "Stream timeout reached";
-                            this.sendMetadata(debugMessage);
-                            this.shutdownGracefully(debugMessage);
-                        }, timeout,
-                        TimeUnit.MILLISECONDS));
+        scheduleTask(() -> {
+                    final String debugMessage = "Stream timeout reached";
+                    this.sendMetadata(debugMessage);
+                    this.shutdownGracefully(debugMessage);
+                }, getParameters().streamTimeoutMillis,
+                TimeUnit.MILLISECONDS);
 
         this.lastCommitMillis = System.currentTimeMillis();
         scheduleTask(this::checkCommitTimeout, getParameters().commitTimeoutMillis, TimeUnit.MILLISECONDS);

--- a/src/test/java/org/zalando/nakadi/controller/EventStreamControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventStreamControllerTest.java
@@ -70,6 +70,8 @@ import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
 import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -205,19 +207,22 @@ public class EventStreamControllerTest {
                         .header("X-nakadi-cursors", "[{\"partition\":\"0\",\"offset\":\"000000000000000000\"}]"))
                 .andExpect(status().isOk());
 
-        final EventStreamConfig expectedConfig = EventStreamConfig
-                .builder()
-                .withBatchLimit(1)
-                .withBatchTimeout(30)
-                .withCursors(ImmutableList.of(
-                        new NakadiCursor(timeline, "0", "000000000000000000")))
-                .withStreamKeepAliveLimit(0)
-                .withStreamLimit(0)
-                .withStreamTimeout(0)
-                .build();
         // we have to retry here as mockMvc exits at the very beginning, before the body starts streaming
         TestUtils.waitFor(
-                () -> assertThat(configCaptor.getValue(), equalTo(expectedConfig)), 2000, 50, MockitoException.class);
+                () -> {
+                    final EventStreamConfig actualConfig = configCaptor.getValue();
+
+                    assertThat(actualConfig.getBatchLimit(), equalTo(1));
+                    assertThat(actualConfig.getBatchTimeout(), equalTo(30));
+                    assertThat(actualConfig.getCursors(),
+                            equalTo(ImmutableList.of(new NakadiCursor(timeline, "0", "000000000000000000"))));
+                    assertThat(actualConfig.getStreamKeepAliveLimit(), equalTo(0));
+                    assertThat(actualConfig.getStreamLimit(), equalTo(0));
+                    assertThat(actualConfig.getStreamTimeout(),
+                            greaterThanOrEqualTo(EventStreamConfig.MAX_STREAM_TIMEOUT - 1200));
+                    assertThat(actualConfig.getStreamTimeout(),
+                            lessThanOrEqualTo(EventStreamConfig.MAX_STREAM_TIMEOUT));
+                }, 2000, 50, MockitoException.class);
     }
 
     @Test

--- a/src/test/java/org/zalando/nakadi/controller/EventStreamControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventStreamControllerTest.java
@@ -208,21 +208,20 @@ public class EventStreamControllerTest {
                 .andExpect(status().isOk());
 
         // we have to retry here as mockMvc exits at the very beginning, before the body starts streaming
-        TestUtils.waitFor(
-                () -> {
-                    final EventStreamConfig actualConfig = configCaptor.getValue();
+        TestUtils.waitFor(() -> {
+            final EventStreamConfig actualConfig = configCaptor.getValue();
 
-                    assertThat(actualConfig.getBatchLimit(), equalTo(1));
-                    assertThat(actualConfig.getBatchTimeout(), equalTo(30));
-                    assertThat(actualConfig.getCursors(),
-                            equalTo(ImmutableList.of(new NakadiCursor(timeline, "0", "000000000000000000"))));
-                    assertThat(actualConfig.getStreamKeepAliveLimit(), equalTo(0));
-                    assertThat(actualConfig.getStreamLimit(), equalTo(0));
-                    assertThat(actualConfig.getStreamTimeout(),
-                            greaterThanOrEqualTo(EventStreamConfig.MAX_STREAM_TIMEOUT - 1200));
-                    assertThat(actualConfig.getStreamTimeout(),
-                            lessThanOrEqualTo(EventStreamConfig.MAX_STREAM_TIMEOUT));
-                }, 2000, 50, MockitoException.class);
+            assertThat(actualConfig.getBatchLimit(), equalTo(1));
+            assertThat(actualConfig.getBatchTimeout(), equalTo(30));
+            assertThat(actualConfig.getCursors(),
+                    equalTo(ImmutableList.of(new NakadiCursor(timeline, "0", "000000000000000000"))));
+            assertThat(actualConfig.getStreamKeepAliveLimit(), equalTo(0));
+            assertThat(actualConfig.getStreamLimit(), equalTo(0));
+            assertThat(actualConfig.getStreamTimeout(),
+                    greaterThanOrEqualTo(EventStreamConfig.MAX_STREAM_TIMEOUT - 1200));
+            assertThat(actualConfig.getStreamTimeout(),
+                    lessThanOrEqualTo(EventStreamConfig.MAX_STREAM_TIMEOUT));
+        }, 2000, 50, MockitoException.class);
     }
 
     @Test

--- a/src/test/java/org/zalando/nakadi/service/EventStreamConfigBuilderTest.java
+++ b/src/test/java/org/zalando/nakadi/service/EventStreamConfigBuilderTest.java
@@ -3,8 +3,11 @@ package org.zalando.nakadi.service;
 import org.junit.Test;
 import org.zalando.nakadi.exceptions.UnprocessableEntityException;
 
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.zalando.nakadi.service.EventStreamConfig.MAX_STREAM_TIMEOUT;
 
 public class EventStreamConfigBuilderTest {
 
@@ -56,6 +59,27 @@ public class EventStreamConfigBuilderTest {
                 .withBatchTimeout(10)
                 .withStreamTimeout(1)
                 .build();
+    }
+
+    @Test
+    public void streamTimeoutHigherThanMax() throws UnprocessableEntityException {
+        final EventStreamConfig config = EventStreamConfig
+                .builder()
+                .withStreamTimeout(MAX_STREAM_TIMEOUT + 100)
+                .build();
+
+        assertThat(config.getStreamTimeout(), lessThanOrEqualTo(MAX_STREAM_TIMEOUT));
+    }
+
+    @Test
+    public void unlimitedStreamTimeout() throws UnprocessableEntityException {
+        final EventStreamConfig config = EventStreamConfig
+                .builder()
+                .withStreamTimeout(0)
+                .build();
+
+        assertThat(config.getStreamTimeout(), greaterThan(0));
+        assertThat(config.getStreamTimeout(), lessThanOrEqualTo(MAX_STREAM_TIMEOUT));
     }
 
 }

--- a/src/test/java/org/zalando/nakadi/service/subscription/StreamParametersTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/StreamParametersTest.java
@@ -1,0 +1,81 @@
+package org.zalando.nakadi.service.subscription;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.zalando.nakadi.exceptions.UnprocessableEntityException;
+import org.zalando.nakadi.service.EventStreamConfig;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
+
+public class StreamParametersTest {
+
+    @Test(expected = UnprocessableEntityException.class)
+    public void whenBatchLimitLowerOrEqualToZeroTheException() throws Exception{
+        StreamParameters.of(0, null, 0, null, null, 0, 0, "");
+    }
+
+    @Test
+    public void checkParamsAreTransformedCorrectly() throws Exception{
+        final StreamParameters streamParameters = StreamParameters.of(1, null, 10, 60L, null, 1000, 20, "");
+
+        assertThat(streamParameters.batchLimitEvents, equalTo(1));
+        assertThat(streamParameters.batchTimeoutMillis, equalTo(10000L));
+        assertThat(streamParameters.streamTimeoutMillis, equalTo(60000L));
+        assertThat(streamParameters.maxUncommittedMessages, equalTo(1000));
+        assertThat(streamParameters.commitTimeoutMillis, equalTo(20000L));
+    }
+
+    @Test
+    public void whenStreamTimeoutOmittedThenItIsGenerated() throws Exception{
+        final StreamParameters streamParameters = StreamParameters.of(1, null, 0, null, null, 0, 0, "");
+
+        checkStreamTimeoutIsGeneratedCorrectly(streamParameters);
+    }
+
+    @Test
+    public void whenStreamTimeoutIsGreaterThanMaxThenItIsGenerated() throws Exception{
+        final StreamParameters streamParameters = StreamParameters.of(1, null, 0,
+                EventStreamConfig.MAX_STREAM_TIMEOUT + 1L, null, 0, 0, "");
+
+        checkStreamTimeoutIsGeneratedCorrectly(streamParameters);
+    }
+
+    @Test
+    public void checkIsStreamLimitReached() throws Exception{
+        final StreamParameters streamParameters = StreamParameters.of(1, 150L, 0, null, null, 0, 0, "");
+
+        assertThat(streamParameters.isStreamLimitReached(140), is(false));
+        assertThat(streamParameters.isStreamLimitReached(151), is(true));
+        assertThat(streamParameters.isStreamLimitReached(150), is(true));
+    }
+
+    @Test
+    public void checkIsKeepAliveLimitReached() throws Exception{
+        final StreamParameters streamParameters = StreamParameters.of(1, null, 0, null, 5, 0, 0, "");
+
+        assertThat(streamParameters.isKeepAliveLimitReached(IntStream.of(5, 7, 6, 12)), is(true));
+        assertThat(streamParameters.isKeepAliveLimitReached(IntStream.of(5, 7, 4, 12)), is(false));
+    }
+
+    @Test
+    public void checkgetMessagesAllowedToSend() throws Exception{
+        final StreamParameters streamParameters = StreamParameters.of(1, 200L, 0, null, null, 0, 0, "");
+
+        assertThat(streamParameters.getMessagesAllowedToSend(50, 190), equalTo(10L));
+        assertThat(streamParameters.getMessagesAllowedToSend(50, 120), equalTo(50L));
+    }
+
+    private void checkStreamTimeoutIsGeneratedCorrectly(final StreamParameters streamParameters) {
+        assertThat(streamParameters.streamTimeoutMillis, lessThanOrEqualTo(
+                TimeUnit.SECONDS.toMillis((long) EventStreamConfig.MAX_STREAM_TIMEOUT)));
+        assertThat(streamParameters.streamTimeoutMillis, greaterThanOrEqualTo(
+                TimeUnit.SECONDS.toMillis((long)EventStreamConfig.MAX_STREAM_TIMEOUT - 1200)));
+    }
+}

--- a/src/test/java/org/zalando/nakadi/service/subscription/StreamParametersTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/StreamParametersTest.java
@@ -1,6 +1,5 @@
 package org.zalando.nakadi.service.subscription;
 
-import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.zalando.nakadi.exceptions.UnprocessableEntityException;
 import org.zalando.nakadi.service.EventStreamConfig;
@@ -17,12 +16,12 @@ import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
 public class StreamParametersTest {
 
     @Test(expected = UnprocessableEntityException.class)
-    public void whenBatchLimitLowerOrEqualToZeroTheException() throws Exception{
+    public void whenBatchLimitLowerOrEqualToZeroTheException() throws Exception {
         StreamParameters.of(0, null, 0, null, null, 0, 0, "");
     }
 
     @Test
-    public void checkParamsAreTransformedCorrectly() throws Exception{
+    public void checkParamsAreTransformedCorrectly() throws Exception {
         final StreamParameters streamParameters = StreamParameters.of(1, null, 10, 60L, null, 1000, 20, "");
 
         assertThat(streamParameters.batchLimitEvents, equalTo(1));
@@ -33,14 +32,14 @@ public class StreamParametersTest {
     }
 
     @Test
-    public void whenStreamTimeoutOmittedThenItIsGenerated() throws Exception{
+    public void whenStreamTimeoutOmittedThenItIsGenerated() throws Exception {
         final StreamParameters streamParameters = StreamParameters.of(1, null, 0, null, null, 0, 0, "");
 
         checkStreamTimeoutIsGeneratedCorrectly(streamParameters);
     }
 
     @Test
-    public void whenStreamTimeoutIsGreaterThanMaxThenItIsGenerated() throws Exception{
+    public void whenStreamTimeoutIsGreaterThanMaxThenItIsGenerated() throws Exception {
         final StreamParameters streamParameters = StreamParameters.of(1, null, 0,
                 EventStreamConfig.MAX_STREAM_TIMEOUT + 1L, null, 0, 0, "");
 
@@ -48,7 +47,7 @@ public class StreamParametersTest {
     }
 
     @Test
-    public void checkIsStreamLimitReached() throws Exception{
+    public void checkIsStreamLimitReached() throws Exception {
         final StreamParameters streamParameters = StreamParameters.of(1, 150L, 0, null, null, 0, 0, "");
 
         assertThat(streamParameters.isStreamLimitReached(140), is(false));
@@ -57,7 +56,7 @@ public class StreamParametersTest {
     }
 
     @Test
-    public void checkIsKeepAliveLimitReached() throws Exception{
+    public void checkIsKeepAliveLimitReached() throws Exception {
         final StreamParameters streamParameters = StreamParameters.of(1, null, 0, null, 5, 0, 0, "");
 
         assertThat(streamParameters.isKeepAliveLimitReached(IntStream.of(5, 7, 6, 12)), is(true));
@@ -65,7 +64,7 @@ public class StreamParametersTest {
     }
 
     @Test
-    public void checkgetMessagesAllowedToSend() throws Exception{
+    public void checkgetMessagesAllowedToSend() throws Exception {
         final StreamParameters streamParameters = StreamParameters.of(1, 200L, 0, null, null, 0, 0, "");
 
         assertThat(streamParameters.getMessagesAllowedToSend(50, 190), equalTo(10L));
@@ -76,6 +75,6 @@ public class StreamParametersTest {
         assertThat(streamParameters.streamTimeoutMillis, lessThanOrEqualTo(
                 TimeUnit.SECONDS.toMillis((long) EventStreamConfig.MAX_STREAM_TIMEOUT)));
         assertThat(streamParameters.streamTimeoutMillis, greaterThanOrEqualTo(
-                TimeUnit.SECONDS.toMillis((long)EventStreamConfig.MAX_STREAM_TIMEOUT - 1200)));
+                TimeUnit.SECONDS.toMillis((long) EventStreamConfig.MAX_STREAM_TIMEOUT - 1200)));
     }
 }


### PR DESCRIPTION
[ARUHA-1316: Limit stream_timeout for LoLA and HiLA](https://techjira.zalando.net/browse/ARUHA-1316)

## Description
Limited stream timeout to 1h ±10min.

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
We should watch carefully in a case it brings problems to our users.
