### PR TITLE
ensure linear runtime regex pattern matching

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,7 +159,9 @@ dependencies {
     compile 'org.apache.curator:curator-recipes:2.12.0'
 
     // json
-    compile 'com.github.everit-org.json-schema:org.everit.json.schema:86c29435e43e3e56924cf6ddf3013b5a381930b6'
+    compile ('com.github.everit-org.json-schema:org.everit.json.schema:6cb8ae440b0bc34030d7bea85ac609d980d741fb') {
+        exclude module: "json"
+    }
     compile ('com.fasterxml.jackson.datatype:jackson-datatype-json-org:2.8.8') {
         exclude module: "json"
     }

--- a/src/test/java/org/zalando/nakadi/validation/JSONSchemaValidationTest.java
+++ b/src/test/java/org/zalando/nakadi/validation/JSONSchemaValidationTest.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
 import static org.zalando.nakadi.utils.IsOptional.isAbsent;
 import static org.zalando.nakadi.utils.TestUtils.readFile;
@@ -105,6 +106,26 @@ public class JSONSchemaValidationTest {
     }
 
     @Test
+    public void requirePatternMatchingToBeFast() {
+        String pattern = "a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?aaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        String value = "aaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+        final EventType et = EventTypeTestBuilder.builder().name("some-event-type").schema(patternSchema(pattern)).build();
+        et.setCategory(EventCategory.UNDEFINED);
+
+        long startTime = System.currentTimeMillis();
+
+        final JSONObject event = undefinedEvent(value);
+
+        final Optional<ValidationError> error = EventValidation.forType(et).validate(event);
+
+        long duration = System.currentTimeMillis() - startTime;
+
+        assertThat(error, isAbsent());
+        assertThat(duration, lessThan(100L));
+    }
+
+    @Test
     public void acceptsDefinitionsOnDataChangeEvents() throws Exception {
         final JSONObject schema = new JSONObject(readFile("product-json-schema.json"));
         final EventType et = EventTypeTestBuilder.builder().name("some-event-type").schema(schema).build();
@@ -131,10 +152,33 @@ public class JSONSchemaValidationTest {
         return schema;
     }
 
+    private JSONObject patternSchema(String pattern) {
+        final JSONObject schema = new JSONObject();
+        final JSONObject string = new JSONObject();
+        string.put("type", "string");
+        string.put("pattern", pattern);
+
+        final JSONObject properties = new JSONObject();
+        properties.put("foo", string);
+
+        schema.put("type", "object");
+        schema.put("required", Arrays.asList(new String[]{"foo"}));
+        schema.put("properties", properties);
+
+        return schema;
+    }
+
     private JSONObject businessEvent() {
         final JSONObject event = new JSONObject();
         event.put("foo", "bar");
         event.put("metadata", metadata());
+
+        return event;
+    }
+
+    private JSONObject undefinedEvent(String foo) {
+        final JSONObject event = new JSONObject();
+        event.put("foo", foo);
 
         return event;
     }


### PR DESCRIPTION
There is exponential runtime behaviour in Java's PCRE regex lib. Hence there is a possible denial-of-service attack for Nakadi using particular regex patterns and values for json schema validation.

One added test case picks an example of such a bad-behaving regular expression and checks that schema validation happens within milliseconds. This is not met before.

Changing json-schema to a current version fixes that runtime issue, because json-schema now internally uses `com.google.re2j.Pattern` instead of `java.util.regex.Pattern`. The RE2 engine guarantees linear runtime.