### PR TITLE
INC-13145 Do not log stack trace when users provide a non-existing subscription ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.6.1] - 2018-04-03
+
+### Fixed
+- Do not log a complete stack trace when a user makes a request for a non-existing subscription
+
 ## [2.6.0] - 2018-03-26
 
 ### Added

--- a/src/main/java/org/zalando/nakadi/controller/SubscriptionStreamController.java
+++ b/src/main/java/org/zalando/nakadi/controller/SubscriptionStreamController.java
@@ -22,6 +22,7 @@ import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBo
 import org.zalando.nakadi.config.NakadiSettings;
 import org.zalando.nakadi.domain.Subscription;
 import org.zalando.nakadi.exceptions.NakadiException;
+import org.zalando.nakadi.exceptions.NoSuchSubscriptionException;
 import org.zalando.nakadi.exceptions.runtime.AccessDeniedException;
 import org.zalando.nakadi.exceptions.runtime.SubscriptionPartitionConflictException;
 import org.zalando.nakadi.exceptions.runtime.WrongStreamParametersException;
@@ -113,7 +114,7 @@ public class SubscriptionStreamController {
 
         @Override
         public void onException(final Exception ex) {
-            LOG.warn("Exception occurred while streaming", ex);
+            LOG.warn("Exception occurred while streaming: {}", ex.getMessage());
             if (!headersSent) {
                 headersSent = true;
                 try {
@@ -125,6 +126,9 @@ public class SubscriptionStreamController {
                                 ex.getMessage()));
                     } else if (ex instanceof WrongStreamParametersException) {
                         writeProblemResponse(response, out, Problem.valueOf(MoreStatus.UNPROCESSABLE_ENTITY,
+                                ex.getMessage()));
+                    } else if (ex instanceof NoSuchSubscriptionException) {
+                        writeProblemResponse(response, out, Problem.valueOf(Response.Status.NOT_FOUND,
                                 ex.getMessage()));
                     } else if (ex instanceof NakadiException) {
                         writeProblemResponse(response, out, ((NakadiException) ex).asProblem());

--- a/src/main/java/org/zalando/nakadi/repository/db/SubscriptionDbRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/db/SubscriptionDbRepository.java
@@ -87,7 +87,7 @@ public class SubscriptionDbRepository extends AbstractDbRepository {
         try {
             return jdbcTemplate.queryForObject(sql, new Object[]{id}, rowMapper);
         } catch (final EmptyResultDataAccessException e) {
-            throw new NoSuchSubscriptionException("Subscription with id \"" + id + "\" does not exist", e);
+            throw new NoSuchSubscriptionException("Subscription with id \"" + id + "\" does not exist");
         } catch (final DataAccessException e) {
             LOG.error("Database error when getting subscription", e);
             throw new ServiceUnavailableException("Error occurred when running database request");

--- a/src/main/java/org/zalando/nakadi/service/BlacklistService.java
+++ b/src/main/java/org/zalando/nakadi/service/BlacklistService.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.zalando.nakadi.exceptions.NakadiException;
+import org.zalando.nakadi.exceptions.NoSuchSubscriptionException;
 import org.zalando.nakadi.repository.db.SubscriptionDbRepository;
 import org.zalando.nakadi.repository.zookeeper.ZooKeeperHolder;
 
@@ -77,6 +78,8 @@ public class BlacklistService {
         try {
             return isSubscriptionConsumptionBlocked(
                     subscriptionDbRepository.getSubscription(subscriptionId).getEventTypes(), appId);
+        } catch (final NoSuchSubscriptionException e) {
+            LOG.error(e.getMessage());
         } catch (final NakadiException e) {
             LOG.error(e.getMessage(), e);
         }

--- a/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionService.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionService.java
@@ -169,7 +169,7 @@ public class SubscriptionService {
             final Subscription subscription = subscriptionRepository.getSubscription(subscriptionId);
             return Result.ok(subscription);
         } catch (final NoSuchSubscriptionException e) {
-            LOG.debug("Failed to find subscription: {}", subscriptionId, e);
+            LOG.debug("Failed to find subscription: {}", subscriptionId);
             return Result.problem(e.asProblem());
         } catch (final ServiceUnavailableException e) {
             LOG.error("Error occurred when trying to get subscription: {}", subscriptionId, e);


### PR DESCRIPTION
# Do not log stack trace when users provide a non-existing subscription ID

> Zalando ticket : INC-13145

## Description
This PR stops logging a full stack trace when a users makes a GET request to `/subscriptions/{id}` or `/subscriptions/{id}/events` with a subscription ID that does not exist

