### PR TITLE
API for timelines without creating a new topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Create timeline based on existing topic
+
 ## [2.8.3] - 2018-08-01
 
 ### Fixed

--- a/database/migration/aruha-1818-timeline-topic-uniq.sql
+++ b/database/migration/aruha-1818-timeline-topic-uniq.sql
@@ -1,0 +1,1 @@
+ALTER TABLE zn_data.timeline ADD UNIQUE (st_id, tl_topic);

--- a/database/nakadi/10_data/04_tables/05_timeline.sql
+++ b/database/nakadi/10_data/04_tables/05_timeline.sql
@@ -9,7 +9,8 @@ CREATE TABLE zn_data.timeline (
   tl_cleanup_at      TIMESTAMP WITH TIME ZONE DEFAULT NULL,
   tl_latest_position JSONB                    DEFAULT NULL,
   tl_deleted         BOOLEAN                  DEFAULT FALSE,
-  UNIQUE (et_name, tl_order)
+  UNIQUE (et_name, tl_order),
+  UNIQUE (st_id, tl_topic)
 );
 
 CREATE INDEX ON zn_data.timeline (et_name);

--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -1838,6 +1838,12 @@ paths:
             properties:
               storage_id:
                 type: string
+              topic:
+                type: string
+                description: |
+                  When provided, this field creates a timeline based on an existing topic in the given storage.
+
+                  Only administrator accounts are authorized to use this field.
             required:
               - storage_id
           required: true

--- a/src/acceptance-test/java/org/zalando/nakadi/repository/db/TimelineDbRepositoryTest.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/repository/db/TimelineDbRepositoryTest.java
@@ -118,12 +118,13 @@ public class TimelineDbRepositoryTest extends AbstractDbRepositoryTest {
 
     private Timeline insertTimeline(final int order) {
         return tRepository.createTimeline(createTimeline(
-                storage, UUID.randomUUID(), order, "test_topic", testEt.getName(),
+                storage, UUID.randomUUID(), order, UUID.randomUUID().toString(), testEt.getName(),
                 new Date(), null, null, null));
     }
 
     private Timeline insertTimeline(final Date cleanupDate, final boolean deleted, final int order) {
-        final Timeline timeline = createTimeline(storage, UUID.randomUUID(), order, "test_topic", testEt.getName(),
+        final Timeline timeline = createTimeline(storage, UUID.randomUUID(), order, UUID.randomUUID().toString(),
+                testEt.getName(),
                 new Date(), new Date(), cleanupDate, null);
         timeline.setDeleted(deleted);
         return tRepository.createTimeline(timeline);

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/TimelinesControllerAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/TimelinesControllerAT.java
@@ -1,59 +1,117 @@
 package org.zalando.nakadi.webservice;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.ImmutableList;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.http.ContentType;
 import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
+import org.json.JSONObject;
 import org.junit.Test;
+import org.zalando.nakadi.domain.CleanupPolicy;
+import org.zalando.nakadi.domain.EnrichmentStrategyDescriptor;
+import org.zalando.nakadi.domain.EventCategory;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeOptions;
 import org.zalando.nakadi.utils.EventTypeTestBuilder;
+import org.zalando.nakadi.view.TimelineView;
 import org.zalando.nakadi.webservice.utils.NakadiTestUtils;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 
+import static com.jayway.restassured.http.ContentType.JSON;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.equalTo;
 import static org.zalando.nakadi.util.DateWithinMatcher.dateWithin;
+import static org.zalando.nakadi.webservice.BaseAT.MAPPER;
 
-public class TimelinesControllerAT extends BaseAT {
+public class TimelinesControllerAT extends RealEnvironmentAT {
 
     private static final long RETENTION_TIME_MS = Duration.of(2, DAYS).toMillis();
 
-    private final EventType eventType;
-
-    public TimelinesControllerAT() throws JsonProcessingException {
+    @Test
+    public void testCreateNextTimeline() throws Exception {
         final EventTypeOptions eventTypeOptions = new EventTypeOptions();
         eventTypeOptions.setRetentionTime(RETENTION_TIME_MS);
 
-        eventType = EventTypeTestBuilder.builder()
+        final EventType eventType = EventTypeTestBuilder.builder()
                 .options(eventTypeOptions)
                 .build();
 
         NakadiTestUtils.createEventTypeInNakadi(eventType);
-    }
 
-    @Test
-    public void testCreateNextTimeline() throws Exception {
         NakadiTestUtils.switchTimelineDefaultStorage(eventType);
         RestAssured.given()
                 .contentType(ContentType.JSON)
                 .get("event-types/{et_name}/timelines", eventType.getName())
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body("[0].event_type", Matchers.equalTo(eventType.getName()))
+                .body("[0].event_type", equalTo(eventType.getName()))
                 .body("[0].order", Matchers.is(1))
-                .body("[0].storage_id", Matchers.equalTo("default"))
+                .body("[0].storage_id", equalTo("default"))
                 .body("[0].switched_at", dateWithin(1, MINUTES, new DateTime()))
                 .body("[0].cleaned_up_at", dateWithin(1, MINUTES, new DateTime().plusMillis((int) RETENTION_TIME_MS)))
-                .body("[1].event_type", Matchers.equalTo(eventType.getName()))
+                .body("[1].event_type", equalTo(eventType.getName()))
                 .body("[1].order", Matchers.is(2))
-                .body("[1].storage_id", Matchers.equalTo("default"))
+                .body("[1].storage_id", equalTo("default"))
                 .body("[1].switched_at", dateWithin(1, MINUTES, new DateTime()))
                 .body("[1].cleaned_up_at", nullValue());
     }
 
+    @Test
+    public void testCreatTimelineOnExistentTopic() throws Exception {
+        final EventType eventType = EventTypeTestBuilder.builder()
+                .cleanupPolicy(CleanupPolicy.COMPACT)
+                .category(EventCategory.BUSINESS)
+                .enrichmentStrategies(ImmutableList.of(EnrichmentStrategyDescriptor.METADATA_ENRICHMENT))
+                .build();
+
+        // This event type is created only so that it creates a topic which we will use as an existent topic for the
+        // new timeline. That's not how this feature will work on production, since topics are not shared between
+        // event types, but this is a simple way to create a topic. Otherwise we would have to instantiate
+        // KafkaRepository to create a dummy topic.
+        final EventType dummyEventType = EventTypeTestBuilder.builder()
+                .cleanupPolicy(CleanupPolicy.COMPACT)
+                .category(EventCategory.BUSINESS)
+                .enrichmentStrategies(ImmutableList.of(EnrichmentStrategyDescriptor.METADATA_ENRICHMENT))
+                .build();
+
+        NakadiTestUtils.createEventTypeInNakadi(eventType);
+        NakadiTestUtils.createEventTypeInNakadi(dummyEventType);
+
+
+        final List<TimelineView> retrievedTimeline = MAPPER.readValue(requestSpec()
+                .contentType(JSON)
+                .header("accept", "application/json")
+                .get("/event-types/" + dummyEventType.getName() + "/timelines")
+                .getBody()
+                .asString(),
+                new TypeReference<ArrayList<TimelineView>>() { });
+
+        final String existentTopic = retrievedTimeline.get(0).getTopic();
+
+        RestAssured.given()
+                .body(new JSONObject().put("storage_id", "default").put("topic", existentTopic))
+                .header("Content-type", "application/json")
+                .post("event-types/{et_name}/timelines", eventType.getName())
+                .then()
+                .body(equalTo(""))
+                .statusCode(HttpStatus.SC_CREATED);
+
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .get("event-types/{et_name}/timelines", eventType.getName())
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("[1].event_type", equalTo(eventType.getName()))
+                .body("[1].order", Matchers.is(2))
+                .body("[1].storage_id", equalTo("default"))
+                .body("[1].topic", equalTo(existentTopic))
+                .body("[1].cleaned_up_at", nullValue());
+    }
 }

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/TimelinesControllerAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/TimelinesControllerAT.java
@@ -58,7 +58,7 @@ public class TimelinesControllerAT extends RealEnvironmentAT {
     }
 
     @Test
-    public void testCreatTimelineOnExistentTopic() throws Exception {
+    public void testCreateTimelineOnExistingTopic() throws Exception {
         final EventType eventType = EventTypeTestBuilder.builder()
                 .cleanupPolicy(CleanupPolicy.COMPACT)
                 .category(EventCategory.BUSINESS)

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/TimelinesControllerAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/TimelinesControllerAT.java
@@ -1,6 +1,5 @@
 package org.zalando.nakadi.webservice;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableList;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.http.ContentType;
@@ -15,20 +14,15 @@ import org.zalando.nakadi.domain.EventCategory;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeOptions;
 import org.zalando.nakadi.utils.EventTypeTestBuilder;
-import org.zalando.nakadi.view.TimelineView;
 import org.zalando.nakadi.webservice.utils.NakadiTestUtils;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 
-import static com.jayway.restassured.http.ContentType.JSON;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.equalTo;
 import static org.zalando.nakadi.util.DateWithinMatcher.dateWithin;
-import static org.zalando.nakadi.webservice.BaseAT.MAPPER;
 
 public class TimelinesControllerAT extends RealEnvironmentAT {
 

--- a/src/main/java/org/zalando/nakadi/controller/TimelinesController.java
+++ b/src/main/java/org/zalando/nakadi/controller/TimelinesController.java
@@ -50,7 +50,7 @@ public class TimelinesController {
                                             @RequestBody final TimelineRequest timelineRequest)
             throws AccessDeniedException, TimelineException, TopicRepositoryException, InconsistentStateException,
             RepositoryProblemException {
-        timelineService.createTimeline(eventTypeName, timelineRequest.getStorageId());
+        timelineService.createTimeline(eventTypeName, timelineRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/src/main/java/org/zalando/nakadi/view/TimelineRequest.java
+++ b/src/main/java/org/zalando/nakadi/view/TimelineRequest.java
@@ -1,8 +1,13 @@
 package org.zalando.nakadi.view;
 
+import javax.annotation.Nullable;
+
 public class TimelineRequest {
 
     private String storageId;
+
+    @Nullable
+    private String topic;
 
     public String getStorageId() {
         return storageId;
@@ -10,5 +15,13 @@ public class TimelineRequest {
 
     public void setStorageId(final String storageId) {
         this.storageId = storageId;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(final String topic) {
+        this.topic = topic;
     }
 }

--- a/src/test/java/org/zalando/nakadi/service/timeline/TimelineServiceTest.java
+++ b/src/test/java/org/zalando/nakadi/service/timeline/TimelineServiceTest.java
@@ -26,6 +26,7 @@ import org.zalando.nakadi.repository.db.TimelineDbRepository;
 import org.zalando.nakadi.service.AdminService;
 import org.zalando.nakadi.service.FeatureToggleService;
 import org.zalando.nakadi.utils.EventTypeTestBuilder;
+import org.zalando.nakadi.view.TimelineRequest;
 
 import java.util.Collections;
 import java.util.Date;
@@ -149,7 +150,10 @@ public class TimelineServiceTest {
 
         when(adminService.isAdmin(any())).thenReturn(true);
 
-        timelineService.createTimeline("et1", "st1");
+        final TimelineRequest timelineRequest = new TimelineRequest();
+        timelineRequest.setStorageId("st1");
+
+        timelineService.createTimeline("et1", timelineRequest);
     }
 
 }


### PR DESCRIPTION
This API change makes it possible to connect an event type to an
existing topic.

I considered that the timeline is the structure that acts as an interface to a low level storage and not the event type.

Adding a topic to the event type would not be enough because we would also need to specify the "storage". The only entity that is connected to a storage is the timeline so for me it was the logical place to do that. Also, attaching an event type to a topic eliminates the possibility to later on "attach" other topics to an event type.

So I think that allowing for this in the timeline is the most flexible place.