### PR TITLE
Remove partition key fields check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.8.3] - 2018-08-01
+
+### Fixed
+- Removed partition key fields check
+
 ## [2.8.2] - 2018-07-31
 
 ### Removed

--- a/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -505,7 +505,6 @@ public class EventTypeService {
                 throw new InvalidEventTypeException("\"metadata\" property is reserved");
             }
 
-            validatePartitionKeys(schema, eventType);
             validateOrderingKeys(schema, eventType);
 
             if (eventType.getCompatibilityMode() == CompatibilityMode.COMPATIBLE) {
@@ -525,16 +524,6 @@ public class EventTypeService {
             final String errorMessage = incompatibilities.stream().map(Object::toString)
                     .collect(Collectors.joining(", "));
             throw new InvalidEventTypeException("Invalid schema: " + errorMessage);
-        }
-    }
-
-    private void validatePartitionKeys(final Schema schema, final EventTypeBase eventType)
-            throws InvalidEventTypeException, JSONException, SchemaException {
-        final List<String> absentFields = eventType.getPartitionKeyFields().stream()
-                .filter(field -> !schema.definesProperty(convertToJSONPointer(field)))
-                .collect(Collectors.toList());
-        if (!absentFields.isEmpty()) {
-            throw new InvalidEventTypeException("partition_key_fields " + absentFields + " absent in schema");
         }
     }
 

--- a/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
@@ -188,19 +188,6 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
     }
 
     @Test
-    public void whenPUTWithInvalidPartitionStrategyThen422() throws Exception {
-
-        final EventType eventType = EventTypeTestBuilder.builder()
-                .partitionKeyFields(Lists.newArrayList("invalid_key")).build();
-
-        doReturn(eventType).when(eventTypeRepository).findByName(any());
-
-        putEventType(eventType, eventType.getName())
-                .andExpect(status().isUnprocessableEntity())
-                .andExpect(content().contentType("application/problem+json"));
-    }
-
-    @Test
     public void whenPUTwithPartitionStrategyChangeFromRandomToUserDefinedThenOK() throws Exception {
         final EventType eventType = EventTypeTestBuilder.builder()
                 .partitionStrategy(PartitionStrategy.RANDOM_STRATEGY)
@@ -569,44 +556,6 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
                 .andExpect(status().isConflict())
                 .andExpect(content().contentType("application/problem+json"))
                 .andExpect(content().string(matchesProblem(expectedProblem)));
-    }
-
-    @Test
-    public void whenCreateEventTypeWithWrongPartitionKeyFieldsThen422() throws Exception {
-
-        final EventType eventType = EventTypeTestBuilder.builder()
-                .partitionKeyFields(Collections.singletonList("blabla")).build();
-
-        doReturn(eventType).when(eventTypeRepository).findByName(eventType.getName());
-
-        postEventType(eventType).andExpect(status().isUnprocessableEntity())
-                .andExpect(content().contentType("application/problem+json"));
-    }
-
-    @Test
-    public void whenPUTEventTypeWithWrongPartitionKeyFieldsThen422() throws Exception {
-
-        final EventType eventType = EventTypeTestBuilder.builder()
-                .partitionKeyFields(Collections.singletonList("blabla")).build();
-
-        doReturn(eventType).when(eventTypeRepository).findByName(eventType.getName());
-
-        putEventType(eventType, eventType.getName()).andExpect(status().isUnprocessableEntity())
-                .andExpect(content().contentType("application/problem+json"));
-    }
-
-    @Test
-    public void whenPUTEventTypeWithWrongPartitionKeyToBusinessCategoryFieldsThen422() throws Exception {
-
-        final EventType eventType = EventTypeTestBuilder.builder()
-                .partitionKeyFields(Collections.singletonList("blabla"))
-                .category(BUSINESS)
-                .build();
-
-        doReturn(eventType).when(eventTypeRepository).findByName(eventType.getName());
-
-        putEventType(eventType, eventType.getName()).andExpect(status().isUnprocessableEntity())
-                .andExpect(content().contentType("application/problem+json"));
     }
 
     @Test


### PR DESCRIPTION
This feature was assumed to be enabled for a long time now. It happens
that it was never enabled, since it breaks existent use cases. More
specifically event log, which has not predefined schema.

Since this feature was never there and now it was accidentally enabled,
this is a hotfix to completely remove.
