### PR TITLE
Documentation: Link to new homepage for nakadi-client for Haskell

### DIFF
--- a/docs/_documentation/using_clients.md
+++ b/docs/_documentation/using_clients.md
@@ -14,7 +14,7 @@ Nakadi does not ship with a client, but there are some open source clients avail
 | Reactive Nakadi | Scala/Akka         | <https://github.com/zalando-nakadi/reactive-nakadi> |
 | Fahrschein      | Java               | <https://github.com/zalando-nakadi/fahrschein>      |
 | Nakadion        | Rust               | <https://github.com/chridou/nakadion>               |
-| nakadi-client   | Haskell            | <https://hackage.haskell.org/package/nakadi-client> |
+| nakadi-client   | Haskell            | <http://nakadi-client.haskell.silverratio.net>      |
 | go-nakadi       | Go                 | <https://github.com/stoewer/go-nakadi>              |
 | nakacli         | CLI                | <https://github.com/amrhassan/nakacli>              |
 


### PR DESCRIPTION
# One-line summary

Updated Nakadi documentation to refer to the new homepage of the nakadi-client package for Haskell instead of referring straight to the API documentation as published on Hackage.

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
n/a

