### PR TITLE
Replace Kafka producer on timeout

### DIFF
--- a/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -63,6 +63,7 @@ public class KafkaRepositoryAT extends BaseAT {
     private static final int NAKADI_SUBSCRIPTION_MAX_PARTITIONS = 8;
     private static final boolean KAFKA_ENABLE_AUTO_COMMIT = false;
     private static final int KAFKA_MAX_REQUEST_SIZE = 2098152;
+    private static final int KAFKA_MAX_MAX_BLOCK_MS = 30000;
     private static final String DEFAULT_ADMIN_DATA_TYPE = "service";
     private static final String DEFAULT_ADMIN_VALUE = "nakadi";
     private static final String DEFAULT_WARN_ALL_DATA_ACCESS_MESSAGE = "";
@@ -95,7 +96,7 @@ public class KafkaRepositoryAT extends BaseAT {
                 DEFAULT_WARN_ALL_DATA_ACCESS_MESSAGE,
                 DEFAULT_WARN_LOG_COMPACTION_MESSAGE);
         kafkaSettings = new KafkaSettings(KAFKA_REQUEST_TIMEOUT, KAFKA_BATCH_SIZE,
-                KAFKA_LINGER_MS, KAFKA_ENABLE_AUTO_COMMIT, KAFKA_MAX_REQUEST_SIZE);
+                KAFKA_LINGER_MS, KAFKA_ENABLE_AUTO_COMMIT, KAFKA_MAX_REQUEST_SIZE, KAFKA_MAX_MAX_BLOCK_MS);
         zookeeperSettings = new ZookeeperSettings(ZK_SESSION_TIMEOUT, ZK_CONNECTION_TIMEOUT);
         kafkaHelper = new KafkaTestHelper(KAFKA_URL);
         defaultTopicConfig = new NakadiTopicConfig(DEFAULT_PARTITION_COUNT, DEFAULT_CLEANUP_POLICY,

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -116,6 +116,7 @@ public class KafkaLocationManager {
         producerProps.put(ProducerConfig.LINGER_MS_CONFIG, kafkaSettings.getLingerMs());
         producerProps.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "lz4");
         producerProps.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, kafkaSettings.getMaxRequestSize());
+        producerProps.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, kafkaSettings.getMaxBlockMsConfig());
         return producerProps;
     }
 }

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSettings.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSettings.java
@@ -17,20 +17,22 @@ public class KafkaSettings {
     private final int batchSize;
     private final long lingerMs;
     private final boolean enableAutoCommit;
-
     private final int maxRequestSize;
+    private final int maxBlockMsConfig;
 
     @Autowired
     public KafkaSettings(@Value("${nakadi.kafka.request.timeout.ms}") final int requestTimeoutMs,
                          @Value("${nakadi.kafka.batch.size}") final int batchSize,
                          @Value("${nakadi.kafka.linger.ms}") final long lingerMs,
                          @Value("${nakadi.kafka.enable.auto.commit}") final boolean enableAutoCommit,
-                         @Value("${nakadi.kafka.max.request.size}") final int maxRequestSize) {
+                         @Value("${nakadi.kafka.max.request.size}") final int maxRequestSize,
+                         @Value("${nakadi.kafka.max.max.block.ms.config}") final int maxBlockMsConfig) {
         this.requestTimeoutMs = requestTimeoutMs;
         this.batchSize = batchSize;
         this.lingerMs = lingerMs;
         this.enableAutoCommit = enableAutoCommit;
         this.maxRequestSize = maxRequestSize;
+        this.maxBlockMsConfig = maxBlockMsConfig;
     }
 
     public int getRequestTimeoutMs() {
@@ -51,5 +53,9 @@ public class KafkaSettings {
 
     public int getMaxRequestSize() {
         return maxRequestSize;
+    }
+
+    public int getMaxBlockMsConfig() {
+        return maxBlockMsConfig;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,6 +67,7 @@ nakadi:
     max.request.size: 2098152
     linger.ms: 0
     enable.auto.commit: false
+    max.max.block.ms.config: 5000 # kafka default is 60000ms
   zookeeper:
     kafkaNamespace:
     brokers: zookeeper:2181


### PR DESCRIPTION
## Description
During rolling restart of Kafka cluster it was noticed, that Kafka client fails to request metadata in 60 seconds, after broker was restarted. Only fix is to restart Nakadi cluster.
```
org.apache.kafka.common.errors.TimeoutException: Failed to update metadata after 60000 ms.
```