### PR TITLE
ARUHA-1452 Allow migration from EmptySchema to ObjectSchema and back.

### DIFF
--- a/src/main/java/org/zalando/nakadi/validation/schema/diff/SchemaDiff.java
+++ b/src/main/java/org/zalando/nakadi/validation/schema/diff/SchemaDiff.java
@@ -50,9 +50,6 @@ public class SchemaDiff {
             if (originalIn instanceof EmptySchema && updateIn instanceof ObjectSchema) {
                 original = replaceWithEmptyObjectSchema(originalIn);
                 update = updateIn;
-            } else if (originalIn instanceof ObjectSchema && updateIn instanceof EmptySchema) {
-                original = originalIn;
-                update = replaceWithEmptyObjectSchema(updateIn);
             } else {
                 state.addChange(TYPE_CHANGED);
                 return;

--- a/src/main/java/org/zalando/nakadi/validation/schema/diff/SchemaDiff.java
+++ b/src/main/java/org/zalando/nakadi/validation/schema/diff/SchemaDiff.java
@@ -90,7 +90,7 @@ public class SchemaDiff {
         });
     }
 
-    private static Schema replaceWithEmptyObjectSchema(Schema in) {
+    private static Schema replaceWithEmptyObjectSchema(final Schema in) {
         return ObjectSchema.builder()
                 .id(in.getId())
                 .title(in.getTitle())

--- a/src/test/java/org/zalando/nakadi/validation/schema/SchemaDiffTest.java
+++ b/src/test/java/org/zalando/nakadi/validation/schema/SchemaDiffTest.java
@@ -7,6 +7,7 @@ import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.zalando.nakadi.domain.SchemaChange;
 import org.zalando.nakadi.validation.schema.diff.SchemaDiff;
 
 import java.io.IOException;
@@ -56,5 +57,14 @@ public class SchemaDiffTest {
         final Schema newOne = SchemaLoader.load(new JSONObject(
                 readFile("org/zalando/nakadi/validation/recursive-schema.json")));
         Assert.assertTrue(service.collectChanges(original, newOne).isEmpty());
+    }
+
+    @Test
+    public void testSchemaAddsProperties() {
+        final Schema first = SchemaLoader.load(new JSONObject("{}"));
+
+        final Schema second = SchemaLoader.load(new JSONObject("{\"properties\": {}}"));
+        final List<SchemaChange> changes = service.collectChanges(first, second);
+        Assert.assertTrue(changes.isEmpty());
     }
 }


### PR DESCRIPTION
[ARUHA-1452: Not possible to add "properties" object to schema when updating ET]

The problem with the schema library is that EmptySchema is not empty ObjectSchema (as it may seem).
In order to be able to treat it in the same way, emptySchema is casted to the actual type that is being checked.

