### PR TITLE
Use https instead of plain http in nakadi-client URL

### DIFF
--- a/docs/_documentation/using_clients.md
+++ b/docs/_documentation/using_clients.md
@@ -12,7 +12,7 @@ Nakadi does not ship with a client, but there are some open source clients avail
 | Nakadi Java     | Java               | <https://github.com/dehora/nakadi-java>             |
 | Fahrschein      | Java               | <https://github.com/zalando-nakadi/fahrschein>      |
 | Nakadion        | Rust               | <https://crates.io/crates/nakadion>                 |
-| nakadi-client   | Haskell            | <http://nakadi-client.haskell.silverratio.net>      |
+| nakadi-client   | Haskell            | <https://nakadi-client.haskell.silverratio.net>     |
 | go-nakadi       | Go                 | <https://github.com/stoewer/go-nakadi>              |
 | nakacli         | CLI                | <https://github.com/amrhassan/nakacli>              |
 


### PR DESCRIPTION
# One-line summary

Documentation change: the homepage of the nakadi-client package for Haskell is now reachable via HTTPS. Previously it was only reachable via plain HTTP.

## Description

Changed URL: http → https.

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes

n/a
