### PR TITLE
ARUHA-1498 Remove internal link from readme. Fixes #831

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,6 @@ The goal of Nakadi (**ნაკადი** means *stream* in Georgian) is to pro
 
 ### Links
 
-Read more to understand *The big picture* 
-[Architecture for data integration](https://pages.github.bus.zalan.do/core-platform/docs/architecture/data_integration.html) 
-
 Watch the talk [Data Integration in the World of Microservices](https://clusterhq.com/2016/05/20/microservices-zalando/) 
 
 ### Development status


### PR DESCRIPTION
ARUHA-1498: Remove internal link from public documentation for Nakadi

## Description
Removes Zalando internal link from README.md
Fixes #831 

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

