### PR TITLE
Aruha 1387 faster stream initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Optimized stream initialization
+
 ## [2.3.3] - 2017-12-12
 
 ### Added

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StartingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StartingState.java
@@ -1,5 +1,6 @@
 package org.zalando.nakadi.service.subscription.state;
 
+import org.zalando.nakadi.domain.PartitionEndStatistics;
 import org.zalando.nakadi.domain.PartitionStatistics;
 import org.zalando.nakadi.domain.Subscription;
 import org.zalando.nakadi.domain.SubscriptionBase;
@@ -171,12 +172,12 @@ public class StartingState extends State {
                     .flatMap(timelines -> {
                         try {
                             return timelineService.getTopicRepository(timelines.get(0))
-                                    .loadTopicStatistics(timelines).stream();
+                                    .loadTopicEndStatistics(timelines).stream();
                         } catch (final ServiceUnavailableException e) {
                             throw new NakadiRuntimeException(e);
                         }
                     })
-                    .map(PartitionStatistics::getLast)
+                    .map(PartitionEndStatistics::getLast)
                     .map(converter::convertToNoToken)
                     .collect(Collectors.toList());
         }

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -481,9 +481,7 @@ class StreamingState extends State {
                     }
                 })
                 .map(PartitionStatistics::getBeforeFirst)
-                .collect(Collectors.toMap(
-                        cursor -> new EventTypePartition(cursor.getEventType(), cursor.getPartition()),
-                        cursor -> cursor));
+                .collect(Collectors.toMap(NakadiCursor::getEventTypePartition, cursor -> cursor));
     }
 
     private NakadiCursor createNakadiCursor(final SubscriptionCursorWithoutToken cursor) {

--- a/src/test/java/org/zalando/nakadi/service/subscription/StartingStateTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/StartingStateTest.java
@@ -108,7 +108,7 @@ public class StartingStateTest {
         final PartitionStatistics statsForTopic1 = mock(PartitionStatistics.class);
         when(statsForTopic1.getLast()).thenReturn(end1);
 
-        when(topicRepository.loadTopicStatistics(any())).thenReturn(Lists.newArrayList(statsForEt0, statsForTopic1));
+        when(topicRepository.loadTopicEndStatistics(any())).thenReturn(Lists.newArrayList(statsForEt0, statsForTopic1));
 
         when(timelineService.getTopicRepository(eq(timelineEt01))).thenReturn(topicRepository);
 

--- a/src/test/java/org/zalando/nakadi/service/subscription/state/StreamingStateTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/state/StreamingStateTest.java
@@ -1,12 +1,14 @@
 package org.zalando.nakadi.service.subscription.state;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.zalando.nakadi.domain.EventTypePartition;
 import org.zalando.nakadi.domain.NakadiCursor;
 import org.zalando.nakadi.domain.PartitionStatistics;
+import org.zalando.nakadi.domain.Storage;
 import org.zalando.nakadi.domain.Subscription;
 import org.zalando.nakadi.domain.Timeline;
 import org.zalando.nakadi.exceptions.InternalNakadiException;
@@ -26,7 +28,6 @@ import org.zalando.nakadi.view.SubscriptionCursorWithoutToken;
 
 import java.util.Collections;
 import java.util.Date;
-import java.util.Optional;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -121,13 +122,14 @@ public class StreamingStateTest {
         when(timelineService.createEventConsumer(any())).thenReturn(consumer);
         when(subscription.getEventTypes()).thenReturn(Collections.singleton("t"));
 
-        final Timeline timeline = new Timeline("t", 0, null, "t", new Date());
+        final Storage storage = mock(Storage.class);
+        final Timeline timeline = new Timeline("t", 0, storage, "t", new Date());
         when(timelineService.getActiveTimelinesOrdered(eq("t"))).thenReturn(Collections.singletonList(timeline));
         final TopicRepository topicRepository = mock(TopicRepository.class);
         when(timelineService.getTopicRepository(eq(timeline))).thenReturn(topicRepository);
         final PartitionStatistics stats = mock(PartitionStatistics.class);
         when(stats.getBeforeFirst()).thenReturn(new NakadiCursor(timeline, "0", "0"));
-        when(topicRepository.loadPartitionStatistics(eq(timeline), eq("0"))).thenReturn(Optional.of(stats));
+        when(topicRepository.loadTopicStatistics(any())).thenReturn(Lists.newArrayList(stats));
 
         state.onEnter();
 


### PR DESCRIPTION
https://techjira.zalando.net/browse/ARUHA-1387

## Description
This PR optimizes the initialization of streams with a large number of event types. It does so by reducing the amount of requests made to Kafka in order to get the first and last available offsets.

Before this PR, for a subscription with 50 event types, it would request Kafka 50 times (or 100 in case of first usage). This would cause streams to not send data for several seconds. This delay in start would cause clients to trigger "Read Timeouts". In extreme situations, they would not be able to read anything and would have to retry several times until the request is served by a less loaded instance which would execute all this requests more quickly.

The optimization is not about object allocation, usage of streams or anything else. It's about calling Kafka the minimum number of times possible.

## Review
- [x] Tests
- [x] CHANGELOG
