### PR TITLE
ARUHA-1626: fixed commit for subscriptions that use direct assignment of partitions;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Fixed commit for subscriptions that use direct assignment of partitions
+
 ## [2.6.3] - 2018-04-10
 
 ### Fixed

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRebalanceAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRebalanceAT.java
@@ -322,7 +322,7 @@ public class HilaRebalanceAT extends BaseAT {
         final int commitStatusCode = commitCursors(subscription.getId(),
                 ImmutableList.of(client.getBatches().get(0).getCursor()), client.getSessionId());
 
-        // check that we get 200
+        // check that we get 204
         assertThat(commitStatusCode, is(HttpStatus.NO_CONTENT.value()));
     }
 

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRebalanceAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRebalanceAT.java
@@ -1,6 +1,8 @@
 package org.zalando.nakadi.webservice.hila;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
@@ -299,6 +301,29 @@ public class HilaRebalanceAT extends BaseAT {
         final TestStreamingClient autoClient2 = new TestStreamingClient(URL, subscription.getId(), "");
         autoClient2.start();
         waitFor(() -> assertThat(autoClient2.getResponseCode(), is(HttpStatus.CONFLICT.value())));
+    }
+
+    @Test(timeout = 10000)
+    public void testCommitWhenDirectAssignment() throws Exception {
+        // connect with 1 stream directly requesting one partition
+        final TestStreamingClient client = new TestStreamingClient(URL, subscription.getId(), "batch_flush_timeout=1",
+                Optional.empty(),
+                Optional.of("{\"partitions\":[" +
+                        "{\"event_type\":\"" + eventType.getName() + "\",\"partition\":\"0\"}]}"));
+        client.start();
+        // wait for rebalance to finish
+        waitFor(() -> assertThat(getNumberOfAssignedStreams(subscription.getId()), Matchers.is(1)));
+        // publish 1 event
+        publishBusinessEventWithUserDefinedPartition(eventType.getName(), 1, x -> "blah", x -> "0");
+        // wait for event to come
+        waitFor(() -> assertThat(client.getBatches(), hasSize(1)));
+
+        // commit cursor
+        final int commitStatusCode = commitCursors(subscription.getId(),
+                ImmutableList.of(client.getBatches().get(0).getCursor()), client.getSessionId());
+
+        // check that we get 200
+        assertThat(commitStatusCode, is(HttpStatus.NO_CONTENT.value()));
     }
 
     public List<SubscriptionCursor> getLastCursorsForPartitions(final TestStreamingClient client,

--- a/src/main/java/org/zalando/nakadi/service/CursorsService.java
+++ b/src/main/java/org/zalando/nakadi/service/CursorsService.java
@@ -110,6 +110,7 @@ public class CursorsService {
 
         final Map<EventTypePartition, String> partitionSessions = Stream
                 .of(subscriptionClient.getTopology().getPartitions())
+                .filter(p -> p.getSession() != null)
                 .collect(Collectors.toMap(Partition::getKey, Partition::getSession));
         for (final NakadiCursor cursor : cursors) {
             final EventTypePartition etPartition = cursor.getEventTypePartition();


### PR DESCRIPTION
# Fixed the problem with getting 500 status when committing for subscription that uses direct assignment of partitions

> Fix 500 on Nakadi stream from single partition : ARUHA-1626

## Review
- [ ] Tests
- [ ] Documentation
- [x] CHANGELOG

## Deployment Notes
-
