### PR TITLE
ARUHA-1798 Upgrade kafka client to  1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Log Compaction Feature Toggle
 
 ### Changed
-- Upgraded Kafka client to 1.1.0
+- Upgraded Kafka client to 1.1.1
 
 ## [2.8.0]
 

--- a/build.gradle
+++ b/build.gradle
@@ -137,8 +137,8 @@ dependencies {
     compile 'org.echocat.jomon:runtime:1.6.3'
 
     // kafka & zookeeper
-    compile 'org.apache.kafka:kafka-clients:1.1.0'
-    compile('org.apache.kafka:kafka_2.12:1.1.0') {
+    compile 'org.apache.kafka:kafka-clients:1.1.1'
+    compile('org.apache.kafka:kafka_2.12:1.1.1') {
         exclude module: "zookeeper"
     }
     compile("org.apache.curator:curator-recipes:$curatorVersion") {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:1.1.1
+    image: wurstmeister/kafka:1.1.0
     network_mode: "host"
     ports:
       - "9092:9092"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:1.1.0
+    image: wurstmeister/kafka:1.1.1
     network_mode: "host"
     ports:
       - "9092:9092"


### PR DESCRIPTION
# Upgrade Kafka client to 1.1.1

> Zalando ticket : ARUHA-1798

## Description
New version of Kafka client

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
This version of Kafka client should be compatible with all versions of Kafka clusters from 0.10.1.0 up.