### PR TITLE
990 - change the relative link to absolute path to fix a broken link in the documentations.

### DIFF
--- a/docs/_documentation/using_consuming-events-hila.md
+++ b/docs/_documentation/using_consuming-events-hila.md
@@ -35,7 +35,7 @@ examples of Subscription API creation and usage:
   - [Deleting a Subscription](#deleting-a-subscription): How to remove a Subscription.
   - [Getting and Listing Subscriptions](#getting-and-listing-subscriptions): How to view individual an subscription and list existing susbcriptions.
 
-For a more detailed description and advanced configuration options please take a look at Nakadi [swagger](api/nakadi-event-bus-api.yaml) file.
+For a more detailed description and advanced configuration options please take a look at Nakadi [swagger](https://github.com/zalando/nakadi/blob/master/docs/_data/nakadi-event-bus-api.yaml) file.
 
 ### Creating Subscriptions
 


### PR DESCRIPTION


# Fix a broken link in the documentation

> https://github.com/zalando/nakadi/issues/990

## Description

The reason that the link is broken in the documentation is that it uses a relative path. The documentation meant to be used in Nakadi.io as well as Github. Nakadi.io domain and Github interpret the relative paths differently. So to fix the broken link, I changed the path to the absolute path linking to the swagger file in the Github repo.

## Review
- [ ] Tests
- [x] Documentation


