### PR TITLE
Updated publishing example in ReadMe.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,9 +223,9 @@ Events for an event type can be published by posting to its "events" collection:
 curl -v -XPOST http://localhost:8080/event-types/order.ORDER_RECEIVED/events \
  -H "Content-type: application/json" \
  -d '[{
-    "order_number": "24873243241",    
+    "order_number": "24873243241"
   }, {
-    "order_number": "24873243242",    
+    "order_number": "24873243242"
   }]'
 
 


### PR DESCRIPTION
Example of publishing an event in ReadMe.md contains [invalid JSON with trailing commas](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#Trailing_commas_in_JSON). Posting it to API causes a parsing exception.
```
nakadi_1     | [2018-06-14 01:54:09.712Z] [DEBUG] [3uL1wsYUrpu8rUSwobeQ40hl] [qtp1912187243-21] [org.zalando.nakadi.controller.EventPublishingController] --- Problem parsing event
nakadi_1     | org.json.JSONException: Not allowed to finish object with comma at pos 44
nakadi_1     | 	at org.zalando.nakadi.domain.StrictJsonParser.syntaxError(StrictJsonParser.java:235)
nakadi_1     | 	at org.zalando.nakadi.domain.StrictJsonParser.readObjectTillTheEnd(StrictJsonParser.java:180)
nakadi_1     | 	at org.zalando.nakadi.domain.StrictJsonParser.parse(StrictJsonParser.java:105)
```

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
No code changes.
