### PR TITLE
Aruha-2121 Handle UnableProcessException properly in PostSubscriptionController

### DIFF
--- a/src/main/java/org/zalando/nakadi/controller/PostSubscriptionController.java
+++ b/src/main/java/org/zalando/nakadi/controller/PostSubscriptionController.java
@@ -19,6 +19,7 @@ import org.zalando.nakadi.exceptions.runtime.NoSuchEventTypeException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchSubscriptionException;
 import org.zalando.nakadi.exceptions.runtime.SubscriptionCreationDisabledException;
 import org.zalando.nakadi.exceptions.runtime.SubscriptionUpdateConflictException;
+import org.zalando.nakadi.exceptions.runtime.UnableProcessException;
 import org.zalando.nakadi.exceptions.runtime.UnprocessableSubscriptionException;
 import org.zalando.nakadi.exceptions.runtime.ValidationException;
 import org.zalando.nakadi.service.FeatureToggleService;
@@ -52,7 +53,8 @@ public class PostSubscriptionController {
             throws ValidationException,
             UnprocessableSubscriptionException,
             InconsistentStateException,
-            SubscriptionCreationDisabledException {
+            SubscriptionCreationDisabledException,
+            UnableProcessException {
         if (errors.hasErrors()) {
             throw new ValidationException(errors);
         }

--- a/src/main/java/org/zalando/nakadi/controller/advice/PostSubscriptionExceptionHandler.java
+++ b/src/main/java/org/zalando/nakadi/controller/advice/PostSubscriptionExceptionHandler.java
@@ -9,6 +9,7 @@ import org.zalando.nakadi.exceptions.runtime.NakadiBaseException;
 import org.zalando.nakadi.exceptions.runtime.SubscriptionCreationDisabledException;
 import org.zalando.nakadi.exceptions.runtime.SubscriptionUpdateConflictException;
 import org.zalando.nakadi.exceptions.runtime.TooManyPartitionsException;
+import org.zalando.nakadi.exceptions.runtime.UnableProcessException;
 import org.zalando.nakadi.exceptions.runtime.UnprocessableSubscriptionException;
 import org.zalando.nakadi.exceptions.runtime.WrongInitialCursorsException;
 import org.zalando.problem.Problem;
@@ -42,7 +43,8 @@ public class PostSubscriptionExceptionHandler implements AdviceTrait {
     @ExceptionHandler({
             WrongInitialCursorsException.class,
             TooManyPartitionsException.class,
-            UnprocessableSubscriptionException.class})
+            UnprocessableSubscriptionException.class,
+            UnableProcessException.class})
     public ResponseEntity<Problem> handleUnprocessableSubscription(final NakadiBaseException exception,
                                                                    final NativeWebRequest request) {
         LOG.debug(exception.getMessage());

--- a/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionService.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionService.java
@@ -36,6 +36,7 @@ import org.zalando.nakadi.exceptions.runtime.RepositoryProblemException;
 import org.zalando.nakadi.exceptions.runtime.ServiceTemporarilyUnavailableException;
 import org.zalando.nakadi.exceptions.runtime.SubscriptionUpdateConflictException;
 import org.zalando.nakadi.exceptions.runtime.TooManyPartitionsException;
+import org.zalando.nakadi.exceptions.runtime.UnableProcessException;
 import org.zalando.nakadi.exceptions.runtime.WrongInitialCursorsException;
 import org.zalando.nakadi.repository.EventTypeRepository;
 import org.zalando.nakadi.repository.TopicRepository;
@@ -118,7 +119,7 @@ public class SubscriptionService {
     public Subscription createSubscription(final SubscriptionBase subscriptionBase, final Optional<String> user)
             throws TooManyPartitionsException, RepositoryProblemException, DuplicatedSubscriptionException,
             NoSuchEventTypeException, InconsistentStateException, WrongInitialCursorsException,
-            DbWriteOperationsBlockedException {
+            DbWriteOperationsBlockedException, UnableProcessException, ServiceTemporarilyUnavailableException {
         if (featureToggleService.isFeatureEnabled(FeatureToggleService.Feature.DISABLE_DB_WRITE_OPERATIONS)) {
             throw new DbWriteOperationsBlockedException("Cannot create subscription: write operations on DB " +
                     "are blocked by feature flag.");

--- a/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionValidationService.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionValidationService.java
@@ -17,6 +17,7 @@ import org.zalando.nakadi.exceptions.runtime.RepositoryProblemException;
 import org.zalando.nakadi.exceptions.runtime.ServiceTemporarilyUnavailableException;
 import org.zalando.nakadi.exceptions.runtime.SubscriptionUpdateConflictException;
 import org.zalando.nakadi.exceptions.runtime.TooManyPartitionsException;
+import org.zalando.nakadi.exceptions.runtime.UnableProcessException;
 import org.zalando.nakadi.exceptions.runtime.WrongInitialCursorsException;
 import org.zalando.nakadi.exceptions.runtime.WrongStreamParametersException;
 import org.zalando.nakadi.repository.EventTypeRepository;
@@ -60,7 +61,8 @@ public class SubscriptionValidationService {
 
     public void validateSubscription(final SubscriptionBase subscription)
             throws TooManyPartitionsException, RepositoryProblemException, NoSuchEventTypeException,
-            InconsistentStateException, WrongInitialCursorsException {
+            InconsistentStateException, WrongInitialCursorsException, UnableProcessException,
+            ServiceTemporarilyUnavailableException {
 
         // check that all event-types exist
         final Map<String, Optional<EventType>> eventTypesOrNone = getSubscriptionEventTypesOrNone(subscription);


### PR DESCRIPTION
Also, improve method signature when UnableProcessException can be
thrown

# Handle UnableProcessException properly in PostSubscriptionController

> Zalando ticket : ARUHA-2121

## Description
Also, improve method signature when UnableProcessException can be
thrown
