### PR TITLE
aruha-1399 collect event publishing KPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Nakadi collects event publishing KPI data 
+
 ## [2.4.1] - 2017-12-18
 
 ### Fixed

--- a/src/main/java/org/zalando/nakadi/controller/EventPublishingController.java
+++ b/src/main/java/org/zalando/nakadi/controller/EventPublishingController.java
@@ -133,6 +133,7 @@ public class EventPublishingController {
                     .put("app", applicationName)
                     .put("app_hashed", nakadiKpiPublisher.hash(applicationName))
                     .put("number_of_events", eventCount)
+                    .put("ms_spent", msSpent)
                     .put("batch_size", totalSizeBytes));
         }
     }

--- a/src/main/java/org/zalando/nakadi/controller/EventPublishingController.java
+++ b/src/main/java/org/zalando/nakadi/controller/EventPublishingController.java
@@ -2,9 +2,11 @@ package org.zalando.nakadi.controller;
 
 import com.google.common.base.Charsets;
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,6 +25,7 @@ import org.zalando.nakadi.metrics.EventTypeMetrics;
 import org.zalando.nakadi.security.Client;
 import org.zalando.nakadi.service.BlacklistService;
 import org.zalando.nakadi.service.EventPublisher;
+import org.zalando.nakadi.service.NakadiKpiPublisher;
 import org.zalando.problem.Problem;
 import org.zalando.problem.ThrowableProblem;
 import org.zalando.problem.spring.web.advice.Responses;
@@ -43,14 +46,21 @@ public class EventPublishingController {
     private final EventPublisher publisher;
     private final EventTypeMetricRegistry eventTypeMetricRegistry;
     private final BlacklistService blacklistService;
+    private final NakadiKpiPublisher nakadiKpiPublisher;
+    private final String kpiBatchPublishedEventType;
 
     @Autowired
     public EventPublishingController(final EventPublisher publisher,
                                      final EventTypeMetricRegistry eventTypeMetricRegistry,
-                                     final BlacklistService blacklistService) {
+                                     final BlacklistService blacklistService,
+                                     final NakadiKpiPublisher nakadiKpiPublisher,
+                                     @Value("${nakadi.kpi.event-types.nakadiBatchPublished}")
+                                         final String kpiBatchPublishedEventType) {
         this.publisher = publisher;
         this.eventTypeMetricRegistry = eventTypeMetricRegistry;
         this.blacklistService = blacklistService;
+        this.nakadiKpiPublisher = nakadiKpiPublisher;
+        this.kpiBatchPublishedEventType = kpiBatchPublishedEventType;
     }
 
     @RequestMapping(value = "/event-types/{eventTypeName}/events", method = POST)
@@ -117,6 +127,13 @@ public class EventPublishingController {
 
             LOG.info("[SLO] [publishing-latency] time={} size={} count={} eventTypeName={} app={}", msSpent,
                     totalSizeBytes, eventCount, eventTypeName, applicationName);
+
+            nakadiKpiPublisher.publish(kpiBatchPublishedEventType, () -> new JSONObject()
+                    .put("event_type", eventTypeName)
+                    .put("app", client.getClientId())
+                    .put("app_hashed", nakadiKpiPublisher.hash(applicationName))
+                    .put("number_of_events", eventCount)
+                    .put("batch_size", totalSizeBytes));
         }
     }
 

--- a/src/main/java/org/zalando/nakadi/controller/EventPublishingController.java
+++ b/src/main/java/org/zalando/nakadi/controller/EventPublishingController.java
@@ -130,7 +130,7 @@ public class EventPublishingController {
 
             nakadiKpiPublisher.publish(kpiBatchPublishedEventType, () -> new JSONObject()
                     .put("event_type", eventTypeName)
-                    .put("app", client.getClientId())
+                    .put("app", applicationName)
                     .put("app_hashed", nakadiKpiPublisher.hash(applicationName))
                     .put("number_of_events", eventCount)
                     .put("batch_size", totalSizeBytes));

--- a/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
+++ b/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
@@ -1,8 +1,6 @@
 package org.zalando.nakadi.filters;
 
-import com.google.common.base.Charsets;
 import com.google.common.net.HttpHeaders;
-import org.apache.commons.codec.binary.Hex;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,7 +15,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.security.MessageDigest;
 import java.security.Principal;
 import java.util.Optional;
 
@@ -25,15 +22,13 @@ import java.util.Optional;
 public class LoggingFilter extends OncePerRequestFilter {
 
     private static final Logger LOG = LoggerFactory.getLogger(LoggingFilter.class);
-    private final MessageDigest sha256MessageDigest;
+
     private final NakadiKpiPublisher nakadiKpiPublisher;
     private final String accessLogEventType;
 
     @Autowired
-    public LoggingFilter(final MessageDigest sha256MessageDigest,
-                         final NakadiKpiPublisher nakadiKpiPublisher,
+    public LoggingFilter(final NakadiKpiPublisher nakadiKpiPublisher,
                          @Value("${nakadi.kpi.event-types.nakadiAccessLog}") final String accessLogEventType) {
-        this.sha256MessageDigest = sha256MessageDigest;
         this.nakadiKpiPublisher = nakadiKpiPublisher;
         this.accessLogEventType = accessLogEventType;
     }
@@ -74,7 +69,7 @@ public class LoggingFilter extends OncePerRequestFilter {
                     .put("path", path)
                     .put("query", query)
                     .put("app", user)
-                    .put("app_hashed", Hex.encodeHexString(sha256MessageDigest.digest(user.getBytes(Charsets.UTF_8))))
+                    .put("app_hashed", nakadiKpiPublisher.hash(user))
                     .put("status_code", response.getStatus())
                     .put("response_time_ms", timing));
         }

--- a/src/main/java/org/zalando/nakadi/service/NakadiKpiPublisher.java
+++ b/src/main/java/org/zalando/nakadi/service/NakadiKpiPublisher.java
@@ -1,5 +1,7 @@
 package org.zalando.nakadi.service;
 
+import com.google.common.base.Charsets;
+import org.apache.commons.codec.binary.Hex;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -7,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.zalando.nakadi.util.FeatureToggleService;
 
+import java.security.MessageDigest;
 import java.util.function.Supplier;
 
 @Component
@@ -16,12 +19,15 @@ public class NakadiKpiPublisher {
 
     private final FeatureToggleService featureToggleService;
     private final EventsProcessor eventsProcessor;
+    private final MessageDigest sha256MessageDigest;
 
     @Autowired
     protected NakadiKpiPublisher(final FeatureToggleService featureToggleService,
-                                 final EventsProcessor eventsProcessor) {
+                                 final EventsProcessor eventsProcessor,
+                                 final MessageDigest sha256MessageDigest) {
         this.featureToggleService = featureToggleService;
         this.eventsProcessor = eventsProcessor;
+        this.sha256MessageDigest = sha256MessageDigest;
     }
 
     public void publish(final String etName, final Supplier<JSONObject> eventSupplier) {
@@ -35,6 +41,10 @@ public class NakadiKpiPublisher {
         } catch (final Exception e) {
             LOG.error("Error occurred when submitting KPI event for publishing", e);
         }
+    }
+
+    public String hash(final String value) {
+        return Hex.encodeHexString(sha256MessageDigest.digest(value.getBytes(Charsets.UTF_8)));
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -110,6 +110,7 @@ nakadi:
     event-types:
       nakadiAccessLog: "nakadi.access.log"
       nakadiEventTypeLog: "nakadi.event.type.log"
+      nakadiBatchPublished: "nakadi.batch.published"
   hasher.salt: "salt"
 
 twintip:

--- a/src/test/java/org/zalando/nakadi/controller/EventPublishingControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventPublishingControllerTest.java
@@ -35,9 +35,11 @@ import java.util.function.Supplier;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -210,12 +212,15 @@ public class EventPublishingControllerTest {
 
         assertThat(etNameCaptor.getValue(), equalTo("kpiEventTypeName"));
 
-        assertThat((JSONObject) eventGeneratorCaptor.getValue().get(),
+        final JSONObject kpi = (JSONObject) eventGeneratorCaptor.getValue().get();
+        assertThat(kpi,
                 is(sameJSONObjectAs(new JSONObject().put("app", "adminClientId")
                         .put("app_hashed", "hashed-application-name")
                         .put("event_type", "my-topic")
                         .put("batch_size", 33)
-                        .put("number_of_events",3))));
+                        .put("number_of_events",3)).allowingExtraUnexpectedFields()));
+
+        assertThat(kpi.getInt("ms_spent"), is(notNullValue()));
     }
 
     private List<BatchItemResponse> responses() {

--- a/src/test/java/org/zalando/nakadi/controller/EventPublishingControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventPublishingControllerTest.java
@@ -2,8 +2,10 @@ package org.zalando.nakadi.controller;
 
 import com.codahale.metrics.MetricRegistry;
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
@@ -23,17 +25,22 @@ import org.zalando.nakadi.security.Client;
 import org.zalando.nakadi.security.ClientResolver;
 import org.zalando.nakadi.service.BlacklistService;
 import org.zalando.nakadi.service.EventPublisher;
+import org.zalando.nakadi.service.NakadiKpiPublisher;
 import org.zalando.nakadi.util.FeatureToggleService;
 import org.zalando.nakadi.utils.TestUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -47,6 +54,7 @@ import static org.zalando.nakadi.domain.EventPublishingStatus.SUBMITTED;
 import static org.zalando.nakadi.domain.EventPublishingStep.PARTITIONING;
 import static org.zalando.nakadi.domain.EventPublishingStep.PUBLISHING;
 import static org.zalando.nakadi.domain.EventPublishingStep.VALIDATING;
+import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONObjectAs;
 
 public class EventPublishingControllerTest {
 
@@ -59,6 +67,7 @@ public class EventPublishingControllerTest {
 
     private MockMvc mockMvc;
     private EventTypeMetricRegistry eventTypeMetricRegistry;
+    private NakadiKpiPublisher kpiPublisher;
     private BlacklistService blacklistService;
 
     @Before
@@ -66,6 +75,7 @@ public class EventPublishingControllerTest {
         metricRegistry = new MetricRegistry();
         publisher = mock(EventPublisher.class);
         eventTypeMetricRegistry = new EventTypeMetricRegistry(metricRegistry);
+        kpiPublisher = mock(NakadiKpiPublisher.class);
         settings = mock(SecuritySettings.class);
         when(settings.getAuthMode()).thenReturn(OFF);
         when(settings.getAdminClientId()).thenReturn("nakadi");
@@ -76,7 +86,8 @@ public class EventPublishingControllerTest {
         final FeatureToggleService featureToggleService = Mockito.mock(FeatureToggleService.class);
 
         final EventPublishingController controller =
-                new EventPublishingController(publisher, eventTypeMetricRegistry, blacklistService);
+                new EventPublishingController(publisher, eventTypeMetricRegistry, blacklistService, kpiPublisher,
+                        "kpiEventTypeName");
 
         mockMvc = standaloneSetup(controller)
                 .setMessageConverters(new StringHttpMessageConverter(), TestUtils.JACKSON_2_HTTP_MESSAGE_CONVERTER)
@@ -175,6 +186,33 @@ public class EventPublishingControllerTest {
 
         assertThat(eventTypeMetrics.getResponseCount(200), equalTo(2L));
         assertThat(eventTypeMetrics.getResponseCount(500), equalTo(1L));
+    }
+
+    @Test
+    public void publishedEventsKPIReported() throws Exception {
+        final EventPublishResult success = new EventPublishResult(SUBMITTED, null, submittedResponses(3));
+        Mockito
+                .doReturn(success)
+                .doReturn(success)
+                .doThrow(InternalNakadiException.class)
+                .when(publisher)
+                .publish(any(), any(), any(Client.class));
+
+        postBatch(TOPIC, EVENT_BATCH);
+
+        final ArgumentCaptor<String> etNameCaptor = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<Supplier> eventGeneratorCaptor = ArgumentCaptor.forClass(Supplier.class);
+
+        verify(kpiPublisher, times(1)).publish(etNameCaptor.capture(),
+                eventGeneratorCaptor.capture());
+
+        assertThat(etNameCaptor.getValue(), equalTo("kpiEventTypeName"));
+
+        assertThat((JSONObject) eventGeneratorCaptor.getValue().get(),
+                is(sameJSONObjectAs(new JSONObject().put("app", "adminClientId")
+                        .put("event_type", "my-topic")
+                        .put("batch_size", 33)
+                        .put("number_of_events",3))));
     }
 
     private List<BatchItemResponse> responses() {

--- a/src/test/java/org/zalando/nakadi/controller/EventPublishingControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventPublishingControllerTest.java
@@ -198,6 +198,8 @@ public class EventPublishingControllerTest {
                 .when(publisher)
                 .publish(any(), any(), any(Client.class));
 
+        when(kpiPublisher.hash(any())).thenReturn("hashed-application-name");
+
         postBatch(TOPIC, EVENT_BATCH);
 
         final ArgumentCaptor<String> etNameCaptor = ArgumentCaptor.forClass(String.class);
@@ -210,6 +212,7 @@ public class EventPublishingControllerTest {
 
         assertThat((JSONObject) eventGeneratorCaptor.getValue().get(),
                 is(sameJSONObjectAs(new JSONObject().put("app", "adminClientId")
+                        .put("app_hashed", "hashed-application-name")
                         .put("event_type", "my-topic")
                         .put("batch_size", 33)
                         .put("number_of_events",3))));

--- a/src/test/java/org/zalando/nakadi/service/NakadiKpiPublisherTest.java
+++ b/src/test/java/org/zalando/nakadi/service/NakadiKpiPublisherTest.java
@@ -1,23 +1,35 @@
 package org.zalando.nakadi.service;
 
 import org.json.JSONObject;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.zalando.nakadi.config.NakadiConfig;
 import org.zalando.nakadi.util.FeatureToggleService;
 
+import java.security.MessageDigest;
 import java.util.function.Supplier;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 
 public class NakadiKpiPublisherTest {
 
     private final FeatureToggleService featureToggleService = Mockito.mock(FeatureToggleService.class);
     private final EventsProcessor eventsProcessor = Mockito.mock(EventsProcessor.class);
+    private MessageDigest messageDigest;
+
+    @Before
+    public void setUp() {
+        messageDigest = new NakadiConfig().sha256MessageDigest("123");
+    }
 
     @Test
     public void testPublishWithFeatureToggleOn() throws Exception {
         Mockito.when(featureToggleService.isFeatureEnabled(FeatureToggleService.Feature.KPI_COLLECTION))
                 .thenReturn(true);
         final Supplier<JSONObject> dataSupplier = () -> null;
-        new NakadiKpiPublisher(featureToggleService, eventsProcessor)
+        new NakadiKpiPublisher(featureToggleService, eventsProcessor, messageDigest)
                 .publish("test_et_name", dataSupplier);
 
         Mockito.verify(eventsProcessor).enrichAndSubmit("test_et_name", dataSupplier.get());
@@ -28,10 +40,18 @@ public class NakadiKpiPublisherTest {
         Mockito.when(featureToggleService.isFeatureEnabled(FeatureToggleService.Feature.KPI_COLLECTION))
                 .thenReturn(false);
         final Supplier<JSONObject> dataSupplier = () -> null;
-        new NakadiKpiPublisher(featureToggleService, eventsProcessor)
+        new NakadiKpiPublisher(featureToggleService, eventsProcessor, messageDigest)
                 .publish("test_et_name", dataSupplier);
 
         Mockito.verify(eventsProcessor, Mockito.never()).enrichAndSubmit("test_et_name", dataSupplier.get());
+    }
+
+    @Test
+    public void testHash() throws Exception {
+        final NakadiKpiPublisher publisher = new NakadiKpiPublisher(featureToggleService, eventsProcessor,
+                messageDigest);
+        assertThat(publisher.hash("application"),
+                equalTo("befee725ab2ed3b17020112089a693ad8d8cfbf62b2442dcb5b89d66ce72391e"));
     }
 
 }


### PR DESCRIPTION
https://techjira.zalando.net/browse/ARUHA-1401

## Description

Collecting data necessary to calculate event publishing KPIs. Further details can be found in the data modeling document https://docs.google.com/document/d/1d4Z4FzSSrVCl2oy2G-bAPEcFbyAed_ZOxQqzr2rBGpw/edit#heading=h.c9gt0cqkozqy

It was necessary to refactor out the `hash` computation so that it could
be reused.

## Deployment Notes
The corresponding event type should be created in the targeted deployment environments.
