### PR TITLE
Added Riptide Stream to list of clients

### DIFF
--- a/docs/_documentation/using_clients.md
+++ b/docs/_documentation/using_clients.md
@@ -7,14 +7,15 @@ position: 10
 
 Nakadi does not ship with a client, but there are some open source clients available that you can try:
 
-| Name            | Language/Framework |  GitHub                                             |
-|-----------------|--------------------|-----------------------------------------------------|
-| Nakadi Java     | Java               | <https://github.com/dehora/nakadi-java>             |
-| Fahrschein      | Java               | <https://github.com/zalando-nakadi/fahrschein>      |
-| Nakadion        | Rust               | <https://crates.io/crates/nakadion>                 |
-| nakadi-client   | Haskell            | <https://nakadi-client.haskell.silverratio.net>     |
-| go-nakadi       | Go                 | <https://github.com/stoewer/go-nakadi>              |
-| nakacli         | CLI                | <https://github.com/amrhassan/nakacli>              |
+| Name            | Language/Framework |  GitHub                                                         |
+|-----------------|--------------------|-----------------------------------------------------------------|
+| Nakadi Java     | Java               | <https://github.com/dehora/nakadi-java>                         |
+| Fahrschein      | Java               | <https://github.com/zalando-nakadi/fahrschein>                  |
+| Riptide: Stream | Java/Spring        | <https://github.com/zalando/riptide/tree/master/riptide-stream> |
+| Nakadion        | Rust               | <https://crates.io/crates/nakadion>                             |
+| nakadi-client   | Haskell            | <https://nakadi-client.haskell.silverratio.net>                 |
+| go-nakadi       | Go                 | <https://github.com/stoewer/go-nakadi>                          |
+| nakacli         | CLI                | <https://github.com/amrhassan/nakacli>                          |
 
 
 More Nakadi related projects can be found here [https://github.com/zalando-nakadi](https://github.com/zalando-nakadi)


### PR DESCRIPTION
See zalando/riptide#352

# One-line summary

Added Riptide Stream to list of clients

## Description

Riptide Stream is a module that is part of the Riptide ecosystem/library. It has no direct dependency to Riptide and can just be used with a plain Spring RestTemplate. Therefore it's a compelling way for Spring applications that need to stream events from Nakadi. Riptide Stream does not offer anything Nakadi specific. Any calls to create subscriptions and commit cursors need to done manually, but that's usually no big issue since those are just simple HTTP calls (in comparison to reading the HTTP event stream).

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
