### PR TITLE
localhost uses http not https - fixed samples in docs

### DIFF
--- a/docs/_api/event-types_name_events_get.md
+++ b/docs/_api/event-types_name_events_get.md
@@ -5,7 +5,7 @@ position: 100
 The HTTP response on the wire will look something like this (the newline is show as `\n` for clarity):
 
 ```sh
-curl -v https://localhost:8080/event-types/order_received/events 
+curl -v http://localhost:8080/event-types/order_received/events 
     
 
 HTTP/1.1 200 OK

--- a/docs/_documentation/intro.md
+++ b/docs/_documentation/intro.md
@@ -107,7 +107,7 @@ like
 An event type can be created by posting to the `event-types` resource.
 
 ```sh
-curl -v -XPOST https://localhost:8080/event-types -H "Content-type: application/json" -d '{
+curl -v -XPOST http://localhost:8080/event-types -H "Content-type: application/json" -d '{
   "name": "order.ORDER_RECEIVED",
   "owning_application": "order-service",
   "category": "undefined",
@@ -124,7 +124,7 @@ curl -v -XPOST https://localhost:8080/event-types -H "Content-type: application/
 Events for an event type can be published by posting to its "events" collection:
 
 ```sh
-curl -v -XPOST https://localhost:8080/event-types/order.ORDER_RECEIVED/events -H "Content-type: application/json" -d '[
+curl -v -XPOST http://localhost:8080/event-types/order.ORDER_RECEIVED/events -H "Content-type: application/json" -d '[
   {
     "order_number": "24873243241",
     "metadata": {
@@ -149,7 +149,7 @@ HTTP/1.1 200 OK
 You can open a stream for an Event Type via the `events` sub-resource:
 
 ```sh
-curl -v https://localhost:8080/event-types/order.ORDER_RECEIVED/events 
+curl -v http://localhost:8080/event-types/order.ORDER_RECEIVED/events 
     
 
 HTTP/1.1 200 OK

--- a/docs/_documentation/using_authorization.md
+++ b/docs/_documentation/using_authorization.md
@@ -49,7 +49,7 @@ Here is a sample request with an authorization section. It gives read, write, an
 of type `service`:
 
 ```bash
-curl -v -XPOST -H "Content-Type: application/json" https://localhost:8080/event-types -d '{
+curl -v -XPOST -H "Content-Type: application/json" http://localhost:8080/event-types -d '{
   "name": "order_received",
   "owning_application": "acme-order-service",
   "category": "business",
@@ -80,7 +80,7 @@ Updating an event type is similar to creating one. Here is a sample request, tha
 to the same application:
 
 ```bash
-curl -v -XPUT -H "Content-Type: application/json" https://localhost:8080/event-types/order_received -d '{
+curl -v -XPUT -H "Content-Type: application/json" http://localhost:8080/event-types/order_received -d '{
   "name": "order_received",
   "owning_application": "acme-order-service",
   "category": "business",

--- a/docs/_documentation/using_consuming-events-lola.md
+++ b/docs/_documentation/using_consuming-events-lola.md
@@ -12,7 +12,7 @@ position: 8
 A consumer can open the stream for an Event Type via the `/events` sub-resource. For example to connect to the `order_received` stream send a GET request to its stream as follows:
 
 ```sh
-curl -v https://localhost:8080/event-types/order_received/events 
+curl -v http://localhost:8080/event-types/order_received/events 
 ```
 
 The stream accepts various parameters from the consumer, which you can read about in the ["API Reference"](#nakadi-event-bus-api).
@@ -23,7 +23,7 @@ In this section we'll just describe the response format, along with how cursors 
 The HTTP response on the wire will look something like this (the newline is show as `\n` for clarity):
 
 ```sh
-curl -v https://localhost:8080/event-types/order_received/events 
+curl -v http://localhost:8080/event-types/order_received/events 
     
 
 HTTP/1.1 200 OK
@@ -61,7 +61,7 @@ The `events` array contains a list of events that were published in the order th
 By default the `/events` resource will return data from all partitions of an event type stream and will do so from the end (or "tail") of the stream. To select only particular partitions and a position in the stream to start, you can supply an `X-Nakadi-Cursors` header in the request:
 
 ```sh
-curl -v https://localhost:8080/event-types/order_received/events \
+curl -v http://localhost:8080/event-types/order_received/events \
   -H 'X-Nakadi-Cursors: [{"partition": "0", "offset":"12"}]'
 ```
 
@@ -70,7 +70,7 @@ The `X-Nakadi-Cursors` header value is a JSON array of _cursors_. Each cursor in
 The `offset` value of the cursor allows you select where in the stream partition you want to consume from. This can be any known offset value, or the dedicated value `begin` which will start the stream from the beginning. For example, to read from partition `0` from the beginning:
 
 ```sh
-curl -v https://localhost:8080/event-types/order_received/events \
+curl -v http://localhost:8080/event-types/order_received/events \
   -H 'X-Nakadi-Cursors:[{"partition": "0", "offset":"begin"}]'
 ```
 
@@ -80,7 +80,7 @@ curl -v https://localhost:8080/event-types/order_received/events \
 If there are no events to be delivered the server will keep a streaming connection open by periodically sending a batch with no events but which contains a `cursor` pointing to the current offset. For example:
 
 ```sh
-curl -v https://localhost:8080/event-types/order_received/events 
+curl -v http://localhost:8080/event-types/order_received/events 
       
 
 HTTP/1.1 200 OK

--- a/docs/_documentation/using_event-types.md
+++ b/docs/_documentation/using_event-types.md
@@ -161,7 +161,7 @@ An event type can be created by posting to the `/event-types` resource.
 This example shows a `business` category event type called `order_received`:
 
 ```sh
-curl -v -XPOST -H "Content-Type: application/json" https://localhost:8080/event-types -d '{
+curl -v -XPOST -H "Content-Type: application/json" http://localhost:8080/event-types -d '{
   "name": "order_received",
   "owning_application": "acme-order-service",
   "category": "business",

--- a/docs/_documentation/using_producing-events.md
+++ b/docs/_documentation/using_producing-events.md
@@ -14,7 +14,7 @@ The URI for a stream is a nested resource and based on the event type's name - f
 This example posts two events to the `order_received` stream:
 
 ```sh
-curl -v -XPOST -H "Content-Type: application/json" https://localhost:8080/event-types/order_received/events -d '[
+curl -v -XPOST -H "Content-Type: application/json" http://localhost:8080/event-types/order_received/events -d '[
   {
     "order_number": "24873243241",
     "metadata": {


### PR DESCRIPTION
# One-line summary
Fixed samples in the docs, replaced https with http for localhost.

## Description
Some curl samples were failing with TLS error.

## Review
- [ ] Tests
- [X] Documentation
- [ ] CHANGELOG

## Deployment Notes
-
