### PR TITLE
Subscription authorization

### DIFF
--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -1019,6 +1019,29 @@ paths:
       responses:
         '204':
           description: Subscription was deleted
+        '403':
+          description: Access forbidden
+          schema:
+            $ref: '#/definitions/Problem'
+        '404':
+          description: Subscription not found
+          schema:
+            $ref: '#/definitions/Problem'
+    put:
+      tags:
+        - subscription-api
+      security:
+        - oauth2: ['nakadi.event_stream.read']
+      description: Updates a subscription.
+      parameters:
+        - $ref: '#/parameters/SubscriptionId'
+      responses:
+        '204':
+          description: Subscription was updated
+        '403':
+          description: Access forbidden
+          schema:
+            $ref: '#/definitions/Problem'
         '404':
           description: Subscription not found
           schema:
@@ -1158,6 +1181,10 @@ paths:
       responses:
         '204':
           description: Offsets were reset
+        '403':
+          description: Access forbidden
+          schema:
+            $ref: '#/definitions/Problem'
         '404':
           description: Subscription not found
           schema:

--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -1032,9 +1032,21 @@ paths:
         - subscription-api
       security:
         - oauth2: ['nakadi.event_stream.read']
-      description: Updates a subscription.
+      description: |
+        This endpoint only allows to update the authorization section of a subscription. All other properties are
+        immutable. This operation is restricted to subjects with administrative role.
       parameters:
-        - $ref: '#/parameters/SubscriptionId'
+        - name: subscription
+          in: body
+          description: Subscription with modified authorization section.
+          schema:
+            $ref: '#/definitions/Subscription'
+          required: true
+        - name: subscription_id
+          in: path
+          type: string
+          description: Id of subscription
+          required: true
       responses:
         '204':
           description: Subscription was updated

--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -1109,6 +1109,10 @@ paths:
                   $ref: '#/definitions/CursorCommitResult'
             required:
               - items
+        '403':
+          description: Access forbidden
+          schema:
+            $ref: '#/definitions/Problem'
         '404':
           description: Subscription not found
           schema:
@@ -1212,6 +1216,10 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/Problem'
+        '403':
+          description: Access forbidden
+          schema:
+            $ref: '#/definitions/Problem'
         '404':
           description: Subscription not found.
           schema:
@@ -1224,10 +1232,6 @@ paths:
             already equals the maximum value - the total number of partitions in this subscription.
 
             - Request to reset subscription cursors is still in progress.
-          schema:
-            $ref: '#/definitions/Problem'
-        '403':
-          description: Access is forbidden for the client or event type
           schema:
             $ref: '#/definitions/Problem'
 
@@ -1355,6 +1359,10 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/Problem'
+        '403':
+          description: Access forbidden
+          schema:
+            $ref: '#/definitions/Problem'
         '404':
           description: Subscription not found.
           schema:
@@ -1369,10 +1377,6 @@ paths:
             - Request to reset subscription cursors is still in progress.
 
             - It is requested to read from a partition that is already assigned to another stream by direct request.
-          schema:
-            $ref: '#/definitions/Problem'
-        '403':
-          description: Access is forbidden for the client or event type
           schema:
             $ref: '#/definitions/Problem'
         '422':
@@ -2344,9 +2348,40 @@ definitions:
           status.
         items:
           $ref: '#/definitions/SubscriptionEventTypeStatus'
+      authorization:
+          $ref: '#/definitions/SubscriptionAuthorization'
     required:
       - owning_application
       - event_types
+
+  SubscriptionAuthorization:
+      type: object
+      description: |
+        Authorization section of a Subscription. This section defines two access control lists: one for consuming
+        events and committing cursors ('readers'), and one for administering a subscription ('admins').
+        Regardless of the values of the authorization properties, administrator accounts will always be authorized.
+      properties:
+        admins:
+          type: array
+          description: |
+            An array of subject attributes that are required for updating the subscription. Any one of the attributes
+            defined in this array is sufficient to be authorized. The wildcard item takes precedence over all others,
+            i.e. if it is present, all users are authorized.
+          items:
+            $ref: '#/definitions/AuthorizationAttribute'
+          minItems: 1
+        readers:
+          type: array
+          description: |
+            An array of subject attributes that are required for reading events and committing cursors to this
+            subscription. Any one of the attributes defined in this array is sufficient to be authorized. The wildcard
+            item takes precedence over all others, i.e., if it is present, all users are authorized.
+          items:
+            $ref: '#/definitions/AuthorizationAttribute'
+          minItems: 1
+      required:
+        - admins
+        - readers
 
   EventType:
     description: An event type defines the schema and its runtime properties.


### PR DESCRIPTION
https://techjira.zalando.net/browse/ARUHA-1681

Since the introduction of Event Type Authorization, it was planned that
Subscriptions would also be authorized. Even though data is already
protected through Event Type Authorization, users can still accidentally
commit offsets to subscriptions owned by other users, eventually causing
applications to not process all the data. Subscriptions could also be
accidentally deleted or have its slots assigned to some other
application impeding applications from consuming data.

With this feature we address all of the problems above. This is just the
API definition.