### PR TITLE
Aruha 1489 Deprecate Low-level API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Low-level API marked as deprecated
+
 ## [2.5.7] - 2018-02-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The project is in active development. See the [CHANGELOG.md](CHANGELOG.md)
     * REST abstraction over Kafka-like queues.
     * CRUD for event types.
     * Event batch publishing.
-    * Low-level interface.
+    * Low-level interface (**deprecated**).
         * manual client side partition management is needed
         * no support of commits
     * High-level interface (Subscription API).

--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -47,10 +47,7 @@ info:
     Nakadi via the **Schema Registry API** for the definition of EventTypes, while Clients via the
     streaming API for submission and reception of Events.
 
-    A low level **Unmanaged API** is available, providing full control and responsibility of
-    position tracking and partition resolution (and therefore ordering) to the Clients.
-
-    In the **High Level API** the consumption of Events proceeds via the establishment
+    In the **Subscriptions API** (High Level API), the consumption of Events proceeds via the establishment
     of a named **Subscription** to an EventType. Subscriptions are persistent relationships from an
     Application (which might have several instances) and the stream of one or more EventType's,
     whose consumption tracking is managed by Nakadi, freeing Consumers from any responsibility in
@@ -73,7 +70,7 @@ info:
     Other aspects of the Event Bus are at this moment to be defined and otherwise specified, not included
     in this version of this specification.
 
-  version: '0.9.1'
+  version: '0.10.0'
   contact:
     name: Team Aruha @ Zalando
     email: team-aruha+nakadi-maintainers@zalando.de
@@ -407,12 +404,15 @@ paths:
             $ref: '#/definitions/Problem'
 
     get:
+      deprecated: true
       tags:
         - stream-api
         - unmanaged-api
       security:
         - oauth2: ['nakadi.event_stream.read']
       description: |
+        **The Low Level API is deprecated. It will be removed in a future version.**
+
         Starts a stream delivery for the specified partitions of the given EventType.
 
         The event stream is formatted as a sequence of `EventStreamBatch`es separated by `\n`. Each

--- a/docs/_documentation/using_consuming-events-lola.md
+++ b/docs/_documentation/using_consuming-events-lola.md
@@ -5,6 +5,8 @@ position: 8
 
 ## Consuming Events with the Low-level API
 
+**The Low-level API is deprecated, and will be removed from a future version of Nakadi. Please consider using the High-level API instead.**
+
 ### Connecting to a Stream
 
 A consumer can open the stream for an Event Type via the `/events` sub-resource. For example to connect to the `order_received` stream send a GET request to its stream as follows:

--- a/src/main/java/org/zalando/nakadi/controller/EventStreamController.java
+++ b/src/main/java/org/zalando/nakadi/controller/EventStreamController.java
@@ -257,6 +257,8 @@ public class EventStreamController {
                 final String kafkaQuotaClientId = getKafkaQuotaClientId(eventTypeName, client);
 
                 response.setStatus(HttpStatus.OK.value());
+                response.setHeader("Warning", "299 - nakadi - the Low-level API is deprecated and will " +
+                        "be removed from a future release. Please consider migrating to the High-level API.");
                 response.setContentType("application/x-json-stream");
                 final EventConsumer eventConsumer = timelineService.createEventConsumer(
                         kafkaQuotaClientId, streamConfig.getCursors());

--- a/src/main/java/org/zalando/nakadi/controller/EventStreamController.java
+++ b/src/main/java/org/zalando/nakadi/controller/EventStreamController.java
@@ -258,7 +258,7 @@ public class EventStreamController {
 
                 response.setStatus(HttpStatus.OK.value());
                 response.setHeader("Warning", "299 - nakadi - the Low-level API is deprecated and will " +
-                        "be removed from a future release. Please consider migrating to the High-level API.");
+                        "be removed from a future release. Please consider migrating to the Subscriptions API.");
                 response.setContentType("application/x-json-stream");
                 final EventConsumer eventConsumer = timelineService.createEventConsumer(
                         kafkaQuotaClientId, streamConfig.getCursors());


### PR DESCRIPTION
# Deprecate Low-level API

> Zalando ticket : ARUHA-1489

## Description
This PR marks the Low-level API as deprecated:
- in the documentation
- in the swagger file
- with a warning added to the response to calls to the deprecated endpoint

Users of the low-level API are encouraged to migrate to the high-level API.

## Review
- [ ] Tests
- [x] Documentation
- [x] CHANGELOG
