### PR TITLE
Fix error when access to timelines is forbidden

### DIFF
--- a/src/main/java/org/zalando/nakadi/domain/NakadiResource.java
+++ b/src/main/java/org/zalando/nakadi/domain/NakadiResource.java
@@ -1,0 +1,41 @@
+package org.zalando.nakadi.domain;
+
+import org.zalando.nakadi.plugin.api.authz.AuthorizationAttribute;
+import org.zalando.nakadi.plugin.api.authz.AuthorizationService;
+import org.zalando.nakadi.plugin.api.authz.Resource;
+
+import java.util.List;
+import java.util.Optional;
+
+public class NakadiResource implements Resource {
+    public static final String NAKADI_RESOURCE = "nakadi";
+
+    private final String name;
+    private final ResourceAuthorization resourceAuthorization;
+
+    public NakadiResource(final String name, final ResourceAuthorization resourceAuthorization) {
+        this.name = name;
+        this.resourceAuthorization = resourceAuthorization;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getType() {
+        return NAKADI_RESOURCE;
+    }
+
+    @Override
+    public Optional<List<AuthorizationAttribute>> getAttributesForOperation(
+            final AuthorizationService.Operation operation) {
+        return resourceAuthorization.getAttributesForOperation(operation);
+    }
+
+    @Override
+    public String toString() {
+        return "AuthorizedResource{" + NAKADI_RESOURCE + "='" + name + "'}";
+    }
+}

--- a/src/main/java/org/zalando/nakadi/service/timeline/TimelineService.java
+++ b/src/main/java/org/zalando/nakadi/service/timeline/TimelineService.java
@@ -15,8 +15,8 @@ import org.zalando.nakadi.domain.CleanupPolicy;
 import org.zalando.nakadi.domain.DefaultStorage;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeBase;
-import org.zalando.nakadi.domain.EventTypeResource;
 import org.zalando.nakadi.domain.NakadiCursor;
+import org.zalando.nakadi.domain.NakadiResource;
 import org.zalando.nakadi.domain.PartitionStatistics;
 import org.zalando.nakadi.domain.Storage;
 import org.zalando.nakadi.domain.Timeline;
@@ -337,8 +337,8 @@ public class TimelineService {
     public List<Timeline> getTimelines(final String eventTypeName)
             throws AccessDeniedException, UnableProcessException, TimelineException, NotFoundException {
         if (!adminService.isAdmin(AuthorizationService.Operation.READ)) {
-            throw new AccessDeniedException(AuthorizationService.Operation.ADMIN,
-                    new EventTypeResource(eventTypeName, null));
+            throw new AccessDeniedException(AuthorizationService.Operation.READ,
+                    new NakadiResource("nakadi", null));
         }
 
         try {


### PR DESCRIPTION
# Fix error when access to timelines is forbidden

## Description
Getting the list of timelines requires nakadi.read access, but the error message mentions admin on the event type, which is incorrect.
