### PR TITLE
WIP: audit log

### DIFF
--- a/src/main/resources/audit_event_type.json
+++ b/src/main/resources/audit_event_type.json
@@ -1,0 +1,35 @@
+{
+  "properties": {
+    "previous_object": {
+      "type": ["null", "object"],
+      "description": "When modifying an already existent entity, its value is captured in this field as a JSON object. So, for example, when changing an Event Type attribute, this field contains the entire state before the changes are applied"
+    },
+    "previous_text": {
+      "type": ["null", "string"],
+      "description": "Contains the same information as the field `previous_object` but as text, since the data lake stores a flat map of all the fields in the object, destroying information about its structure. Storing the text makes sure that the original data is not lost by any transformation that the data lake may apply on the data"
+    },
+    "new_object": {
+      "type": ["null", "object"],
+      "description": "New value submitted by the user"
+    },
+    "new_text": {
+      "type": ["null", "string"],
+      "description": "New value submitted by the user as text, in order to preserve the structure, if needed"
+    },
+    "resource_type": {
+      "x-extensible-enum": [
+        "event_type", "subscription", "timeline"
+      ],
+      "type":"string"
+    },
+    "resource_id": {
+      "description": "Resource identifier. Together with `resource_type` allows for the selection of a resource",
+      "type": "string"
+    },
+    "user": {
+      "description": "User or service that requested the changes",
+      "type": "string"
+    },
+    "required": ["user", "resource_id", "resource_type", "new_text", "new_object", "previous_text", "previous_object"]
+  }
+}


### PR DESCRIPTION
# WIP: Audit log 

https://jira.zalando.net/browse/ARUHA-2123

## Description
This PR contains code that captures content changes, including a snapshot of the state before and after the fact. I decided to store the entities both as objects and text (serialized json) in order to be sure that further transformations downstream - data lake flatmap, for example - would not destroy relevant structural information. But object is still present in order to make searching by entity attributes easier.