### PR TITLE
Don't allow schema root object type to be array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Removed partition key fields check
 
-### Removed
-- Removed the ability to specify schema root object type to be of type array.
+### Fixed
+- Fixed and added check for schema root object type to be only of type object.
 
 ## [2.8.2] - 2018-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Removed partition key fields check
 
+### Removed
+- Removed the ability to specify schema root object type to be of type array.
+
 ## [2.8.2] - 2018-07-31
 
 ### Removed

--- a/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -501,6 +501,11 @@ public class EventTypeService {
             final JSONObject schemaAsJson = new JSONObject(eventTypeSchema);
             final Schema schema = SchemaLoader.load(schemaAsJson);
 
+            if (schemaAsJson.has("type") && schemaAsJson.getString("type").equals("array")
+                    && eventType.getCategory() != EventCategory.UNDEFINED) {
+                throw new InvalidEventTypeException("\"type\" of root element in schema cannot be \"array\"");
+            }
+
             if (eventType.getCategory() == EventCategory.BUSINESS && schema.definesProperty("#/metadata")) {
                 throw new InvalidEventTypeException("\"metadata\" property is reserved");
             }

--- a/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -501,9 +501,8 @@ public class EventTypeService {
             final JSONObject schemaAsJson = new JSONObject(eventTypeSchema);
             final Schema schema = SchemaLoader.load(schemaAsJson);
 
-            if (schemaAsJson.has("type") && schemaAsJson.getString("type").equals("array")
-                    && eventType.getCategory() != EventCategory.UNDEFINED) {
-                throw new InvalidEventTypeException("\"type\" of root element in schema cannot be \"array\"");
+            if (schemaAsJson.has("type") && !schemaAsJson.getString("type").equals("object")) {
+                throw new InvalidEventTypeException("\"type\" of root element in schema can only be \"object\"");
             }
 
             if (eventType.getCategory() == EventCategory.BUSINESS && schema.definesProperty("#/metadata")) {

--- a/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -499,12 +499,12 @@ public class EventTypeService {
             JsonUtils.checkEventTypeSchemaValid(eventTypeSchema);
 
             final JSONObject schemaAsJson = new JSONObject(eventTypeSchema);
-            final Schema schema = SchemaLoader.load(schemaAsJson);
 
-            if (schemaAsJson.has("type") && !schemaAsJson.getString("type").equals("object")) {
+            if (schemaAsJson.has("type") && !Objects.equals("object", schemaAsJson.getString("type"))) {
                 throw new InvalidEventTypeException("\"type\" of root element in schema can only be \"object\"");
             }
 
+            final Schema schema = SchemaLoader.load(schemaAsJson);
             if (eventType.getCategory() == EventCategory.BUSINESS && schema.definesProperty("#/metadata")) {
                 throw new InvalidEventTypeException("\"metadata\" property is reserved");
             }

--- a/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
@@ -175,6 +175,17 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
     }
 
     @Test
+    public void whenPostWithRootElementOfTypeArrayThenReturn422() throws Exception {
+        final Problem expectedProblem = createInvalidEventTypeExceptionProblem("\"type\" of root element in"
+                + " schema cannot be \"array\"");
+
+        final String eventType = "{\"category\": \"data\", \"owning_application\": \"blah-app\", \n" +
+                "  \"name\": \"blah-event-type\",\n" +
+                "  \"schema\": {\"type\": \"json_schema\", \"schema\": \"{\\\"type\\\":\\\"array\\\" }\"}}";
+        postETAndExpect422WithProblem(eventType, expectedProblem);
+    }
+
+    @Test
     public void whenPOSTWithInvalidPartitionStrategyThen422() throws Exception {
         final EventType eventType = buildDefaultEventType();
 

--- a/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
@@ -177,7 +177,7 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
     @Test
     public void whenPostWithRootElementOfTypeArrayThenReturn422() throws Exception {
         final Problem expectedProblem = createInvalidEventTypeExceptionProblem("\"type\" of root element in"
-                + " schema cannot be \"array\"");
+                + " schema can only be \"object\"");
 
         final String eventType = "{\"category\": \"data\", \"owning_application\": \"blah-app\", \n" +
                 "  \"name\": \"blah-event-type\",\n" +


### PR DESCRIPTION
Don't allow the root object type in schema for business and data category to be of type array

> Zalando ticket : ARUHA-1715 

## Description
Presently, it is allowed to specify the type of root object in schema to be of type `array`. That is now restricted.

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG
