### PR TITLE
Add timeout for subscription locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Added timeout for subscription locking
+
 ## [2.4.1] - 2017-12-18
 
 ### Fixed


### PR DESCRIPTION
[ARUHA-1388: Subscription is locked in ZK]

## Description
There is an unreproducable bug in curator library with obtaining a lock with this actions: 
1. Create lease
2. Loose zk connection
3. Try to delete lease and fail

It is impossible to reproduce, and it is really really really rare. 
In order to reduce the impact on system because of this bug and provide log entries to filter on, we will just log it for further investigation. 
