### PR TITLE
ARUHA-1442 Limit memory consumption of subscription streamer to 50 Mb

### DIFF
--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -2667,6 +2667,8 @@ parameters:
       is reached, the messages are immediately flushed to the client and batch flush timer is reset.
 
       * If 0 or undefined, will assume 30 seconds.
+
+      * Value is treated as a recommendation. Nakadi may flush chunks with a smaller timeout.
     type: number
     format: int32
     required: false

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/EventStreamReadingAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/EventStreamReadingAT.java
@@ -39,7 +39,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -462,7 +461,7 @@ public class EventStreamReadingAT extends BaseAT {
     }
 
     @Test(timeout = 10000)
-    public void whenMemoryOverflowItIsUsed() throws IOException {
+    public void whenMemoryOverflowEventsDumped() throws IOException {
         // Create event type
         final EventType loadEt = EventTypeTestBuilder.builder()
                 .defaultStatistic(new EventTypeStatistics(PARTITIONS_NUM, PARTITIONS_NUM))

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/EventStreamReadingAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/EventStreamReadingAT.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
+import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.response.Header;
 import com.jayway.restassured.response.Response;
 import org.hamcrest.Matchers;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -15,7 +17,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeStatistics;
-import org.zalando.nakadi.exceptions.NoSuchEventTypeException;
 import org.zalando.nakadi.repository.kafka.KafkaTestHelper;
 import org.zalando.nakadi.service.BlacklistService;
 import org.zalando.nakadi.utils.EventTypeTestBuilder;
@@ -23,7 +24,11 @@ import org.zalando.nakadi.utils.TestUtils;
 import org.zalando.nakadi.view.Cursor;
 import org.zalando.nakadi.webservice.utils.NakadiTestUtils;
 
+import javax.servlet.http.HttpServletResponse;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Arrays;
@@ -37,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.jayway.restassured.RestAssured.given;
 import static java.text.MessageFormat.format;
@@ -65,7 +71,7 @@ public class EventStreamReadingAT extends BaseAT {
     private List<Cursor> kafkaInitialNextOffsets;
 
     @BeforeClass
-    public static void setupClass() throws JsonProcessingException, NoSuchEventTypeException {
+    public static void setupClass() throws JsonProcessingException {
         eventType = EventTypeTestBuilder.builder()
                 .defaultStatistic(new EventTypeStatistics(PARTITIONS_NUM, PARTITIONS_NUM))
                 .build();
@@ -76,7 +82,7 @@ public class EventStreamReadingAT extends BaseAT {
     }
 
     @Before
-    public void setUp() throws InterruptedException, JsonProcessingException {
+    public void setUp() throws JsonProcessingException {
         kafkaHelper = new KafkaTestHelper(KAFKA_URL);
         initialCursors = kafkaHelper.getOffsetsToReadFromLatest(topicName);
         kafkaInitialNextOffsets = kafkaHelper.getNextOffsets(topicName);
@@ -86,7 +92,7 @@ public class EventStreamReadingAT extends BaseAT {
     @Test(timeout = 10000)
     @SuppressWarnings("unchecked")
     public void whenPushFewEventsAndReadThenGetEventsInStream()
-            throws ExecutionException, InterruptedException, JsonProcessingException {
+            throws ExecutionException, InterruptedException {
 
         // ARRANGE //
         // push events to one of the partitions
@@ -127,7 +133,7 @@ public class EventStreamReadingAT extends BaseAT {
 
     @Test(timeout = 10000)
     public void whenAcceptEncodingGzipReceiveCompressedStream()
-            throws ExecutionException, InterruptedException, JsonProcessingException {
+            throws ExecutionException, InterruptedException {
 
         // ARRANGE //
         // push events to one of the partitions
@@ -152,7 +158,7 @@ public class EventStreamReadingAT extends BaseAT {
     @Test(timeout = 10000)
     @SuppressWarnings("unchecked")
     public void whenPushedAmountOfEventsMoreThanBatchSizeAndReadThenGetEventsInMultipleBatches()
-            throws ExecutionException, InterruptedException, JsonProcessingException {
+            throws ExecutionException, InterruptedException {
 
         // ARRANGE //
         // push events to one of the partitions so that they don't fit into one branch
@@ -203,8 +209,7 @@ public class EventStreamReadingAT extends BaseAT {
 
     @Test(timeout = 10000)
     @SuppressWarnings("unchecked")
-    public void whenReadFromTheEndThenLatestOffsetsInStream()
-            throws ExecutionException, InterruptedException, JsonProcessingException {
+    public void whenReadFromTheEndThenLatestOffsetsInStream() {
 
         // ACT //
         // just stream without X-nakadi-cursors; that should make nakadi to read from the very end
@@ -237,8 +242,7 @@ public class EventStreamReadingAT extends BaseAT {
 
     @Test(timeout = 10000)
     @SuppressWarnings("unchecked")
-    public void whenReachKeepAliveLimitThenStreamIsClosed()
-            throws ExecutionException, InterruptedException, JsonProcessingException {
+    public void whenReachKeepAliveLimitThenStreamIsClosed() {
         // ACT //
         final int keepAliveLimit = 3;
         final Response response = given()
@@ -362,8 +366,7 @@ public class EventStreamReadingAT extends BaseAT {
 
     @Ignore
     @Test(timeout = 10000)
-    public void whenExceedMaxConsumersNumThen429() throws IOException, InterruptedException, ExecutionException,
-            TimeoutException {
+    public void whenExceedMaxConsumersNumThen429() throws IOException, InterruptedException, ExecutionException {
         final String etName = NakadiTestUtils.createEventType().getName();
 
         // try to create 8 consuming connections
@@ -456,6 +459,43 @@ public class EventStreamReadingAT extends BaseAT {
         } finally {
             SettingsControllerAT.whitelist(eventType.getName(), BlacklistService.Type.CONSUMER_ET);
         }
+    }
+
+    @Test(timeout = 10000)
+    public void whenMemoryOverflowItIsUsed() throws IOException {
+        // Create event type
+        final EventType loadEt = EventTypeTestBuilder.builder()
+                .defaultStatistic(new EventTypeStatistics(PARTITIONS_NUM, PARTITIONS_NUM))
+                .build();
+        NakadiTestUtils.createEventTypeInNakadi(loadEt);
+
+        // Publish events to event type, that are not fitting memory
+        final String evt = "{\"foo\":\"barbarbar\"}";
+        final int eventCount = 2 * (10000 / evt.length());
+        NakadiTestUtils.publishEvents(loadEt.getName(), eventCount, i -> evt);
+
+        // Configure streaming so it will:(more than 10s and batch_limit
+        // - definitely wait for more than test timeout (10s)
+        // - collect batch, which size is greater than events published to this event type
+        final String url = RestAssured.baseURI + ":" + RestAssured.port + createStreamEndpointUrl(loadEt.getName())
+                + "?batch_limit=" + (10 * eventCount)
+                + "&stream_limit=" + (10 * eventCount)
+                + "&batch_flush_timeout=11"
+                + "&stream_timeout=11";
+        final HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+        // Start from the begin.
+        connection.setRequestProperty("X-Nakadi-Cursors",
+                "[" + IntStream.range(0, PARTITIONS_NUM)
+                        .mapToObj(i -> "{\"partition\": \"" + i + "\",\"offset\":\"begin\"}")
+                        .collect(Collectors.joining(",")) + "]");
+        Assert.assertEquals(HttpServletResponse.SC_OK, connection.getResponseCode());
+
+        final InputStream inputStream = connection.getInputStream();
+        final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+
+        final String line = reader.readLine();
+        Assert.assertNotNull(line);
+        // If we read at least one line, than it means, that we were able to read data before test timeout reached.
     }
 
 

--- a/src/main/java/org/zalando/nakadi/controller/EventStreamController.java
+++ b/src/main/java/org/zalando/nakadi/controller/EventStreamController.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -97,6 +98,7 @@ public class EventStreamController {
     private final MetricRegistry streamMetrics;
     private final AuthorizationValidator authorizationValidator;
     private final EventTypeChangeListener eventTypeChangeListener;
+    private final Long maxMemoryUsageBytes;
 
     @Autowired
     public EventStreamController(final EventTypeRepository eventTypeRepository,
@@ -111,7 +113,9 @@ public class EventStreamController {
                                  final FeatureToggleService featureToggleService,
                                  final CursorConverter cursorConverter,
                                  final AuthorizationValidator authorizationValidator,
-                                 final EventTypeChangeListener eventTypeChangeListener) {
+                                 final EventTypeChangeListener eventTypeChangeListener,
+                                 @Value("${nakadi.stream.maxStreamMemoryBytes}")
+                                     @Nullable final Long maxMemoryUsageBytes) {
         this.eventTypeRepository = eventTypeRepository;
         this.timelineService = timelineService;
         this.jsonMapper = jsonMapper;
@@ -125,6 +129,7 @@ public class EventStreamController {
         this.cursorConverter = cursorConverter;
         this.authorizationValidator = authorizationValidator;
         this.eventTypeChangeListener = eventTypeChangeListener;
+        this.maxMemoryUsageBytes = maxMemoryUsageBytes;
     }
 
     @VisibleForTesting
@@ -235,6 +240,7 @@ public class EventStreamController {
                         .withEtName(eventTypeName)
                         .withConsumingAppId(client.getClientId())
                         .withCursors(getStreamingStart(eventType, cursorsStr))
+                        .withMaxMemoryUsageBytes(maxMemoryUsageBytes)
                         .build();
 
                 // acquire connection slots to limit the number of simultaneous connections from one client

--- a/src/main/java/org/zalando/nakadi/controller/EventStreamController.java
+++ b/src/main/java/org/zalando/nakadi/controller/EventStreamController.java
@@ -114,8 +114,7 @@ public class EventStreamController {
                                  final CursorConverter cursorConverter,
                                  final AuthorizationValidator authorizationValidator,
                                  final EventTypeChangeListener eventTypeChangeListener,
-                                 @Value("${nakadi.stream.maxStreamMemoryBytes}")
-                                     @Nullable final Long maxMemoryUsageBytes) {
+                                 @Value("${nakadi.stream.maxStreamMemoryBytes}") final Long maxMemoryUsageBytes) {
         this.eventTypeRepository = eventTypeRepository;
         this.timelineService = timelineService;
         this.jsonMapper = jsonMapper;

--- a/src/main/java/org/zalando/nakadi/service/EventStream.java
+++ b/src/main/java/org/zalando/nakadi/service/EventStream.java
@@ -134,8 +134,8 @@ public class EventStream {
                             .get();
                     sendBatch(latestOffsets.get(heaviestPartition.getKey()), heaviestPartition.getValue());
                     final long freed = heaviestPartition.getValue().stream().mapToLong(v -> v.length).sum();
-                    LOG.warn("Memory limit reached for event type {}: {} bytes. Freed: {} bytes",
-                            config.getEtName(), bytesInMemory, freed);
+                    LOG.warn("Memory limit reached for event type {}: {} bytes. Freed: {} bytes, {} messages",
+                            config.getEtName(), bytesInMemory, freed, heaviestPartition.getValue().size());
                     bytesInMemory -= freed;
                     // Init new batch for subscription
                     heaviestPartition.getValue().clear();

--- a/src/main/java/org/zalando/nakadi/service/EventStreamConfig.java
+++ b/src/main/java/org/zalando/nakadi/service/EventStreamConfig.java
@@ -17,6 +17,7 @@ public class EventStreamConfig {
     private static final int STREAM_LIMIT_DEFAULT = 0;
     private static final int BATCH_FLUSH_TIMEOUT_DEFAULT = 30;
     private static final int STREAM_KEEP_ALIVE_LIMIT_DEFAULT = 0;
+    private static final long DEF_MAX_MEMORY_USAGE_BYTES = 50 * 1024 * 1024;
     private static final Random RANDOM = new Random();
 
     private final List<NakadiCursor> cursors;
@@ -27,10 +28,12 @@ public class EventStreamConfig {
     private final int streamKeepAliveLimit;
     private final String etName;
     private final String consumingAppId;
+    private final long maxMemoryUsageBytes;
 
     private EventStreamConfig(final List<NakadiCursor> cursors, final int batchLimit,
                               final int streamLimit, final int batchTimeout, final int streamTimeout,
-                              final int streamKeepAliveLimit, final String etName, final String consumingAppId) {
+                              final int streamKeepAliveLimit, final String etName, final String consumingAppId,
+                              final long maxMemoryUsageBytes) {
         this.cursors = cursors;
         this.batchLimit = batchLimit;
         this.streamLimit = streamLimit;
@@ -39,6 +42,7 @@ public class EventStreamConfig {
         this.streamKeepAliveLimit = streamKeepAliveLimit;
         this.etName = etName;
         this.consumingAppId = consumingAppId;
+        this.maxMemoryUsageBytes = maxMemoryUsageBytes;
     }
 
     public List<NakadiCursor> getCursors() {
@@ -71,6 +75,10 @@ public class EventStreamConfig {
 
     public String getConsumingAppId() {
         return consumingAppId;
+    }
+
+    public long getMaxMemoryUsageBytes() {
+        return maxMemoryUsageBytes;
     }
 
     @Override
@@ -123,11 +131,19 @@ public class EventStreamConfig {
         private int batchTimeout = BATCH_FLUSH_TIMEOUT_DEFAULT;
         private int streamTimeout = generateDefaultStreamTimeout();
         private int streamKeepAliveLimit = STREAM_KEEP_ALIVE_LIMIT_DEFAULT;
+        private long maxMemoryUsageBytes = DEF_MAX_MEMORY_USAGE_BYTES;
         private String etName;
         private String consumingAppId;
 
         public Builder withCursors(final List<NakadiCursor> cursors) {
             this.cursors = cursors;
+            return this;
+        }
+
+        public Builder withMaxMemoryUsageBytes(@Nullable final Long maxMemoryUsageBytes) {
+            if (null != maxMemoryUsageBytes) {
+                this.maxMemoryUsageBytes = maxMemoryUsageBytes;
+            }
             return this;
         }
 
@@ -190,7 +206,7 @@ public class EventStreamConfig {
                 throw new UnprocessableEntityException("batch_limit can't be lower than 1");
             }
             return new EventStreamConfig(cursors, batchLimit, streamLimit, batchTimeout, streamTimeout,
-                    streamKeepAliveLimit, etName, consumingAppId);
+                    streamKeepAliveLimit, etName, consumingAppId, maxMemoryUsageBytes);
         }
     }
 

--- a/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -68,6 +68,8 @@ public class StreamingContext implements SubscriptionStreamer {
 
     private final long kpiCollectionFrequencyMs;
 
+    private final long streamMemoryLimitBytes;
+
     private State currentState = new DummyState();
     private ZkSubscription<List<String>> sessionListSubscription;
     private Closeable authorizationCheckSubscription;
@@ -99,6 +101,7 @@ public class StreamingContext implements SubscriptionStreamer {
         this.kpiPublisher = builder.kpiPublisher;
         this.kpiDataStreamedEventType = builder.kpiDataStremedEventType;
         this.kpiCollectionFrequencyMs = builder.kpiCollectionFrequencyMs;
+        this.streamMemoryLimitBytes = builder.streamMemoryLimitBytes;
     }
 
     public TimelineService getTimelineService() {
@@ -301,6 +304,10 @@ public class StreamingContext implements SubscriptionStreamer {
         return cursorComparator;
     }
 
+    public long getStreamMemoryLimitBytes() {
+        return streamMemoryLimitBytes;
+    }
+
     public static final class Builder {
         private SubscriptionOutput out;
         private StreamParameters parameters;
@@ -325,9 +332,15 @@ public class StreamingContext implements SubscriptionStreamer {
         private NakadiKpiPublisher kpiPublisher;
         private String kpiDataStremedEventType;
         private long kpiCollectionFrequencyMs;
+        private long streamMemoryLimitBytes;
 
         public Builder setOut(final SubscriptionOutput out) {
             this.out = out;
+            return this;
+        }
+
+        public Builder setStreamMemoryLimitBytes(final long streamMemoryLimitBytes) {
+            this.streamMemoryLimitBytes = streamMemoryLimitBytes;
             return this;
         }
 

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -27,6 +27,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -235,6 +236,34 @@ class StreamingState extends State {
                 messagesAllowedToSend -= toSend.size();
             }
         }
+
+        long memoryConsumed = offsets.values().stream().mapToLong(PartitionData::getBytesInMemory).sum();
+        while (memoryConsumed > getContext().getStreamMemoryLimitBytes()) {
+            // Select heaviest guy (and on previous step we figured out that we can not send anymore full batches,
+            // therefore we can take all the events from one partition.
+            final Map.Entry<EventTypePartition, PartitionData> heaviestPartition = offsets.entrySet().stream().max(
+                    Comparator.comparing(e -> e.getValue().getBytesInMemory())
+            ).get(); // There is always at least 1 item in list
+
+            long deltaSize = heaviestPartition.getValue().getBytesInMemory();
+            final List<ConsumedEvent> events = heaviestPartition.getValue().extractAll(currentTimeMillis);
+            deltaSize -= heaviestPartition.getValue().getBytesInMemory();
+
+            sentSomething = true;
+            flushData(
+                    heaviestPartition.getKey(),
+                    events,
+                    batchesSent == 0 ?
+                            Optional.of("Stream started with memory overflow") :
+                            Optional.of("Stream parameters are causing overflow"));
+            getLog().warn("Stream overflows memory ({} bytes before flush). Dumping from {}, {} bytes, {} events",
+                    memoryConsumed,
+                    heaviestPartition.getKey(),
+                    deltaSize,
+                    events.size());
+            memoryConsumed -= deltaSize;
+        }
+
         if (lastKpiEventSent + getContext().getKpiCollectionFrequencyMs() < System.currentTimeMillis()) {
             getContext().getSubscription().getEventTypes().stream().forEach(et -> publishKpi(et));
             lastKpiEventSent = System.currentTimeMillis();
@@ -259,7 +288,7 @@ class StreamingState extends State {
 
         getLog().info("[SLO] [streamed-data] api={} eventTypeName={} app={} appHashed={} " +
                         "numberOfEvents={} bytesStreamed={} subscription={}", "hila",
-                        eventTypeName, appName, appNameHashed, count, bytes, getContext().getSubscription().getId());
+                eventTypeName, appName, appNameHashed, count, bytes, getContext().getSubscription().getId());
 
         kpiPublisher.publish(
                 getContext().getKpiDataStreamedEventType(),

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -256,11 +256,8 @@ class StreamingState extends State {
                     batchesSent == 0 ?
                             Optional.of("Stream started with memory overflow") :
                             Optional.of("Stream parameters are causing overflow"));
-            getLog().warn("Stream overflows memory ({} bytes before flush). Dumping from {}, {} bytes, {} events",
-                    memoryConsumed,
-                    heaviestPartition.getKey(),
-                    deltaSize,
-                    events.size());
+            getLog().warn("Memory limit reached: {} bytes. Dumped events from {}. Freed: {} bytes, {} messages",
+                    memoryConsumed, heaviestPartition.getKey(), deltaSize, events.size());
             memoryConsumed -= deltaSize;
         }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -127,6 +127,7 @@ spring:
   profiles: acceptanceTest
 nakadi:
   stream:
+    maxStreamMemoryBytes: 10_000 # ~10 Kb
     default:
       commitTimeout: 5 # seconds
   subscription:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,6 +51,7 @@ nakadi:
     timeoutMs: 31536000000 # 1 year :-P
     default.commitTimeout: 60 # 1 minute
     maxConnections: 5
+    maxStreamMemoryBytes: 50000000 # ~50 MB
   featureToggle.default: false
   kafka:
     request.timeout.ms: 30000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -87,6 +87,7 @@ nakadi:
   timeline.wait.timeoutMs: 40000
   subscription:
     maxPartitions: 100
+    maxStreamMemoryBytes: 50000000 # ~50 MB
   jobs:
     checkRunMs: 600000 # 10 min
     timelineCleanup:

--- a/src/test/java/org/zalando/nakadi/controller/EventStreamControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventStreamControllerTest.java
@@ -163,7 +163,7 @@ public class EventStreamControllerTest {
                 eventTypeRepository, timelineService, TestUtils.OBJECT_MAPPER, eventStreamFactoryMock, metricRegistry,
                 streamMetrics, crutch, blacklistService, consumerLimitingService, featureToggleService,
                 new CursorConverterImpl(eventTypeCache, timelineService), authorizationValidator,
-                eventTypeChangeListener);
+                eventTypeChangeListener, null);
 
         settings = mock(SecuritySettings.class);
         when(settings.getAuthMode()).thenReturn(OFF);


### PR DESCRIPTION
[ARUHA-1442: Limit memory consumption of subscription streamer to 50 Mb](link to ticket)

## Description
Now single subscription stream can kill nakadi with not wisely set streaming configuration parameters. 
This PR allows to collect batches only in case when for single stream it takes less then 50Mb, otherwise heaviest partitions will be dumped.