### PR TITLE
Fix ISE when parsing number larger than max long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fixed and added check for schema root object type to be only of type object.
 
+### Fixed
+- Fixed ISE when parsing number larger than max long
+
 ## [2.8.2] - 2018-07-31
 
 ### Removed

--- a/src/main/java/org/zalando/nakadi/domain/StrictJsonParser.java
+++ b/src/main/java/org/zalando/nakadi/domain/StrictJsonParser.java
@@ -157,13 +157,13 @@ public class StrictJsonParser {
                 throw syntaxError(stringNumber + " can not be used", tokenizer);
             }
         } else {
-            final long longValue = Long.parseLong(stringNumber);
-            if (stringNumber.equals(String.valueOf(longValue))) {
+            try {
+                final long longValue = Long.parseLong(stringNumber);
                 if (longValue <= Integer.MAX_VALUE && longValue >= Integer.MIN_VALUE) {
                     return (int) longValue;
                 }
                 return longValue;
-            } else {
+            } catch (NumberFormatException e) {
                 throw syntaxError("Can not use long value '" + stringNumber + "' cause it is too big", tokenizer);
             }
         }

--- a/src/test/java/org/zalando/nakadi/domain/BatchFactoryTest.java
+++ b/src/test/java/org/zalando/nakadi/domain/BatchFactoryTest.java
@@ -133,12 +133,9 @@ public class BatchFactoryTest {
         } catch (JSONException e) {}
     }
 
-    @Test
+    @Test(expected = JSONException.class)
     public void testNumberLargerThanMaxLongInEvents() {
         final String events = "[{\"number\": 9223372036854775808 }]";
-        try {
-            BatchFactory.from(events);
-            fail();
-        } catch (JSONException e) {}
+        BatchFactory.from(events);
     }
 }

--- a/src/test/java/org/zalando/nakadi/domain/BatchFactoryTest.java
+++ b/src/test/java/org/zalando/nakadi/domain/BatchFactoryTest.java
@@ -132,4 +132,13 @@ public class BatchFactoryTest {
             fail();
         } catch (JSONException e) {}
     }
+
+    @Test
+    public void testNumberLargerThanMaxLongInEvents() {
+        final String events = "[{\"number\": 9223372036854775808 }]";
+        try {
+            BatchFactory.from(events);
+            fail();
+        } catch (JSONException e) {}
+    }
 }


### PR DESCRIPTION
Nakadi replies with status code 500 when the number being parsed is greater than max long.

> Zalando ticket : ARUHA-1784

## Description
When a user publishes an event with a number greater than max long, the strict json parser fails, and nakadi replies with 500.
## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG