### PR TITLE
Reduce logging by removing content duplication

### DIFF
--- a/src/main/java/org/zalando/nakadi/controller/EventPublishingController.java
+++ b/src/main/java/org/zalando/nakadi/controller/EventPublishingController.java
@@ -129,9 +129,6 @@ public class EventPublishingController {
             final long msSpent = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startingNanos);
             final String applicationName = client.getClientId();
 
-            LOG.info("[SLO] [publishing-latency] time={} size={} count={} eventTypeName={} app={}", msSpent,
-                    totalSizeBytes, eventCount, eventTypeName, applicationName);
-
             nakadiKpiPublisher.publish(kpiBatchPublishedEventType, () -> new JSONObject()
                     .put("event_type", eventTypeName)
                     .put("app", applicationName)

--- a/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
+++ b/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
@@ -53,8 +53,9 @@ public class LoggingFilter extends OncePerRequestFilter {
                     .orElse("-");
             final String acceptEncoding = Optional.ofNullable(request.getHeader(HttpHeaders.ACCEPT_ENCODING))
                     .orElse("-");
+            final Long contentLength = request.getContentLengthLong();
 
-            LOG.info("[ACCESS_LOG] {} \"{}{}\" \"{}\" \"{}\" statusCode: {} {} ms \"{}\" \"{}\"",
+            LOG.info("[ACCESS_LOG] {} \"{}{}\" \"{}\" \"{}\" statusCode: {} {} ms \"{}\" \"{}\" {} bytes",
                     method,
                     path,
                     query,
@@ -63,7 +64,8 @@ public class LoggingFilter extends OncePerRequestFilter {
                     response.getStatus(),
                     timing,
                     contentEncoding,
-                    acceptEncoding);
+                    acceptEncoding,
+                    contentLength);
             nakadiKpiPublisher.publish(accessLogEventType, () -> new JSONObject()
                     .put("method", method)
                     .put("path", path)

--- a/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
+++ b/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
@@ -53,7 +53,7 @@ public class LoggingFilter extends OncePerRequestFilter {
                     .orElse("-");
             final String acceptEncoding = Optional.ofNullable(request.getHeader(HttpHeaders.ACCEPT_ENCODING))
                     .orElse("-");
-            final Long contentLength = request.getContentLengthLong();
+            final Long contentLength = request.getContentLengthLong() == -1 ? 0 : request.getContentLengthLong();
 
             LOG.info("[ACCESS_LOG] {} \"{}{}\" \"{}\" \"{}\" statusCode: {} {} ms \"{}\" \"{}\" {} bytes",
                     method,


### PR DESCRIPTION
https://techjira.zalando.net/browse/ARUHA-1698

On each request to publish an event to Nakadi, 2 lines of logs are
generated: 1 for ACCESS_LOG and 1 for SLO log.

SLO log is used by scalyr to report SLOs. It contains basically the same
information but with the addition of the request size.

This change adds the body size to ACCESS_LOG and removes SLO for
publishing requests. This will result in an overall reduction of 30% of log lines,
which is the amount of logging we were requested to reduce in order to
avoid overspending on logs.