### PR TITLE
ARUHA-1504 Global read access for all_data_access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Applications with READ rights to all_data_access can read from all event types, regardless of the event types' 
+authorization policy
+
 ## [2.5.5] - 2018-01-23
 
 ### Changed

--- a/src/main/java/org/zalando/nakadi/domain/AllDataAccessResource.java
+++ b/src/main/java/org/zalando/nakadi/domain/AllDataAccessResource.java
@@ -1,0 +1,54 @@
+package org.zalando.nakadi.domain;
+
+import org.zalando.nakadi.plugin.api.authz.AuthorizationAttribute;
+import org.zalando.nakadi.plugin.api.authz.AuthorizationService;
+import org.zalando.nakadi.plugin.api.authz.Resource;
+
+import java.util.List;
+import java.util.Optional;
+
+public class AllDataAccessResource implements Resource {
+    public static final String ALL_DATA_ACCESS_RESOURCE = "all_data_access";
+
+    private final String name;
+    private final ResourceAuthorization resourceAuthorization;
+
+    public AllDataAccessResource(final String name, final ResourceAuthorization resourceAuthorization) {
+        this.name = name;
+        this.resourceAuthorization = resourceAuthorization;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getType() {
+        return ALL_DATA_ACCESS_RESOURCE;
+    }
+
+    @Override
+    public Optional<List<AuthorizationAttribute>> getAttributesForOperation(
+            final AuthorizationService.Operation operation) {
+        switch (operation) {
+            case READ:
+                return Optional.of(resourceAuthorization.getReaders());
+            case WRITE:
+                return Optional.of(resourceAuthorization.getWriters());
+            case ADMIN:
+                return Optional.of(resourceAuthorization.getAdmins());
+            default:
+                throw new IllegalArgumentException("Operation " + operation + " is not supported");
+        }
+    }
+
+    public List<Permission> getPermissionsList() {
+        return resourceAuthorization.toPermissionsList(name);
+    }
+
+    @Override
+    public String toString() {
+        return "AuthorizedResource{" + ALL_DATA_ACCESS_RESOURCE +"='" + name + "'}";
+    }
+}

--- a/src/main/java/org/zalando/nakadi/repository/db/AuthorizationDbRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/db/AuthorizationDbRepository.java
@@ -39,13 +39,14 @@ public class AuthorizationDbRepository extends AbstractDbRepository {
         return listAllFromResource(ALL_DATA_ACCESS_RESOURCE);
     }
 
-    private List<Permission> listAllFromResource(final String resource) {
+    private List<Permission> listAllFromResource(final String resource) throws RepositoryProblemException {
         final List<Permission> permissions;
         try {
             permissions = jdbcTemplate.query("SELECT * FROM zn_data.authorization WHERE az_resource=?",
                     new Object[] { resource }, permissionRowMapper);
         } catch (final DataAccessException e) {
-            throw new RepositoryProblemException("Error occurred when fetching permissions for ", e);
+            throw new RepositoryProblemException(
+                    String.format("Error occurred when fetching permissions for resource %s", resource), e);
         }
 
         return permissions;

--- a/src/main/java/org/zalando/nakadi/repository/db/AuthorizationDbRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/db/AuthorizationDbRepository.java
@@ -15,6 +15,9 @@ import org.zalando.nakadi.plugin.api.authz.AuthorizationService;
 
 import java.util.List;
 
+import static org.zalando.nakadi.domain.AdminResource.ADMIN_RESOURCE;
+import static org.zalando.nakadi.domain.AllDataAccessResource.ALL_DATA_ACCESS_RESOURCE;
+
 @DB
 @Repository
 public class AuthorizationDbRepository extends AbstractDbRepository {
@@ -29,15 +32,23 @@ public class AuthorizationDbRepository extends AbstractDbRepository {
     }
 
     public List<Permission> listAdmins() throws RepositoryProblemException {
-        final List<Permission> admins;
+        return listAllFromResource(ADMIN_RESOURCE);
+    }
+
+    public List<Permission> listAllDataAccess() throws RepositoryProblemException {
+        return listAllFromResource(ALL_DATA_ACCESS_RESOURCE);
+    }
+
+    private List<Permission> listAllFromResource(final String resource) {
+        final List<Permission> permissions;
         try {
-            admins = jdbcTemplate.query("SELECT * FROM zn_data.authorization WHERE az_resource='nakadi'",
-                    permissionRowMapper);
+            permissions = jdbcTemplate.query("SELECT * FROM zn_data.authorization WHERE az_resource=?",
+                    new Object[] { resource }, permissionRowMapper);
         } catch (final DataAccessException e) {
-            throw new RepositoryProblemException("Error occurred when fetching administrators", e);
+            throw new RepositoryProblemException("Error occurred when fetching permissions for ", e);
         }
 
-        return admins;
+        return permissions;
     }
 
     public void deletePermission(final Permission permission) {

--- a/src/main/java/org/zalando/nakadi/service/AdminService.java
+++ b/src/main/java/org/zalando/nakadi/service/AdminService.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.zalando.nakadi.config.NakadiSettings;
 import org.zalando.nakadi.domain.AdminResource;
+import org.zalando.nakadi.domain.AllDataAccessResource;
 import org.zalando.nakadi.domain.Permission;
 import org.zalando.nakadi.domain.ResourceAuthorization;
 import org.zalando.nakadi.exceptions.UnableProcessException;
@@ -17,6 +18,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.zalando.nakadi.domain.AdminResource.ADMIN_RESOURCE;
+import static org.zalando.nakadi.domain.AllDataAccessResource.ALL_DATA_ACCESS_RESOURCE;
 
 @Service
 public class AdminService {
@@ -58,6 +60,13 @@ public class AdminService {
     public boolean isAdmin(final AuthorizationService.Operation operation) {
         final List<Permission> permissions = getAdmins();
         final Resource resource = new AdminResource(ADMIN_RESOURCE,
+                ResourceAuthorization.fromPermissionsList(permissions));
+        return authorizationService.isAuthorized(operation, resource);
+    }
+
+    public boolean hasAllDataAccess(final AuthorizationService.Operation operation) {
+        final List<Permission> permissions = authorizationDbRepository.listAllDataAccess();
+        final Resource resource = new AllDataAccessResource(ALL_DATA_ACCESS_RESOURCE,
                 ResourceAuthorization.fromPermissionsList(permissions));
         return authorizationService.isAuthorized(operation, resource);
     }

--- a/src/main/java/org/zalando/nakadi/service/AuthorizationValidator.java
+++ b/src/main/java/org/zalando/nakadi/service/AuthorizationValidator.java
@@ -5,9 +5,9 @@ import com.google.common.collect.ImmutableMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.zalando.nakadi.domain.EventType;
-import org.zalando.nakadi.domain.ResourceAuthorization;
 import org.zalando.nakadi.domain.EventTypeBase;
 import org.zalando.nakadi.domain.EventTypeResource;
+import org.zalando.nakadi.domain.ResourceAuthorization;
 import org.zalando.nakadi.domain.SubscriptionBase;
 import org.zalando.nakadi.exceptions.InternalNakadiException;
 import org.zalando.nakadi.exceptions.UnableProcessException;
@@ -155,7 +155,9 @@ public class AuthorizationValidator {
         final Resource resource = new EventTypeResource(eventType.getName(), eventType.getAuthorization());
         try {
             if (!authorizationService.isAuthorized(AuthorizationService.Operation.READ, resource)) {
-                throw new AccessDeniedException(AuthorizationService.Operation.READ, resource);
+                if (!adminService.hasAllDataAccess(AuthorizationService.Operation.READ)) {
+                    throw new AccessDeniedException(AuthorizationService.Operation.READ, resource);
+                }
             }
         } catch (final PluginException e) {
             throw new ServiceTemporarilyUnavailableException("Error calling authorization plugin", e);

--- a/src/main/java/org/zalando/nakadi/service/AuthorizationValidator.java
+++ b/src/main/java/org/zalando/nakadi/service/AuthorizationValidator.java
@@ -154,10 +154,9 @@ public class AuthorizationValidator {
 
         final Resource resource = new EventTypeResource(eventType.getName(), eventType.getAuthorization());
         try {
-            if (!authorizationService.isAuthorized(AuthorizationService.Operation.READ, resource)) {
-                if (!adminService.hasAllDataAccess(AuthorizationService.Operation.READ)) {
-                    throw new AccessDeniedException(AuthorizationService.Operation.READ, resource);
-                }
+            if (!authorizationService.isAuthorized(AuthorizationService.Operation.READ, resource)
+                    && !adminService.hasAllDataAccess(AuthorizationService.Operation.READ)) {
+                throw new AccessDeniedException(AuthorizationService.Operation.READ, resource);
             }
         } catch (final PluginException e) {
             throw new ServiceTemporarilyUnavailableException("Error calling authorization plugin", e);

--- a/src/test/java/org/zalando/nakadi/controller/EventStreamControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventStreamControllerTest.java
@@ -25,6 +25,7 @@ import org.zalando.nakadi.exceptions.NakadiException;
 import org.zalando.nakadi.exceptions.NoSuchEventTypeException;
 import org.zalando.nakadi.exceptions.ServiceUnavailableException;
 import org.zalando.nakadi.exceptions.runtime.AccessDeniedException;
+import org.zalando.nakadi.plugin.api.authz.AuthorizationService;
 import org.zalando.nakadi.repository.EventConsumer;
 import org.zalando.nakadi.repository.EventTypeRepository;
 import org.zalando.nakadi.repository.TopicRepository;
@@ -34,6 +35,7 @@ import org.zalando.nakadi.security.Client;
 import org.zalando.nakadi.security.ClientResolver;
 import org.zalando.nakadi.security.FullAccessClient;
 import org.zalando.nakadi.security.NakadiClient;
+import org.zalando.nakadi.service.AdminService;
 import org.zalando.nakadi.service.AuthorizationValidator;
 import org.zalando.nakadi.service.BlacklistService;
 import org.zalando.nakadi.service.ClosedConnectionsCrutch;
@@ -42,9 +44,9 @@ import org.zalando.nakadi.service.EventStream;
 import org.zalando.nakadi.service.EventStreamConfig;
 import org.zalando.nakadi.service.EventStreamFactory;
 import org.zalando.nakadi.service.EventTypeChangeListener;
+import org.zalando.nakadi.service.FeatureToggleService;
 import org.zalando.nakadi.service.converter.CursorConverterImpl;
 import org.zalando.nakadi.service.timeline.TimelineService;
-import org.zalando.nakadi.service.FeatureToggleService;
 import org.zalando.nakadi.utils.TestUtils;
 import org.zalando.problem.Problem;
 
@@ -116,6 +118,8 @@ public class EventStreamControllerTest {
     private Timeline timeline;
     private AuthorizationValidator authorizationValidator;
     private EventTypeChangeListener eventTypeChangeListener;
+    private AdminService adminService;
+    private AuthorizationService authorizationService;
 
     @Before
     public void setup() throws NakadiException, UnknownHostException, InvalidCursorException {
@@ -124,6 +128,8 @@ public class EventStreamControllerTest {
 
         eventTypeRepository = mock(EventTypeRepository.class);
         topicRepositoryMock = mock(TopicRepository.class);
+        adminService = mock(AdminService.class);
+        authorizationService = mock(AuthorizationService.class);
         when(topicRepositoryMock.topicExists(TEST_TOPIC)).thenReturn(true);
         eventStreamFactoryMock = mock(EventStreamFactory.class);
         eventTypeCache = mock(EventTypeCache.class);
@@ -464,6 +470,24 @@ public class EventStreamControllerTest {
 
         final Problem expectedProblem = Problem.valueOf(FORBIDDEN, "Access on READ some-type:some-name denied");
         assertThat(responseToString(responseBody), TestUtils.JSON_TEST_HELPER.matchesObject(expectedProblem));
+    }
+
+    @Test
+    public void testAccessAllowedForAllDataAccess() throws Exception {
+        doNothing().when(authorizationValidator).authorizeStreamRead(any());
+
+        prepareScopeRead();
+        final ArgumentCaptor<Integer> statusCaptor = getStatusCaptor();
+        final ArgumentCaptor<String> contentTypeCaptor = getContentTypeCaptor();
+
+        when(eventStreamFactoryMock.createEventStream(any(), any(), any(), any()))
+                .thenReturn(mock(EventStream.class));
+
+        writeStream();
+
+        assertThat(statusCaptor.getValue(), equalTo(HttpStatus.OK.value()));
+        assertThat(contentTypeCaptor.getValue(), equalTo("application/x-json-stream"));
+        verify(authorizationValidator, times(1)).authorizeStreamRead(any());
     }
 
     private void writeStream() throws Exception {

--- a/src/test/java/org/zalando/nakadi/controller/PartitionsControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/PartitionsControllerTest.java
@@ -25,9 +25,9 @@ import org.zalando.nakadi.security.ClientResolver;
 import org.zalando.nakadi.service.AuthorizationValidator;
 import org.zalando.nakadi.service.CursorConverter;
 import org.zalando.nakadi.service.CursorOperationsService;
+import org.zalando.nakadi.service.FeatureToggleService;
 import org.zalando.nakadi.service.converter.CursorConverterImpl;
 import org.zalando.nakadi.service.timeline.TimelineService;
-import org.zalando.nakadi.service.FeatureToggleService;
 import org.zalando.nakadi.utils.TestUtils;
 import org.zalando.nakadi.view.CursorLag;
 import org.zalando.nakadi.view.EventTypePartitionView;
@@ -42,6 +42,7 @@ import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -183,6 +184,18 @@ public class PartitionsControllerTest {
         mockMvc.perform(
                 get(String.format("/event-types/%s/partitions", TEST_EVENT_TYPE)))
                 .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void whenAllDataAccessGetPartitionsThenOk() throws Exception {
+        when(eventTypeRepositoryMock.findByName(TEST_EVENT_TYPE)).thenReturn(EVENT_TYPE);
+
+        doNothing().when(authorizationValidator).authorizeStreamRead(any());
+
+        mockMvc.perform(get(String.format("/event-types/%s/partitions", TEST_EVENT_TYPE)))
+                .andExpect(status().isOk());
+
+        Mockito.verify(authorizationValidator, Mockito.times(1)).authorizeStreamRead(any());
     }
 
     @Test


### PR DESCRIPTION
# Allow READ access to applications with READ permission for all_data_access resource

> Zalando ticket : ARUHA-1504

## Description
If an application holds a READ permission for resource all_data_access, it will be able to read from all event types, regardless of their authorization policy.

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
The list of subjects with permissions for all_data_access must be inserted directly into the DB.
