### PR TITLE
ARUHA-2106: Added populating of kafka event key

### DIFF
--- a/src/main/java/org/zalando/nakadi/partitioning/HashPartitionStrategy.java
+++ b/src/main/java/org/zalando/nakadi/partitioning/HashPartitionStrategy.java
@@ -5,21 +5,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.zalando.nakadi.domain.EventCategory;
 import org.zalando.nakadi.domain.EventType;
+import org.zalando.nakadi.exceptions.Try;
 import org.zalando.nakadi.exceptions.runtime.InvalidPartitionKeyFieldsException;
 import org.zalando.nakadi.exceptions.runtime.NakadiRuntimeException;
-import org.zalando.nakadi.exceptions.Try;
 import org.zalando.nakadi.util.JsonPathAccess;
-import org.zalando.nakadi.validation.JsonSchemaEnrichment;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static java.lang.Math.abs;
+import static org.zalando.nakadi.validation.JsonSchemaEnrichment.DATA_PATH_PREFIX;
 
 @Component
 public class HashPartitionStrategy implements PartitionStrategy {
-
-    private static final String DATA_PATH_PREFIX = JsonSchemaEnrichment.DATA_CHANGE_WRAP_FIELD + ".";
 
     private final HashPartitionStrategyCrutch hashPartitioningCrutch;
     private final StringHash stringHash;

--- a/src/main/java/org/zalando/nakadi/service/EventPublisher.java
+++ b/src/main/java/org/zalando/nakadi/service/EventPublisher.java
@@ -10,6 +10,7 @@ import org.zalando.nakadi.domain.BatchFactory;
 import org.zalando.nakadi.domain.BatchItem;
 import org.zalando.nakadi.domain.BatchItemResponse;
 import org.zalando.nakadi.domain.CleanupPolicy;
+import org.zalando.nakadi.domain.EventCategory;
 import org.zalando.nakadi.domain.EventPublishResult;
 import org.zalando.nakadi.domain.EventPublishingStatus;
 import org.zalando.nakadi.domain.EventPublishingStep;
@@ -26,9 +27,11 @@ import org.zalando.nakadi.exceptions.runtime.NoSuchEventTypeException;
 import org.zalando.nakadi.exceptions.runtime.PartitioningException;
 import org.zalando.nakadi.exceptions.runtime.ServiceTemporarilyUnavailableException;
 import org.zalando.nakadi.partitioning.PartitionResolver;
+import org.zalando.nakadi.partitioning.PartitionStrategy;
 import org.zalando.nakadi.repository.db.EventTypeCache;
 import org.zalando.nakadi.service.timeline.TimelineService;
 import org.zalando.nakadi.service.timeline.TimelineSync;
+import org.zalando.nakadi.util.JsonPathAccess;
 import org.zalando.nakadi.validation.EventTypeValidator;
 import org.zalando.nakadi.validation.ValidationError;
 
@@ -38,6 +41,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
+
+import static org.zalando.nakadi.validation.JsonSchemaEnrichment.DATA_PATH_PREFIX;
 
 @Component
 public class EventPublisher {
@@ -99,7 +104,7 @@ public class EventPublisher {
 
             validate(batch, eventType);
             partition(batch, eventType);
-            compact(batch, eventType);
+            setEventKey(batch, eventType);
             enrich(batch, eventType);
             submit(batch, eventType);
 
@@ -169,13 +174,28 @@ public class EventPublisher {
         }
     }
 
-    private void compact(final List<BatchItem> batch, final EventType eventType) {
+    private void setEventKey(final List<BatchItem> batch, final EventType eventType) {
         if (eventType.getCleanupPolicy() == CleanupPolicy.COMPACT) {
             for (final BatchItem item : batch) {
                 final String compactionKey = item.getEvent()
                         .getJSONObject("metadata")
                         .getString("partition_compaction_key");
                 item.setEventKey(compactionKey);
+            }
+        } else if (PartitionStrategy.HASH_STRATEGY.equals(eventType.getPartitionStrategy())) {
+            final List<String> partitionKeyFields = eventType.getPartitionKeyFields();
+            // we will set event key only if there is exactly one partition key field,
+            // in other case it's not clear what should be set as event key
+            if (partitionKeyFields.size() == 1) {
+                String partitionKeyField = partitionKeyFields.get(0);
+                if (EventCategory.DATA.equals(eventType.getCategory())) {
+                    partitionKeyField = DATA_PATH_PREFIX + partitionKeyField;
+                }
+                for (final BatchItem item : batch) {
+                    final JsonPathAccess jsonPath = new JsonPathAccess(item.getEvent());
+                    final String eventKey = jsonPath.get(partitionKeyField).toString();
+                    item.setEventKey(eventKey);
+                }
             }
         }
     }

--- a/src/main/java/org/zalando/nakadi/validation/JsonSchemaEnrichment.java
+++ b/src/main/java/org/zalando/nakadi/validation/JsonSchemaEnrichment.java
@@ -19,6 +19,7 @@ import static com.google.common.collect.Lists.newArrayList;
 
 public class JsonSchemaEnrichment {
     public static final String DATA_CHANGE_WRAP_FIELD = "data";
+    public static final String DATA_PATH_PREFIX = JsonSchemaEnrichment.DATA_CHANGE_WRAP_FIELD + ".";
 
     private static final String ADDITIONAL_PROPERTIES = "additionalProperties";
     private static final String ADDITIONAL_ITEMS = "additionalItems";

--- a/src/test/java/org/zalando/nakadi/service/EventPublisherTest.java
+++ b/src/test/java/org/zalando/nakadi/service/EventPublisherTest.java
@@ -41,7 +41,6 @@ import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -514,13 +513,6 @@ public class EventPublisherTest {
     private void mockFaultPartition() throws PartitioningException {
         Mockito
                 .doThrow(new PartitioningException("partition error"))
-                .when(partitionResolver)
-                .resolvePartition(any(), any());
-    }
-
-    private void mockSuccessfulPartitioning() throws PartitioningException {
-        Mockito
-                .doReturn("0")
                 .when(partitionResolver)
                 .resolvePartition(any(), any());
     }

--- a/src/test/java/org/zalando/nakadi/service/EventPublisherTest.java
+++ b/src/test/java/org/zalando/nakadi/service/EventPublisherTest.java
@@ -1,9 +1,11 @@
 package org.zalando.nakadi.service;
 
+import com.google.common.collect.ImmutableList;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.zalando.nakadi.config.NakadiSettings;
 import org.zalando.nakadi.domain.BatchItem;
@@ -15,12 +17,13 @@ import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeBase;
 import org.zalando.nakadi.domain.Timeline;
 import org.zalando.nakadi.enrichment.Enrichment;
-import org.zalando.nakadi.exceptions.runtime.EnrichmentException;
-import org.zalando.nakadi.exceptions.runtime.PartitioningException;
 import org.zalando.nakadi.exceptions.runtime.AccessDeniedException;
+import org.zalando.nakadi.exceptions.runtime.EnrichmentException;
 import org.zalando.nakadi.exceptions.runtime.EventPublishingException;
 import org.zalando.nakadi.exceptions.runtime.EventTypeTimeoutException;
+import org.zalando.nakadi.exceptions.runtime.PartitioningException;
 import org.zalando.nakadi.partitioning.PartitionResolver;
+import org.zalando.nakadi.partitioning.PartitionStrategy;
 import org.zalando.nakadi.repository.TopicRepository;
 import org.zalando.nakadi.repository.db.EventTypeCache;
 import org.zalando.nakadi.service.timeline.TimelineService;
@@ -38,12 +41,14 @@ import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -405,6 +410,66 @@ public class EventPublisherTest {
     }
 
     @Test
+    public void whenSinglePartitioningKeyThenEventKeyIsSet() throws Exception {
+        final EventType eventType = EventTypeTestBuilder.builder()
+                .partitionStrategy(PartitionStrategy.HASH_STRATEGY)
+                .partitionKeyFields(ImmutableList.of("my_field"))
+                .build();
+
+        final JSONArray batch = buildDefaultBatch(1);
+        batch.getJSONObject(0).put("my_field", "my_key");
+
+        mockSuccessfulValidation(eventType);
+
+        publisher.publish(batch.toString(), eventType.getName());
+
+        final List<BatchItem> publishedBatch = capturePublishedBatch();
+        assertThat(publishedBatch.get(0).getEventKey(), equalTo("my_key"));
+    }
+
+    @Test
+    public void whenMultiplePartitioningKeyThenEventKeyIsNotSet() throws Exception {
+        final EventType eventType = EventTypeTestBuilder.builder()
+                .partitionStrategy(PartitionStrategy.HASH_STRATEGY)
+                .partitionKeyFields(ImmutableList.of("my_field", "other_field"))
+                .build();
+
+        final JSONArray batch = buildDefaultBatch(1);
+        final JSONObject event = batch.getJSONObject(0);
+        event.put("my_field", "my_key");
+        event.put("other_field", "other_value");
+
+        mockSuccessfulValidation(eventType);
+
+        publisher.publish(batch.toString(), eventType.getName());
+
+        final List<BatchItem> publishedBatch = capturePublishedBatch();
+        assertThat(publishedBatch.get(0).getEventKey(), equalTo(null));
+    }
+
+    @Test
+    public void whenNoneHashPartitioningStrategyThenEventKeyIsNotSet() throws Exception {
+        final EventType eventType = EventTypeTestBuilder.builder()
+                .partitionStrategy(PartitionStrategy.RANDOM_STRATEGY)
+                .build();
+        final JSONArray batch = buildDefaultBatch(1);
+
+        mockSuccessfulValidation(eventType);
+
+        publisher.publish(batch.toString(), eventType.getName());
+
+        final List<BatchItem> publishedBatch = capturePublishedBatch();
+        assertThat(publishedBatch.get(0).getEventKey(), equalTo(null));
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<BatchItem> capturePublishedBatch() {
+        final ArgumentCaptor<List> batchCaptor = ArgumentCaptor.forClass(List.class);
+        verify(topicRepository, atLeastOnce()).syncPostBatch(any(), batchCaptor.capture());
+        return (List<BatchItem>) batchCaptor.getValue();
+    }
+
+    @Test
     public void whenEnrichmentFailsThenSubsequentItemsAreAborted() throws Exception {
         final EventType eventType = buildDefaultEventType();
         final JSONArray batch = buildDefaultBatch(2);
@@ -449,6 +514,13 @@ public class EventPublisherTest {
     private void mockFaultPartition() throws PartitioningException {
         Mockito
                 .doThrow(new PartitioningException("partition error"))
+                .when(partitionResolver)
+                .resolvePartition(any(), any());
+    }
+
+    private void mockSuccessfulPartitioning() throws PartitioningException {
+        Mockito
+                .doReturn("0")
                 .when(partitionResolver)
                 .resolvePartition(any(), any());
     }


### PR DESCRIPTION
# Added populating of kafka event key

> Zalando ticket : ARUHA-2106

## Description
**WHY**: to be able to do joins by partition key in Nakadi SQL
**WHAT**: if event has "delete" cleanup policy - we should set Kafka key for its events in a case when partitioning strategy is hash and there is exactly one partitioning key field.

## Review
- [ ] Tests
- [ ] Documentation

## Deployment Notes
We need first to roll it out on staging and check that it didn't change the partitioning
