### PR TITLE
Update openjdk base image to 1.8.0-191-19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8-54
+FROM registry.opensource.zalan.do/stups/openjdk:1.8.0-191-19
 
 MAINTAINER Team Aruha, team-aruha@zalando.de
 


### PR DESCRIPTION
# Update openjdk base image to 1.8.0-191-19

## Description
Use the latest openjdk base image

## Review
- [ ] Tests
- [ ] Documentation
