### PR TITLE
Upgrade Kafka to v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Read our [contribution guidelines](CONTRIBUTING.md) on how to submit issues and 
 ### Dependencies
 
 The Nakadi server is a Java 8 [Spring Boot](https://projects.spring.io/spring-boot/) application. 
-It uses [Kafka 1.1.1](https://kafka.apache.org/11/documentation.html) as its broker and
+It uses [Kafka](https://kafka.apache.org/20/documentation.html)  >= 1.0.0 as its broker and
  [PostgreSQL 9.5](https://www.postgresql.org/docs/9.5/static/release-9-5.html) as its supporting database.
 
 Nakadi requires recent versions of docker and docker-compose. In

--- a/build.gradle
+++ b/build.gradle
@@ -141,8 +141,8 @@ dependencies {
     compile 'org.echocat.jomon:runtime:1.6.3'
 
     // kafka & zookeeper
-    compile 'org.apache.kafka:kafka-clients:1.1.1'
-    compile('org.apache.kafka:kafka_2.12:1.1.1') {
+    compile 'org.apache.kafka:kafka-clients:2.0.0'
+    compile('org.apache.kafka:kafka_2.12:2.0.0') {
         exclude module: "zookeeper"
     }
     compile("org.apache.curator:curator-recipes:$curatorVersion") {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.11-1.1.1
+    image: wurstmeister/kafka:2.11-2.0.0
     network_mode: "host"
     ports:
       - "9092:9092"


### PR DESCRIPTION
## Description
Kafka 2 has been released and is the baseline for Confluent 5 platform.

## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
