### PR TITLE
Don't allow adding required properties in forward compatible schema

### DIFF
--- a/docs/_documentation/using_event-types.md
+++ b/docs/_documentation/using_event-types.md
@@ -114,7 +114,7 @@ is not safe.
 Supported changes:
 
 1. changes to meta attributes: titles and descriptions.
-2. addition of new attributes, both optional and required.
+2. addition of new optional attributes.
 3. marking attributes as required.
 4. change additionalProperties from true to object.
 

--- a/src/main/java/org/zalando/nakadi/config/ValidatorConfig.java
+++ b/src/main/java/org/zalando/nakadi/config/ValidatorConfig.java
@@ -99,7 +99,7 @@ public class ValidatorConfig {
         forwardChanges.put(DESCRIPTION_CHANGED, PATCH);
         forwardChanges.put(TITLE_CHANGED, PATCH);
         forwardChanges.put(PROPERTIES_ADDED, MINOR);
-        forwardChanges.put(REQUIRED_ARRAY_EXTENDED, MINOR);
+        forwardChanges.put(REQUIRED_ARRAY_EXTENDED, MAJOR);
         forwardChanges.put(ID_CHANGED, MAJOR);
         forwardChanges.put(SCHEMA_REMOVED, MAJOR);
         forwardChanges.put(TYPE_CHANGED, MAJOR);


### PR DESCRIPTION
# One-line summary

> Zalando ticket : ARUHA-1969 (only if appropriate)

## Description
Remove ability to add a required field.

## Review
- [ ] Tests
- [ ] Documentation
