### PR TITLE
Improve pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
-[ARUHA-XXX: Name of ticket](link to ticket)
+# One-line summary
+
+> Zalando ticket : ARUHA-XXX (only if appropriate)
 
 ## Description
 A few sentences describing the overall goals of the pull request's


### PR DESCRIPTION
## Description
This improves the PR template by moving the Zalando ticket ID out of
the PR title, yet still in a prominent position. It also makes it clear
that a ticket ID is not mandatory. With this template, we avoid giving
the false impression that only Zalando employees can contribute to
Nakadi.

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG