### PR TITLE
Set `network_mode` to bridge in docker-compose to support OSX.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,10 @@ services:
       - NAKADI_FEATURES_DEFAULT_FEATURES_KPI_COLLECTION
       - NAKADI_FEATURES_DEFAULT_FEATURES_DISABLE_DB_WRITE_OPERATIONS
       - NAKADI_FEATURES_DEFAULT_FEATURES_DISABLE_LOG_COMPACTION
-      - NAKADI_ZOOKEEPER_BROKERS=localhost:2181
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/local_nakadi_db
+      - NAKADI_ZOOKEEPER_BROKERS=zookeeper:2181
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/local_nakadi_db
       - SPRING_DATASOURCE_USERNAME=nakadi
       - SPRING_DATASOURCE_PASSWORD=nakadi
-    network_mode: "host"
 
   postgres:
     image: postgres:9.5
@@ -36,27 +35,31 @@ services:
       POSTGRES_USER: nakadi
       POSTGRES_PASSWORD: nakadi
       POSTGRES_DB: local_nakadi_db
-    network_mode: "host"
 
   zookeeper:
     image: wurstmeister/zookeeper:3.4.6
-    network_mode: "host"
     ports:
       - "2181:2181"
 
   kafka:
     image: wurstmeister/kafka:2.11-1.1.1
-    network_mode: "host"
     ports:
       - "9092:9092"
     depends_on:
       - zookeeper
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: localhost
+      KAFKA_ADVERTISED_HOST_NAME: kafka
       KAFKA_ADVERTISED_PORT: 9092
-      KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
       KAFKA_BROKER_ID: 0
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+# https://docs.docker.com/compose/networking/#configure-the-default-network
+# Note: `networks` section here is not required and only added to make config explicit.
+# Uses docker's default "bridge" network mode, and puts all services in the same network.
+networks:
+  default:
+    driver: bridge

--- a/docs/_documentation/getting-started.md
+++ b/docs/_documentation/getting-started.md
@@ -56,7 +56,13 @@ by other applications.
 <a name="macos"></a>
 ### Mac OS Docker Settings
 
-Since Docker for Mac OS runs inside Virtual Box, you will  want to expose
+Nakadi is tested to work with [Docker for Mac](https://docs.docker.com/docker-for-mac/)
+v18.03.1-ce-mac65 on OSX 10.12.6 without additional configuration.
+
+Nakadi can also run in Docker Toolbox for Mac. Check out differences between
+Docker and Docker Toolbox [here](https://docs.docker.com/docker-for-mac/docker-toolbox/).
+
+Since Docker Toolbox runs inside VirtualBox, you will want to expose
 some ports first to allow Nakadi to access its dependencies:
 
 ```sh
@@ -68,7 +74,7 @@ docker-machine ssh default \
 ```
 
 Alternatively you can set up port forwarding on the "default" machine through
-its network settings in the VirtualBox UI. 
+its network settings in the VirtualBox UI.
 
 ![vbox](./img/vbox.png)
 
@@ -79,6 +85,4 @@ running, you might want to run this command:
 ```sh
 eval "$(docker-machine env default)"
 ```
-
-**Note:** Docker for Mac OS (previously in beta) version 1.12 (1.12.0 or 1.12.1) currently is not supported due to the [bug](https://github.com/docker/docker/issues/22753#issuecomment-242711639) in networking host configuration.
 

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/StorageControllerAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/StorageControllerAT.java
@@ -12,10 +12,13 @@ public class StorageControllerAT extends BaseAT {
 
     @Test
     public void shouldChangeDefaultStorageWhenRequested() throws Exception {
+        final String defaultConfig = given()
+                .accept(JSON)
+                .get("/storages/default")
+                .print();
+
         given()
-                .body("{\"id\": \"default-test\",\"kafka_configuration\": {\"exhibitor_address\": null," +
-                        "\"exhibitor_port\": 0,\"zk_address\": \"127.0.0.1:2181\",\"zk_path\": \"\"}," +
-                        "\"storage_type\": \"kafka\"}")
+                .body(defaultConfig.replace("default", "default-test"))
                 .contentType(JSON).post("/storages");
 
         NakadiTestUtils.createEventTypeInNakadi(EventTypeTestBuilder.builder().name("event_a").build());


### PR DESCRIPTION
Changing network mode in `docker-compose.yml` from `host` to `bridge`
allows running it on Mac. This also requires services to refer to
dependencies by their names (e.g. `zookeeper` instead of 'localhost').
Documentation has been updated to reflect the fact, that it is possible
to run Nakadi in Docker on OSX.

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
Updated `docker-compose.yml` for local development and documentation. No code changes.