### PR TITLE
change order of event types

### DIFF
--- a/docs/_documentation/using_event-types.md
+++ b/docs/_documentation/using_event-types.md
@@ -18,11 +18,11 @@ API that lists all the available event types.
 
 There are three main _categories_ of event type defined by Nakadi -
 
-- **Undefined Event**: A free form category suitable for events that are entirely custom to the producer.
+- **Business Event**: An event that is part of, or drives a business process, such as a state transition in a customer order.
 
 - **Data Change Event**: An event that represents a change to a record or other item, or a new item. Change events are associated with a create, update, delete, or snapshot operation.
 
-- **Business Event**: An event that is part of, or drives a business process, such as a state transition in a customer order.
+- **Undefined Event**: A free form category suitable for events that are entirely custom to the producer.
 
 Each event category enables different capabilities for an event type, notably their schema and validation rules, which we'll describe next.
 


### PR DESCRIPTION
Changed order of event types to demote usage of the undefined event type.

If a user is reading the docs, the first thing (s)he sees is the undefined event type. In order to promote the usage of well-structured event types, I propose to change the order.

[ARUHA-XXX: Name of ticket](link to ticket)

## Description
A few sentences describing the overall goals of the pull request's
commits.

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
