### PR TITLE
Remove codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*   @zalando/team-nakadi


### PR DESCRIPTION
I would like to remove this file, because it forces us to perform a
github-style code review, on top of a zappr-style approval.

Zappr is still required as per the rules of play, and as far as I can
tell, github-style reviews do not bring any additional advantages.
Therefore, we need to get rid of one option. Since zappr is
mandatory, the codeowners file has to go.