### PR TITLE
Increase max request size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- max.request.size was increased to slightly more than 2MB.
+
 ## [2.7.4] - 2018-06-13
 
 ### Changed

--- a/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -56,6 +56,7 @@ public class KafkaRepositoryAT extends BaseAT {
     private static final long TIMELINE_WAIT_TIMEOUT = 40000;
     private static final int NAKADI_SUBSCRIPTION_MAX_PARTITIONS = 8;
     private static final boolean KAFKA_ENABLE_AUTO_COMMIT = false;
+    private static final int KAFKA_MAX_REQUEST_SIZE = 2098152;
     private static final String DEFAULT_ADMIN_DATA_TYPE = "service";
     private static final String DEFAULT_ADMIN_VALUE = "nakadi";
     private static final String DEFAULT_WARN_ALL_DATA_ACCESS_MESSAGE = "";
@@ -84,7 +85,7 @@ public class KafkaRepositoryAT extends BaseAT {
                 DEFAULT_ADMIN_VALUE,
                 DEFAULT_WARN_ALL_DATA_ACCESS_MESSAGE);
         kafkaSettings = new KafkaSettings(KAFKA_REQUEST_TIMEOUT, KAFKA_BATCH_SIZE,
-                KAFKA_LINGER_MS, KAFKA_ENABLE_AUTO_COMMIT);
+                KAFKA_LINGER_MS, KAFKA_ENABLE_AUTO_COMMIT, KAFKA_MAX_REQUEST_SIZE);
         zookeeperSettings = new ZookeeperSettings(ZK_SESSION_TIMEOUT, ZK_CONNECTION_TIMEOUT);
         kafkaHelper = new KafkaTestHelper(KAFKA_URL);
         kafkaTopicRepository = createKafkaTopicRepository();

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -115,6 +115,7 @@ public class KafkaLocationManager {
         producerProps.put(ProducerConfig.BATCH_SIZE_CONFIG, kafkaSettings.getBatchSize());
         producerProps.put(ProducerConfig.LINGER_MS_CONFIG, kafkaSettings.getLingerMs());
         producerProps.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "lz4");
+        producerProps.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, kafkaSettings.getMaxRequestSize());
         return producerProps;
     }
 }

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSettings.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSettings.java
@@ -18,15 +18,19 @@ public class KafkaSettings {
     private final long lingerMs;
     private final boolean enableAutoCommit;
 
+    private final int maxRequestSize;
+
     @Autowired
     public KafkaSettings(@Value("${nakadi.kafka.request.timeout.ms}") final int requestTimeoutMs,
                          @Value("${nakadi.kafka.batch.size}") final int batchSize,
                          @Value("${nakadi.kafka.linger.ms}") final long lingerMs,
-                         @Value("${nakadi.kafka.enable.auto.commit}") final boolean enableAutoCommit) {
+                         @Value("${nakadi.kafka.enable.auto.commit}") final boolean enableAutoCommit,
+                         @Value("${nakadi.kafka.max.request.size}") final int maxRequestSize) {
         this.requestTimeoutMs = requestTimeoutMs;
         this.batchSize = batchSize;
         this.lingerMs = lingerMs;
         this.enableAutoCommit = enableAutoCommit;
+        this.maxRequestSize = maxRequestSize;
     }
 
     public int getRequestTimeoutMs() {
@@ -43,5 +47,9 @@ public class KafkaSettings {
 
     public boolean getEnableAutoCommit() {
         return enableAutoCommit;
+    }
+
+    public int getMaxRequestSize() {
+        return maxRequestSize;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,6 +59,7 @@ nakadi:
     poll.timeoutMs: 100
     send.timeoutMs: 5000
     batch.size: 5242880
+    max.request.size: 2098152
     linger.ms: 0
     enable.auto.commit: false
   zookeeper:


### PR DESCRIPTION
https://techjira.zalando.net/browse/ARUHA-1739

In order to send larger messages we need to also allow for bigger
requests. This is not only the case for bigger messages but also if we
want to send larger batches to kafka, which in some cases can increase
throughput.
