### PR TITLE
Send allowed number of events (or less) when memory overflow happens

### DIFF
--- a/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java
@@ -120,10 +120,6 @@ class PartitionData {
         return result;
     }
 
-    public int getNumberOfUnsentEvents() {
-        return this.nakadiEvents.size();
-    }
-
     int getKeepAliveInARow() {
         return keepAliveInARow;
     }

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java
@@ -112,6 +112,18 @@ class PartitionData {
         return result;
     }
 
+    public List<ConsumedEvent> extractMaxEvents(final long currentTimeMillis, final int count) {
+        final List<ConsumedEvent> result = extract(count);
+        if(!result.isEmpty()) {
+            lastSendMillis = currentTimeMillis;
+        }
+        return result;
+    }
+
+    public int getNumberOfUnsentEvents() {
+        return this.nakadiEvents.size();
+    }
+
     int getKeepAliveInARow() {
         return keepAliveInARow;
     }

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -261,7 +261,7 @@ class StreamingState extends State {
 
             long deltaSize = heaviestPartition.getValue().getBytesInMemory();
             final List<ConsumedEvent> events = heaviestPartition.getValue().extractMaxEvents(currentTimeMillis,
-                    Math.min((int) getMessagesAllowedToSend(), heaviestPartition.getValue().getNumberOfUnsentEvents()));
+                    (int) getMessagesAllowedToSend());
             deltaSize -= heaviestPartition.getValue().getBytesInMemory();
 
             sentSomething = true;

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -252,7 +252,7 @@ class StreamingState extends State {
         }
 
         long memoryConsumed = offsets.values().stream().mapToLong(PartitionData::getBytesInMemory).sum();
-        while (memoryConsumed > getContext().getStreamMemoryLimitBytes()) {
+        while (memoryConsumed > getContext().getStreamMemoryLimitBytes() && getMessagesAllowedToSend() > 0) {
             // Select heaviest guy (and on previous step we figured out that we can not send anymore full batches,
             // therefore we can take all the events from one partition.
             final Map.Entry<EventTypePartition, PartitionData> heaviestPartition = offsets.entrySet().stream().max(
@@ -260,7 +260,8 @@ class StreamingState extends State {
             ).get(); // There is always at least 1 item in list
 
             long deltaSize = heaviestPartition.getValue().getBytesInMemory();
-            final List<ConsumedEvent> events = heaviestPartition.getValue().extractAll(currentTimeMillis);
+            final List<ConsumedEvent> events = heaviestPartition.getValue().extractMaxEvents(currentTimeMillis,
+                    Math.min((int) getMessagesAllowedToSend(), heaviestPartition.getValue().getNumberOfUnsentEvents()));
             deltaSize -= heaviestPartition.getValue().getBytesInMemory();
 
             sentSomething = true;


### PR DESCRIPTION
# One-line summary

> Zalando ticket : [ARUHA-1921](https://techjira.zalando.net/browse/ARUHA-1921) 

Nakadi did not respect batch sizes and max uncommitted events parameters when there was a memory overflow. 
## Review
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

