### PR TITLE
Change Nakadion Nakadi Client link in docs

### DIFF
--- a/docs/_documentation/using_clients.md
+++ b/docs/_documentation/using_clients.md
@@ -13,7 +13,7 @@ Nakadi does not ship with a client, but there are some open source clients avail
 | Nakadi Klients  | Scala & Java       | <https://github.com/kanuku/nakadi-klients>          |
 | Reactive Nakadi | Scala/Akka         | <https://github.com/zalando-nakadi/reactive-nakadi> |
 | Fahrschein      | Java               | <https://github.com/zalando-nakadi/fahrschein>      |
-| Nakadion        | Rust               | <https://github.com/chridou/nakadion>               |
+| Nakadion        | Rust               | <https://crates.io/crates/nakadion>                 |
 | nakadi-client   | Haskell            | <http://nakadi-client.haskell.silverratio.net>      |
 | go-nakadi       | Go                 | <https://github.com/stoewer/go-nakadi>              |
 | nakacli         | CLI                | <https://github.com/amrhassan/nakacli>              |


### PR DESCRIPTION
# One-line summary

Changed the link for the Nakadi Rust Client(Nakadion)

## Description
Changed the link for the Nakadi Rust Client(Nakadion) to point
at crates.io(official Rust artifact repository) instead of my personal repository.


