### PR TITLE
ARUHA-1641 Refresh zk subscriptions on timeout

### DIFF
--- a/src/main/java/org/zalando/nakadi/service/subscription/zk/NewZkSubscriptionClient.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/zk/NewZkSubscriptionClient.java
@@ -60,15 +60,12 @@ import static com.google.common.base.Charsets.UTF_8;
  */
 public class NewZkSubscriptionClient extends AbstractZkSubscriptionClient {
 
-    private final ObjectMapper objectMapper;
-
     public NewZkSubscriptionClient(
             final String subscriptionId,
             final CuratorFramework curatorFramework,
             final String loggingPath,
             final ObjectMapper objectMapper) {
-        super(subscriptionId, curatorFramework, loggingPath);
-        this.objectMapper = objectMapper;
+        super(subscriptionId, curatorFramework, objectMapper, loggingPath);
     }
 
     @Override
@@ -116,25 +113,6 @@ public class NewZkSubscriptionClient extends AbstractZkSubscriptionClient {
         } catch (final Exception ex) {
             throw new NakadiRuntimeException(ex);
         }
-    }
-
-    private Topology parseTopology(final byte[] data) {
-        try {
-            return objectMapper.readValue(data, Topology.class);
-        } catch (IOException e) {
-            throw new NakadiRuntimeException(e);
-        }
-    }
-
-    @Override
-    public final ZkSubscription<Topology> subscribeForTopologyChanges(final Runnable onTopologyChanged)
-            throws NakadiRuntimeException {
-        getLog().info("subscribeForTopologyChanges");
-        return new ZkSubscriptionImpl.ZkSubscriptionValueImpl<>(
-                getCurator(),
-                onTopologyChanged,
-                this::parseTopology,
-                getSubscriptionPath(NODE_TOPOLOGY));
     }
 
     protected byte[] serializeSession(final Session session)

--- a/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClient.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClient.java
@@ -178,6 +178,13 @@ public interface ZkSubscriptionClient {
     void resetCursors(List<SubscriptionCursorWithoutToken> cursors, long timeout)
             throws OperationTimeoutException, ZookeeperException;
 
+    /**
+     * Asks all the listeners that were created to check if they are up to date.
+     * If it passed more than {@code staleMillis} millis since last listener call, it will be recreated.
+     * @param staleMillis listener is considered to be stale if it was not triggered for this time.
+     */
+    void refreshListeners(long staleMillis);
+
     class Topology {
         @JsonProperty("partitions")
         private final Partition[] partitions;

--- a/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionImpl.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionImpl.java
@@ -8,14 +8,19 @@ import org.apache.zookeeper.Watcher;
 import org.zalando.nakadi.exceptions.NakadiRuntimeException;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
-public abstract class ZkSubscriptionImpl<ReturnType, ZkType> implements ZkSubscription<ReturnType>, Watcher {
+public abstract class ZkSubscriptionImpl<ReturnType, ZkType> implements ZkSubscription<ReturnType> {
     protected final CuratorFramework curatorFramework;
     protected final String key;
+    private final Consumer<ZkSubscriptionImpl<?, ?>> remover;
     private volatile Runnable listener;
     private volatile ExceptionOrData<ReturnType> data;
+    private volatile long lastUpdate = 0L;
     private final Function<ZkType, ReturnType> converter;
+    private final AtomicInteger activeWatcherIdx = new AtomicInteger(0);
 
     private static class ExceptionOrData<T> {
         private final NakadiRuntimeException ex;
@@ -43,11 +48,13 @@ public abstract class ZkSubscriptionImpl<ReturnType, ZkType> implements ZkSubscr
             final CuratorFramework curatorFramework,
             final Runnable listener,
             final Function<ZkType, ReturnType> converter,
-            final String key) {
+            final String key,
+            final Consumer<ZkSubscriptionImpl<?, ?>> remover) {
         this.listener = listener;
         this.curatorFramework = curatorFramework;
         this.key = key;
         this.converter = converter;
+        this.remover = remover;
         this.data = null;
     }
 
@@ -68,16 +75,53 @@ public abstract class ZkSubscriptionImpl<ReturnType, ZkType> implements ZkSubscr
     @Override
     public void close() {
         listener = null;
+        this.remover.accept(this);
+    }
+
+    public void refresh(final long maxDelay) {
+        final Runnable listener = this.listener;
+        if (null == listener) {
+            return;
+        }
+        final long now = System.currentTimeMillis();
+        if (lastUpdate == 0 || now - lastUpdate > maxDelay) {
+            data = null;
+            lastUpdate = now;
+            listener.run();
+        }
     }
 
     protected abstract ZkType query(boolean createListener) throws NakadiRuntimeException;
 
-    @Override
-    public void process(final WatchedEvent event) {
+    protected Watcher createWatcher() {
+        return new WatcherImpl<>(this, activeWatcherIdx.incrementAndGet());
+    }
+
+    private static class WatcherImpl<T, V> implements Watcher {
+        private final ZkSubscriptionImpl<T, V> subscr;
+        private final int idx;
+
+        private WatcherImpl(final ZkSubscriptionImpl<T, V> subscr, final int idx) {
+            this.subscr = subscr;
+            this.idx = idx;
+        }
+
+        @Override
+        public void process(final WatchedEvent event) {
+            subscr.process(this.idx, event);
+        }
+    }
+
+    public void process(final int orderIdx, final WatchedEvent event) {
         // on this call one actually notifies that data has changed and waits for refresh call.
         // The reason for that is that sometimes it is not possible to query data from zk while being called from
         // notification callback.
+        if (orderIdx < this.activeWatcherIdx.get()) {
+            // Ignore notifications from old watchers.
+            return;
+        }
         data = null;
+        lastUpdate = System.currentTimeMillis();
         final Runnable toNotify = listener;
         // In case if subscription is still active - notify
         if (null != toNotify) {
@@ -91,8 +135,9 @@ public abstract class ZkSubscriptionImpl<ReturnType, ZkType> implements ZkSubscr
                 final CuratorFramework curatorFramework,
                 final Runnable listener,
                 final Function<byte[], R> converter,
-                final String key) throws NakadiRuntimeException {
-            super(curatorFramework, listener, converter, key);
+                final String key,
+                final Consumer<ZkSubscriptionImpl<?, ?>> remover) throws NakadiRuntimeException {
+            super(curatorFramework, listener, converter, key, remover);
             // The very first call is used to initialize listener
             getData();
         }
@@ -101,7 +146,7 @@ public abstract class ZkSubscriptionImpl<ReturnType, ZkType> implements ZkSubscr
         protected byte[] query(final boolean setListener) throws NakadiRuntimeException {
             final GetDataBuilder builder = curatorFramework.getData();
             if (setListener) {
-                builder.usingWatcher(this);
+                builder.usingWatcher(createWatcher());
             }
             try {
                 return builder.forPath(key);
@@ -116,8 +161,9 @@ public abstract class ZkSubscriptionImpl<ReturnType, ZkType> implements ZkSubscr
         public ZkSubscriptionChildrenImpl(
                 final CuratorFramework curatorFramework,
                 final Runnable listener,
-                final String key) throws NakadiRuntimeException {
-            super(curatorFramework, listener, Function.identity(), key);
+                final String key,
+                final Consumer<ZkSubscriptionImpl<?, ?>> remover) throws NakadiRuntimeException {
+            super(curatorFramework, listener, Function.identity(), key, remover);
             getData();
         }
 
@@ -125,7 +171,7 @@ public abstract class ZkSubscriptionImpl<ReturnType, ZkType> implements ZkSubscr
         protected List<String> query(final boolean setListener) throws NakadiRuntimeException {
             final GetChildrenBuilder builder = curatorFramework.getChildren();
             if (setListener) {
-                builder.usingWatcher(this);
+                builder.usingWatcher(createWatcher());
             }
             try {
                 return builder.forPath(key);


### PR DESCRIPTION
ARUHA-1641
Every now and then while streaming nakadi looses information about latest committed cursors. In order to avoid this situation nakadi will try to refresh information about currently committed offsets. 