### PR TITLE
Put nakadi-event-bus-api.yaml under the api/ folder in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Team Aruha, team-aruha@zalando.de
 
 WORKDIR /
 ADD build/libs/nakadi.jar nakadi.jar
-ADD api/nakadi-event-bus-api.yaml nakadi-event-bus-api.yaml
+ADD api/nakadi-event-bus-api.yaml api/nakadi-event-bus-api.yaml
 
 EXPOSE 8080
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -128,7 +128,7 @@ nakadi:
 
 twintip:
   mapping: /api
-  yaml: "file:nakadi-event-bus-api.yaml"
+  yaml: "file:api/nakadi-event-bus-api.yaml"
 ---
 
 spring:
@@ -156,9 +156,6 @@ kpi:
 
 spring:
   profiles: test
-twintip:
-  mapping: /api
-  yaml: "file:api/nakadi-event-bus-api.yaml"
 
 ---
 


### PR DESCRIPTION
# One-line summary

Put nakadi-event-bus-api.yaml under the api/ folder in docker

## Description

When starting the server using the IDE or bootRun, the server currently fails to start because the default setup is to look for `nakadi-event-bus-api.yaml` in the root dir whereas it is in the `api/` folder.
This PR sets it to `api/` by default and makes the appropriate change in the Dockerfile.

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
