### PR TITLE
Aruha 1347 - do not fail when getting subscriptions stats with deleted storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue with subscription stats, which would fail when the last committed offset is on a storage that was deleted
+
 ## [2.3.0] - 2017-11-14
 
 ### Added

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/SubscriptionAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/SubscriptionAT.java
@@ -388,12 +388,6 @@ public class SubscriptionAT extends BaseAT {
         }
     }
 
-    @Test
-    public void whenStatsWithOffsetInDeletedStorageThenDoNotFail() throws IOException {
-        final String et = createEventType().getName();
-        final Subscription s = createSubscriptionForEventType(et);
-    }
-
     private Response commitCursors(final Subscription subscription, final String cursor, final String streamId) {
         return given()
                 .body(cursor)

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/SubscriptionAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/SubscriptionAT.java
@@ -388,6 +388,12 @@ public class SubscriptionAT extends BaseAT {
         }
     }
 
+    @Test
+    public void whenStatsWithOffsetInDeletedStorageThenDoNotFail() throws IOException {
+        final String et = createEventType().getName();
+        final Subscription s = createSubscriptionForEventType(et);
+    }
+
     private Response commitCursors(final Subscription subscription, final String cursor, final String streamId) {
         return given()
                 .body(cursor)

--- a/src/main/java/org/zalando/nakadi/exceptions/runtime/UnknownStorageTypeException.java
+++ b/src/main/java/org/zalando/nakadi/exceptions/runtime/UnknownStorageTypeException.java
@@ -1,0 +1,12 @@
+package org.zalando.nakadi.exceptions.runtime;
+
+public class UnknownStorageTypeException extends MyNakadiRuntimeException1 {
+
+    public UnknownStorageTypeException(final String message) {
+        super(message);
+    }
+
+    public UnknownStorageTypeException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/zalando/nakadi/repository/TopicRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/TopicRepository.java
@@ -77,8 +77,6 @@ public interface TopicRepository {
 
     long totalEventsInPartition(Timeline timeline, String partition);
 
-    long numberOfEventsBeforeCursor(NakadiCursor cursor);
-
     void setRetentionTime(String topic, Long retentionMs) throws TopicConfigException;
 
     NakadiCursor createBeforeBeginCursor(Timeline timeline, String partition);

--- a/src/main/java/org/zalando/nakadi/repository/TopicRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/TopicRepository.java
@@ -75,8 +75,6 @@ public interface TopicRepository {
 
     void validateCommitCursor(NakadiCursor cursor) throws InvalidCursorException;
 
-    long totalEventsInPartition(Timeline timeline, String partition);
-
     void setRetentionTime(String topic, Long retentionMs) throws TopicConfigException;
 
     NakadiCursor createBeforeBeginCursor(Timeline timeline, String partition);

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -33,7 +33,6 @@ import org.zalando.nakadi.exceptions.InvalidCursorException;
 import org.zalando.nakadi.exceptions.ServiceUnavailableException;
 import org.zalando.nakadi.exceptions.TopicCreationException;
 import org.zalando.nakadi.exceptions.TopicDeletionException;
-import org.zalando.nakadi.exceptions.runtime.InvalidCursorOperation;
 import org.zalando.nakadi.exceptions.runtime.TopicConfigException;
 import org.zalando.nakadi.exceptions.runtime.TopicRepositoryException;
 import org.zalando.nakadi.repository.EventConsumer;
@@ -455,19 +454,6 @@ public class KafkaTopicRepository implements TopicRepository {
 
     public int compareOffsets(final NakadiCursor first, final NakadiCursor second) throws InvalidCursorException {
         return KafkaCursor.fromNakadiCursor(first).compareTo(KafkaCursor.fromNakadiCursor(second));
-    }
-
-    //  Method can work only with finished timeline (e.g. it will break for active timeline)
-    public long totalEventsInPartition(final Timeline timeline, final String partitionString)
-            throws InvalidCursorOperation {
-        final Timeline.StoragePosition positions = timeline.getLatestPosition();
-
-        try {
-            return 1 + ((Timeline.KafkaStoragePosition) positions).getLastOffsetForPartition(
-                    KafkaCursor.toKafkaPartition(partitionString));
-        } catch (final IllegalArgumentException ex) {
-            throw new InvalidCursorOperation(InvalidCursorOperation.Reason.PARTITION_NOT_FOUND);
-        }
     }
 
     @Override

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -470,11 +470,6 @@ public class KafkaTopicRepository implements TopicRepository {
         }
     }
 
-    public long numberOfEventsBeforeCursor(final NakadiCursor cursor) {
-        // could be -1 in case the cursor points to BEGIN
-        return KafkaCursor.toKafkaOffset(cursor.getOffset());
-    }
-
     @Override
     public NakadiCursor createBeforeBeginCursor(final Timeline timeline, final String partition) {
         return new KafkaCursor(timeline.getTopic(), KafkaCursor.toKafkaPartition(partition), -1)

--- a/src/main/java/org/zalando/nakadi/service/CursorOperationsService.java
+++ b/src/main/java/org/zalando/nakadi/service/CursorOperationsService.java
@@ -89,8 +89,7 @@ public class CursorOperationsService {
                                 .findAny().orElseThrow(() -> new InvalidCursorOperation(PARTITION_NOT_FOUND));
                         // trick to avoid -1 position - move cursor to previous timeline while there is no data before
                         // it
-                        while (getTopicRepository(newestPosition.getTimeline())
-                                .numberOfEventsBeforeCursor(newestPosition) == -1) {
+                        while (numberOfEventsBeforeCursor(newestPosition) == -1) {
                             final int prevOrder = newestPosition.getTimeline().getOrder() - 1;
                             final Timeline prevTimeline = timelines.stream()
                                     .filter(t -> t.getOrder() == prevOrder)
@@ -168,8 +167,7 @@ public class CursorOperationsService {
         NakadiCursor currentCursor = new NakadiCursor(cursor.getTimeline(), cursor.getPartition(), cursor.getOffset());
         long toMoveBack = -cursor.getShift();
         while (toMoveBack > 0) {
-            final long totalBefore = getTopicRepository(currentCursor.getTimeline())
-                    .numberOfEventsBeforeCursor(currentCursor);
+            final long totalBefore = numberOfEventsBeforeCursor(currentCursor);
             if (totalBefore < toMoveBack) {
                 toMoveBack -= totalBefore + 1; // +1 is because end is inclusive
 

--- a/src/test/java/org/zalando/nakadi/controller/SubscriptionControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/SubscriptionControllerTest.java
@@ -18,12 +18,14 @@ import org.zalando.nakadi.domain.NakadiCursor;
 import org.zalando.nakadi.domain.PaginationLinks;
 import org.zalando.nakadi.domain.PaginationWrapper;
 import org.zalando.nakadi.domain.PartitionEndStatistics;
+import org.zalando.nakadi.domain.Storage;
 import org.zalando.nakadi.domain.Subscription;
 import org.zalando.nakadi.domain.SubscriptionEventTypeStats;
 import org.zalando.nakadi.domain.Timeline;
 import org.zalando.nakadi.exceptions.NoSuchEventTypeException;
 import org.zalando.nakadi.exceptions.NoSuchSubscriptionException;
 import org.zalando.nakadi.exceptions.ServiceUnavailableException;
+import org.zalando.nakadi.exceptions.runtime.MyNakadiRuntimeException1;
 import org.zalando.nakadi.plugin.api.ApplicationService;
 import org.zalando.nakadi.repository.EventTypeRepository;
 import org.zalando.nakadi.repository.TopicRepository;
@@ -49,6 +51,7 @@ import org.zalando.problem.ThrowableProblem;
 
 import javax.ws.rs.core.Response;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -74,6 +77,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 import static org.zalando.nakadi.util.SubscriptionsUriHelper.createSubscriptionListUri;
 import static org.zalando.nakadi.utils.RandomSubscriptionBuilder.builder;
+import static org.zalando.nakadi.utils.TestUtils.buildTimeline;
 import static org.zalando.nakadi.utils.TestUtils.buildTimelineWithTopic;
 import static org.zalando.nakadi.utils.TestUtils.createRandomSubscriptions;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
@@ -89,6 +93,7 @@ public class SubscriptionControllerTest {
     private final ZkSubscriptionClient zkSubscriptionClient;
     private final CursorConverter cursorConverter;
     private final CursorOperationsService cursorOperationsService;
+    private final TimelineService timelineService;
     private static final int PARTITIONS_PER_SUBSCRIPTION = 5;
     private static final Timeline TIMELINE = buildTimelineWithTopic("topic");
 
@@ -102,7 +107,7 @@ public class SubscriptionControllerTest {
         final SubscriptionClientFactory zkSubscriptionClientFactory = mock(SubscriptionClientFactory.class);
         zkSubscriptionClient = mock(ZkSubscriptionClient.class);
         when(zkSubscriptionClientFactory.createClient(any(), any())).thenReturn(zkSubscriptionClient);
-        final TimelineService timelineService = mock(TimelineService.class);
+        timelineService = mock(TimelineService.class);
         when(timelineService.getActiveTimeline(any())).thenReturn(TIMELINE);
         when(timelineService.getTopicRepository((EventTypeBase) any())).thenReturn(topicRepository);
         when(timelineService.getTopicRepository((Timeline) any())).thenReturn(topicRepository);
@@ -255,6 +260,37 @@ public class SubscriptionControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().string(
                         TestUtils.JSON_TEST_HELPER.matchesObject(new ItemsWrapper<>(expectedStats))));
+    }
+
+    @Test
+    public void whenGetSubscriptionStatsWithOffsetFromDeletedStorageThenOk() throws Exception {
+        Storage deletedStorage = new Storage();
+        final Timeline TIMELINE_DELETED_STORAGE = buildTimeline(TIMELINE.getEventType(), deletedStorage, "topic", new Date());
+        final Subscription subscription = builder().withEventType(TIMELINE_DELETED_STORAGE.getEventType()).build();
+        final Partition[] partitions = {
+                new Partition(TIMELINE.getEventType(), "0", "xz", null, Partition.State.ASSIGNED)};
+        final ZkSubscriptionNode zkSubscriptionNode = new ZkSubscriptionNode();
+        zkSubscriptionNode.setPartitions(partitions);
+        zkSubscriptionNode.setSessions(new Session[]{new Session("xz", 0)});
+        when(subscriptionRepository.getSubscription(subscription.getId())).thenReturn(subscription);
+        when(zkSubscriptionClient.getZkSubscriptionNodeLocked()).thenReturn(zkSubscriptionNode);
+        final SubscriptionCursorWithoutToken currentOffset =
+                new SubscriptionCursorWithoutToken(TIMELINE.getEventType(), "0", "3");
+        when(zkSubscriptionClient.getOffset(new EventTypePartition(TIMELINE.getEventType(), "0")))
+                .thenReturn(currentOffset);
+        when(eventTypeRepository.findByName(TIMELINE.getEventType()))
+                .thenReturn(EventTypeTestBuilder.builder().name(TIMELINE.getEventType()).build());
+        final List<PartitionEndStatistics> statistics = Collections.singletonList(
+                new KafkaPartitionEndStatistics(TIMELINE, 0, 13));
+        when(topicRepository.loadTopicEndStatistics(eq(Collections.singletonList(TIMELINE)))).thenReturn(statistics);
+        final NakadiCursor currentCursor = mock(NakadiCursor.class);
+        when(currentCursor.getEventTypePartition()).thenReturn(new EventTypePartition(TIMELINE.getEventType(), "0"));
+        when(cursorConverter.convert((List<SubscriptionCursorWithoutToken>) any()))
+                .thenReturn(Collections.singletonList(currentCursor));
+        when(timelineService.getTopicRepository(TIMELINE_DELETED_STORAGE)).thenThrow(new MyNakadiRuntimeException1("Exception"));
+
+        getSubscriptionStats(subscription.getId())
+                .andExpect(status().isOk());
     }
 
     @Test

--- a/src/test/java/org/zalando/nakadi/controller/SubscriptionControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/SubscriptionControllerTest.java
@@ -18,14 +18,12 @@ import org.zalando.nakadi.domain.NakadiCursor;
 import org.zalando.nakadi.domain.PaginationLinks;
 import org.zalando.nakadi.domain.PaginationWrapper;
 import org.zalando.nakadi.domain.PartitionEndStatistics;
-import org.zalando.nakadi.domain.Storage;
 import org.zalando.nakadi.domain.Subscription;
 import org.zalando.nakadi.domain.SubscriptionEventTypeStats;
 import org.zalando.nakadi.domain.Timeline;
 import org.zalando.nakadi.exceptions.NoSuchEventTypeException;
 import org.zalando.nakadi.exceptions.NoSuchSubscriptionException;
 import org.zalando.nakadi.exceptions.ServiceUnavailableException;
-import org.zalando.nakadi.exceptions.runtime.MyNakadiRuntimeException1;
 import org.zalando.nakadi.plugin.api.ApplicationService;
 import org.zalando.nakadi.repository.EventTypeRepository;
 import org.zalando.nakadi.repository.TopicRepository;
@@ -51,7 +49,6 @@ import org.zalando.problem.ThrowableProblem;
 
 import javax.ws.rs.core.Response;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -77,7 +74,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 import static org.zalando.nakadi.util.SubscriptionsUriHelper.createSubscriptionListUri;
 import static org.zalando.nakadi.utils.RandomSubscriptionBuilder.builder;
-import static org.zalando.nakadi.utils.TestUtils.buildTimeline;
 import static org.zalando.nakadi.utils.TestUtils.buildTimelineWithTopic;
 import static org.zalando.nakadi.utils.TestUtils.createRandomSubscriptions;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
@@ -260,37 +256,6 @@ public class SubscriptionControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().string(
                         TestUtils.JSON_TEST_HELPER.matchesObject(new ItemsWrapper<>(expectedStats))));
-    }
-
-    @Test
-    public void whenGetSubscriptionStatsWithOffsetFromDeletedStorageThenOk() throws Exception {
-        Storage deletedStorage = new Storage();
-        final Timeline TIMELINE_DELETED_STORAGE = buildTimeline(TIMELINE.getEventType(), deletedStorage, "topic", new Date());
-        final Subscription subscription = builder().withEventType(TIMELINE_DELETED_STORAGE.getEventType()).build();
-        final Partition[] partitions = {
-                new Partition(TIMELINE.getEventType(), "0", "xz", null, Partition.State.ASSIGNED)};
-        final ZkSubscriptionNode zkSubscriptionNode = new ZkSubscriptionNode();
-        zkSubscriptionNode.setPartitions(partitions);
-        zkSubscriptionNode.setSessions(new Session[]{new Session("xz", 0)});
-        when(subscriptionRepository.getSubscription(subscription.getId())).thenReturn(subscription);
-        when(zkSubscriptionClient.getZkSubscriptionNodeLocked()).thenReturn(zkSubscriptionNode);
-        final SubscriptionCursorWithoutToken currentOffset =
-                new SubscriptionCursorWithoutToken(TIMELINE.getEventType(), "0", "3");
-        when(zkSubscriptionClient.getOffset(new EventTypePartition(TIMELINE.getEventType(), "0")))
-                .thenReturn(currentOffset);
-        when(eventTypeRepository.findByName(TIMELINE.getEventType()))
-                .thenReturn(EventTypeTestBuilder.builder().name(TIMELINE.getEventType()).build());
-        final List<PartitionEndStatistics> statistics = Collections.singletonList(
-                new KafkaPartitionEndStatistics(TIMELINE, 0, 13));
-        when(topicRepository.loadTopicEndStatistics(eq(Collections.singletonList(TIMELINE)))).thenReturn(statistics);
-        final NakadiCursor currentCursor = mock(NakadiCursor.class);
-        when(currentCursor.getEventTypePartition()).thenReturn(new EventTypePartition(TIMELINE.getEventType(), "0"));
-        when(cursorConverter.convert((List<SubscriptionCursorWithoutToken>) any()))
-                .thenReturn(Collections.singletonList(currentCursor));
-        when(timelineService.getTopicRepository(TIMELINE_DELETED_STORAGE)).thenThrow(new MyNakadiRuntimeException1("Exception"));
-
-        getSubscriptionStats(subscription.getId())
-                .andExpect(status().isOk());
     }
 
     @Test

--- a/src/test/java/org/zalando/nakadi/service/CursorOperationsServiceTest.java
+++ b/src/test/java/org/zalando/nakadi/service/CursorOperationsServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.zalando.nakadi.config.NakadiSettings;
 import org.zalando.nakadi.domain.NakadiCursor;
 import org.zalando.nakadi.domain.ShiftedNakadiCursor;
+import org.zalando.nakadi.domain.Storage;
 import org.zalando.nakadi.domain.Timeline;
 import org.zalando.nakadi.exceptions.runtime.InvalidCursorOperation;
 import org.zalando.nakadi.repository.TopicRepository;
@@ -303,6 +304,10 @@ public class CursorOperationsServiceTest {
     private Timeline mockTimeline(final int order, @Nullable final Long latestOffset) {
         final Timeline timeline = mock(Timeline.class);
         when(timeline.getOrder()).thenReturn(order);
+
+        final Storage storage = new Storage();
+        storage.setType(Storage.Type.KAFKA);
+        when(timeline.getStorage()).thenReturn(storage);
 
         if (latestOffset == null) {
             when(timeline.isActive()).thenReturn(false);

--- a/src/test/java/org/zalando/nakadi/utils/TestUtils.java
+++ b/src/test/java/org/zalando/nakadi/utils/TestUtils.java
@@ -217,10 +217,6 @@ public class TestUtils {
         return new Timeline(etName, 0, new Storage(), topic, createdAt);
     }
 
-    public static Timeline buildTimeline(final String etName, final Storage storage, final String topic, final Date createdAt) {
-        return new Timeline(etName, 0, storage, topic, createdAt);
-    }
-
     public static Timeline buildTimelineWithTopic(final String topic) {
         return new Timeline(randomUUID(), 0, new Storage(), topic, new Date());
     }

--- a/src/test/java/org/zalando/nakadi/utils/TestUtils.java
+++ b/src/test/java/org/zalando/nakadi/utils/TestUtils.java
@@ -213,8 +213,12 @@ public class TestUtils {
         return new Timeline(etName, 0, new Storage(), randomUUID(), new Date());
     }
 
-    public static Timeline buildTimeline(final String etName, final String topic, final Date cratedAt) {
-        return new Timeline(etName, 0, new Storage(), topic, cratedAt);
+    public static Timeline buildTimeline(final String etName, final String topic, final Date createdAt) {
+        return new Timeline(etName, 0, new Storage(), topic, createdAt);
+    }
+
+    public static Timeline buildTimeline(final String etName, final Storage storage, final String topic, final Date createdAt) {
+        return new Timeline(etName, 0, storage, topic, createdAt);
     }
 
     public static Timeline buildTimelineWithTopic(final String topic) {


### PR DESCRIPTION
ARUHA-1347: /stats returns 500s, after Kafka cluster is removed

## Description
In this PR, we do not try to create a TopicRepository when calling /stats, which fails when the cluster has been deleted.

This PR is a quick fix. A more thorough refactoring of Cursors should be planned

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG
