### PR TITLE
Stop consumers when kafka broker ip changed

### DIFF
--- a/src/main/java/org/zalando/nakadi/repository/MultiTimelineEventConsumer.java
+++ b/src/main/java/org/zalando/nakadi/repository/MultiTimelineEventConsumer.java
@@ -15,7 +15,6 @@ import org.zalando.nakadi.service.timeline.TimelineService;
 import org.zalando.nakadi.service.timeline.TimelineSync;
 import org.zalando.nakadi.util.NakadiCollectionUtils;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -308,9 +307,6 @@ public class MultiTimelineEventConsumer implements EventConsumer.ReassignableEve
     public void close() throws IOException {
         try {
             reassign(Collections.emptySet());
-            for (final EventConsumer.LowLevelConsumer consumer : eventConsumers.values()) {
-                consumer.close();
-            }
         } catch (final InvalidCursorException e) {
             throw new IOException(e);
         }

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
@@ -174,8 +174,8 @@ public class KafkaFactory {
         public void close() {
             if (brokerIpAddressChanged) {
                 LOG.info("Closing crutch consumer and removing ip address change listener");
-                this.kafkaLocationManager.removeIpAddressChangeListener(brokerIpAddressChangeListener);
             }
+            this.kafkaLocationManager.removeIpAddressChangeListener(brokerIpAddressChangeListener);
             super.close();
         }
     }

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
@@ -172,9 +172,6 @@ public class KafkaFactory {
 
         @Override
         public void close() {
-            if (brokerIpAddressChanged) {
-                LOG.info("Closing crutch consumer and removing ip address change listener");
-            }
             this.kafkaLocationManager.removeIpAddressChangeListener(brokerIpAddressChangeListener);
             super.close();
         }

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
@@ -165,8 +165,6 @@ public class KafkaFactory {
         @Override
         public ConsumerRecords<byte[], byte[]> poll(final long timeoutMs) {
             if (brokerIpAddressChanged) {
-                LOG.info("Broker address changed, stop polling and removing ip address change listener");
-                this.kafkaLocationManager.removeIpAddressChangeListener(brokerIpAddressChangeListener);
                 throw new KafkaCrutchException("Kafka broker ip address changed, exiting");
             }
             return super.poll(timeoutMs);
@@ -174,9 +172,11 @@ public class KafkaFactory {
 
         @Override
         public void close() {
-            LOG.info("Closing crutch consumer and removing ip address change listener");
+            if (brokerIpAddressChanged) {
+                LOG.info("Closing crutch consumer and removing ip address change listener");
+                this.kafkaLocationManager.removeIpAddressChangeListener(brokerIpAddressChangeListener);
+            }
             super.close();
-            this.kafkaLocationManager.removeIpAddressChangeListener(brokerIpAddressChangeListener);
         }
     }
 

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
@@ -3,6 +3,7 @@ package org.zalando.nakadi.repository.kafka;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
@@ -20,15 +21,14 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class KafkaFactory {
 
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaFactory.class);
     private final KafkaLocationManager kafkaLocationManager;
     private final Counter useCountMetric;
     private final Counter producerTerminations;
-    @Nullable
-    private Producer<String, String> activeProducer;
     private final Map<Producer<String, String>, AtomicInteger> useCount = new ConcurrentHashMap<>();
     private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
-
-    private static final Logger LOG = LoggerFactory.getLogger(KafkaFactory.class);
+    @Nullable
+    private Producer<String, String> activeProducer;
 
     public KafkaFactory(final KafkaLocationManager kafkaLocationManager, final MetricRegistry metricRegistry) {
         this.kafkaLocationManager = kafkaLocationManager;
@@ -133,7 +133,7 @@ public class KafkaFactory {
     }
 
     public Consumer<byte[], byte[]> getConsumer(final Properties properties) {
-        return new KafkaConsumer<>(properties);
+        return new KafkaCrutchConsumer(properties, kafkaLocationManager);
     }
 
     public Consumer<byte[], byte[]> getConsumer() {
@@ -147,6 +147,44 @@ public class KafkaFactory {
         // https://docs.google.com/document/d/1JDgsBemNqS0SrNpWUL90205u0MFmSMnOqrC-ENAb6TM/edit
         // properties.put("client.id", clientId);
         return this.getConsumer(properties);
+    }
+
+    public class KafkaCrutchConsumer extends KafkaConsumer<byte[], byte[]> {
+
+        private final KafkaLocationManager kafkaLocationManager;
+        private final Runnable brokerIpAddressChangeListener;
+        private volatile boolean brokerIpAddressChanged;
+
+        public KafkaCrutchConsumer(final Properties properties, final KafkaLocationManager kafkaLocationManager) {
+            super(properties);
+            this.kafkaLocationManager = kafkaLocationManager;
+            this.brokerIpAddressChangeListener = () -> brokerIpAddressChanged = true;
+            this.kafkaLocationManager.addIpAddressChangeListener(brokerIpAddressChangeListener);
+        }
+
+        @Override
+        public ConsumerRecords<byte[], byte[]> poll(long timeoutMs) {
+            if (brokerIpAddressChanged) {
+                LOG.info("Broker address changed, stop polling and removing ip address change listener");
+                brokerIpAddressChanged = false;
+                this.kafkaLocationManager.removeIpAddressChangeListener(brokerIpAddressChangeListener);
+                throw new KafkaCrutchException("Kafka broker ip address changed, exiting");
+            }
+            return super.poll(timeoutMs);
+        }
+
+        @Override
+        public void close() {
+            LOG.info("Closing crutch consumer and removing ip address change listener");
+            super.close();
+            this.kafkaLocationManager.removeIpAddressChangeListener(brokerIpAddressChangeListener);
+        }
+    }
+
+    public class KafkaCrutchException extends RuntimeException {
+        public KafkaCrutchException(final String message) {
+            super(message);
+        }
     }
 
 }

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
@@ -163,10 +163,9 @@ public class KafkaFactory {
         }
 
         @Override
-        public ConsumerRecords<byte[], byte[]> poll(long timeoutMs) {
+        public ConsumerRecords<byte[], byte[]> poll(final long timeoutMs) {
             if (brokerIpAddressChanged) {
                 LOG.info("Broker address changed, stop polling and removing ip address change listener");
-                brokerIpAddressChanged = false;
                 this.kafkaLocationManager.removeIpAddressChangeListener(brokerIpAddressChangeListener);
                 throw new KafkaCrutchException("Kafka broker ip address changed, exiting");
             }

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -14,10 +14,10 @@ import org.zalando.nakadi.repository.zookeeper.ZooKeeperHolder;
 
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -38,7 +38,7 @@ public class KafkaLocationManager {
         this.zkFactory = zkFactory;
         this.kafkaProperties = new Properties();
         this.kafkaSettings = kafkaSettings;
-        this.ipAddressChangeListeners = new HashSet<>();
+        this.ipAddressChangeListeners = ConcurrentHashMap.newKeySet();
         this.updateBootstrapServers(true);
         this.scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
         this.scheduledExecutor.scheduleAtFixedRate(() -> updateBootstrapServers(false), 1, 1, TimeUnit.MINUTES);
@@ -64,6 +64,7 @@ public class KafkaLocationManager {
         }
 
         if (brokers.isEmpty()) {
+            LOG.info("Brokers list from ZK is empty");
             return;
         }
         final String bootstrapServers = brokers.stream()
@@ -74,6 +75,7 @@ public class KafkaLocationManager {
                 (String) kafkaProperties.get(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG);
 
         if (bootstrapServers.equals(currentBootstrapServers)) {
+            LOG.info("Bootstraps servers list from ZK and from Kafka config is the same");
             return;
         }
 

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -27,8 +27,8 @@ import org.zalando.nakadi.domain.NakadiCursor;
 import org.zalando.nakadi.domain.PartitionEndStatistics;
 import org.zalando.nakadi.domain.PartitionStatistics;
 import org.zalando.nakadi.domain.Timeline;
-import org.zalando.nakadi.exceptions.runtime.InvalidCursorException;
 import org.zalando.nakadi.exceptions.runtime.EventPublishingException;
+import org.zalando.nakadi.exceptions.runtime.InvalidCursorException;
 import org.zalando.nakadi.exceptions.runtime.ServiceTemporarilyUnavailableException;
 import org.zalando.nakadi.exceptions.runtime.TopicConfigException;
 import org.zalando.nakadi.exceptions.runtime.TopicCreationException;
@@ -208,7 +208,9 @@ public class KafkaTopicRepository implements TopicRepository {
         if (null == exception) {
             return false;
         }
-        return Stream.of(NotLeaderForPartitionException.class, UnknownTopicOrPartitionException.class)
+        return Stream.of(NotLeaderForPartitionException.class, UnknownTopicOrPartitionException.class,
+                org.apache.kafka.common.errors.TimeoutException.class, NetworkException.class,
+                UnknownServerException.class)
                 .anyMatch(clazz -> clazz.isAssignableFrom(exception.getClass()));
     }
 

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -21,5 +21,4 @@ log4j.category.org.thymeleaf=WARN
 log4j.category.org.zalando.nakadi=DEBUG
 log4j.category.org.zalando.nakadi.config=INFO
 log4j.category.org.apache.kafka=WARN
-log4j.category.org.apache.kafka.clients=DEBUG
 lgo4j.category.org.zalando.nakadi.service.ClosedConnectionsCrutch=INFO


### PR DESCRIPTION
# One-line summary
During restart of the brokers it was figured out when broker ip changes kafka consumer client does not support that properly and consumers have to be recreated. This PR brings ability to track broker list change and disconnect client.