### PR TITLE
ARUHA-1604: added flushing collected events when reaching stream timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Added flushing of collected events when reaching stream_timeout in subscription API
+
 ## [2.6.3] - 2018-04-10
 
 ### Fixed

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java
@@ -56,12 +56,16 @@ class PartitionData {
 
     @Nullable
     List<ConsumedEvent> takeEventsToStream(final long currentTimeMillis, final int batchSize,
-                                           final long batchTimeoutMillis) {
+                                           final long batchTimeoutMillis, final boolean streamTimeoutReached) {
         final boolean countReached = (nakadiEvents.size() >= batchSize) && batchSize > 0;
         final boolean timeReached = (currentTimeMillis - lastSendMillis) >= batchTimeoutMillis;
         if (countReached || timeReached) {
             lastSendMillis = currentTimeMillis;
             return extract(batchSize);
+        } else if (streamTimeoutReached) {
+            lastSendMillis = currentTimeMillis;
+            final List<ConsumedEvent> extractedEvents = extract(batchSize);
+            return extractedEvents.isEmpty() ? null : extractedEvents;
         } else {
             return null;
         }

--- a/src/test/java/org/zalando/nakadi/service/subscription/state/PartitionDataTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/state/PartitionDataTest.java
@@ -63,7 +63,7 @@ public class PartitionDataTest {
             pd.addEvent(new ConsumedEvent(("test_" + i).getBytes(), createCursor(100L + i + 1)));
         }
         // Now say to it that it was sent
-        pd.takeEventsToStream(currentTimeMillis(), 1000, 0L);
+        pd.takeEventsToStream(currentTimeMillis(), 1000, 0L, false);
         assertEquals(100L, pd.getUnconfirmed());
         for (long i = 0; i < 10; ++i) {
             final PartitionData.CommitResult cr = pd.onCommitOffset(createCursor(110L + i * 10L));
@@ -77,14 +77,14 @@ public class PartitionDataTest {
     public void keepAliveCountShouldIncreaseOnEachEmptyCall() {
         final PartitionData pd = new PartitionData(COMP, null, createCursor(100L), System.currentTimeMillis());
         for (int i = 0; i < 100; ++i) {
-            pd.takeEventsToStream(currentTimeMillis(), 10, 0L);
+            pd.takeEventsToStream(currentTimeMillis(), 10, 0L, false);
             assertEquals(i + 1, pd.getKeepAliveInARow());
         }
         pd.addEvent(new ConsumedEvent("".getBytes(), createCursor(101L)));
         assertEquals(100, pd.getKeepAliveInARow());
-        pd.takeEventsToStream(currentTimeMillis(), 10, 0L);
+        pd.takeEventsToStream(currentTimeMillis(), 10, 0L, false);
         assertEquals(0, pd.getKeepAliveInARow());
-        pd.takeEventsToStream(currentTimeMillis(), 10, 0L);
+        pd.takeEventsToStream(currentTimeMillis(), 10, 0L, false);
         assertEquals(1, pd.getKeepAliveInARow());
     }
 
@@ -97,26 +97,26 @@ public class PartitionDataTest {
         for (int i = 0; i < 100; ++i) {
             pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i + 100L + 1)));
         }
-        List<ConsumedEvent> data = pd.takeEventsToStream(currentTime, 1000, timeout);
+        List<ConsumedEvent> data = pd.takeEventsToStream(currentTime, 1000, timeout, false);
         assertNull(data);
         assertEquals(0, pd.getKeepAliveInARow());
 
         currentTime += timeout + 1;
 
-        data = pd.takeEventsToStream(currentTime, 1000, timeout);
+        data = pd.takeEventsToStream(currentTime, 1000, timeout, false);
         assertNotNull(data);
         assertEquals(100, data.size());
 
         for (int i = 100; i < 200; ++i) {
             pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i + 100L + 1)));
         }
-        data = pd.takeEventsToStream(currentTime, 1000, timeout);
+        data = pd.takeEventsToStream(currentTime, 1000, timeout, false);
         assertNull(data);
         assertEquals(0, pd.getKeepAliveInARow());
 
         currentTime += timeout + 1;
 
-        data = pd.takeEventsToStream(currentTime, 1000, timeout);
+        data = pd.takeEventsToStream(currentTime, 1000, timeout, false);
         assertNotNull(data);
         assertEquals(100, data.size());
     }
@@ -128,8 +128,8 @@ public class PartitionDataTest {
         for (int i = 0; i < 100; ++i) {
             pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i + 100L + 1)));
         }
-        assertNull(pd.takeEventsToStream(currentTimeMillis(), 1000, timeout));
-        final List<ConsumedEvent> eventsToStream = pd.takeEventsToStream(currentTimeMillis(), 99, timeout);
+        assertNull(pd.takeEventsToStream(currentTimeMillis(), 1000, timeout, false));
+        final List<ConsumedEvent> eventsToStream = pd.takeEventsToStream(currentTimeMillis(), 99, timeout, false);
         assertNotNull(eventsToStream);
         assertEquals(99, eventsToStream.size());
     }


### PR DESCRIPTION
# Added flushing collected events when reaching stream timeout in subscription API

> Zalando ticket : ARUHA-1604(only if appropriate)

## Description
When stream_timeout is reached user wants to get events which were collected so far.

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
We should keep an eye on complaining users
