### PR TITLE
ARUHA-1496: disallow  to post event type with null compatability mode

### DIFF
--- a/src/main/java/org/zalando/nakadi/domain/EventTypeBase.java
+++ b/src/main/java/org/zalando/nakadi/domain/EventTypeBase.java
@@ -54,6 +54,7 @@ public class EventTypeBase {
     @Valid
     private ResourceAuthorization authorization;
 
+    @NotNull
     private CompatibilityMode compatibilityMode;
 
     public EventTypeBase() {


### PR DESCRIPTION
Do not allow to create event type with null compatibility mode

> Zalando ticket : ARUHA-1496

## Description
Getting event type with null compatibility mode returns 500

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG
