### PR TITLE
Removing deprecated/unmaintained Nakadi clients

### DIFF
--- a/docs/_documentation/using_clients.md
+++ b/docs/_documentation/using_clients.md
@@ -10,8 +10,6 @@ Nakadi does not ship with a client, but there are some open source clients avail
 | Name            | Language/Framework |  GitHub                                             |
 |-----------------|--------------------|-----------------------------------------------------|
 | Nakadi Java     | Java               | <https://github.com/dehora/nakadi-java>             |
-| Nakadi Klients  | Scala & Java       | <https://github.com/kanuku/nakadi-klients>          |
-| Reactive Nakadi | Scala/Akka         | <https://github.com/zalando-nakadi/reactive-nakadi> |
 | Fahrschein      | Java               | <https://github.com/zalando-nakadi/fahrschein>      |
 | Nakadion        | Rust               | <https://crates.io/crates/nakadion>                 |
 | nakadi-client   | Haskell            | <http://nakadi-client.haskell.silverratio.net>      |


### PR DESCRIPTION
# Summary

This PR removes both the Nakadi Klients and Reactive Nakadi clients as suggested clients for Nakadi, reasons being

1. Both clients are unmaintained. The last commit for Reactive Nakadi is over a year ago and Nakadi Klients is deprecated
2. Nakadi Klients is already marked as deprecated
3. Both clients implement the low level Nakadi API (which is also deprecated) and there is no hint that either of the clients have plans to upgrade to the high level API
