### PR TITLE
ARUHA-1693: Added functionality to delete subscriptions together with event-type (if feature is toggled);

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Added feature toggle to make it possible to remove event-types together with subscriptions
+
 ## [2.7.6] - 2018-06-20
 
 ### Added

--- a/src/main/java/org/zalando/nakadi/service/FeatureToggleService.java
+++ b/src/main/java/org/zalando/nakadi/service/FeatureToggleService.java
@@ -31,6 +31,7 @@ public interface FeatureToggleService {
         CONNECTION_CLOSE_CRUTCH("close_crutch"),
         DISABLE_EVENT_TYPE_CREATION("disable_event_type_creation"),
         DISABLE_EVENT_TYPE_DELETION("disable_event_type_deletion"),
+        DELETE_EVENT_TYPE_WITH_SUBSCRIPTIONS("delete_event_type_with_subscriptions"),
         DISABLE_SUBSCRIPTION_CREATION("disable_subscription_creation"),
         HIGH_LEVEL_API("high_level_api"),
         CHECK_PARTITIONS_KEYS("check_partitions_keys"),

--- a/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
+++ b/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
@@ -129,6 +129,7 @@ public class EventTypeServiceTest {
                 .thenReturn(true);
 
         eventTypeService.delete(eventType.getName());
+        // no exception should be thrown
     }
 
     @Test


### PR DESCRIPTION
# Added functionality to delete subscriptions together with event-type (if feature is toggled)

> Zalando ticket : ARUHA-1693

## Description
On test environments we may allow users to delete event-types together with subscriptions

## Review
- [ ] Tests
- [ ] Documentation
- [x] CHANGELOG

## Deployment Notes
We should toggle this feature to make it work
