### PR TITLE
Fixed check if keep alive limit is reached for indefinitely configured limit

### DIFF
--- a/src/main/java/org/zalando/nakadi/service/subscription/StreamParameters.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/StreamParameters.java
@@ -61,7 +61,7 @@ public class StreamParameters {
                         .filter(timeout -> timeout > 0 && timeout <= EventStreamConfig.MAX_STREAM_TIMEOUT)
                         .orElse((long) EventStreamConfig.generateDefaultStreamTimeout()));
         this.maxUncommittedMessages = userParameters.getMaxUncommittedEvents().orElse(10);
-        this.batchKeepAliveIterations = userParameters.getStreamKeepAliveLimit();
+        this.batchKeepAliveIterations = userParameters.getStreamKeepAliveLimit().filter(v -> v != 0);
         this.partitions = userParameters.getPartitions();
         this.consumingClient = consumingClient;
 
@@ -78,12 +78,12 @@ public class StreamParameters {
         return streamLimitEvents.map(v -> Math.max(0, Math.min(limit, v - sentSoFar))).orElse(limit);
     }
 
-    public boolean isStreamLimitReached(final long commitedEvents) {
-        return streamLimitEvents.map(v -> v <= commitedEvents).orElse(false);
+    public boolean isStreamLimitReached(final long committedEvents) {
+        return streamLimitEvents.map(v -> v <= committedEvents).orElse(false);
     }
 
     public boolean isKeepAliveLimitReached(final IntStream keepAlive) {
-        return batchKeepAliveIterations.map(it -> keepAlive.allMatch(v -> v >= it) && it > 0).orElse(false);
+        return batchKeepAliveIterations.map(it -> keepAlive.allMatch(v -> v >= it)).orElse(false);
     }
 
     public Client getConsumingClient() {

--- a/src/main/java/org/zalando/nakadi/service/subscription/StreamParameters.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/StreamParameters.java
@@ -83,7 +83,7 @@ public class StreamParameters {
     }
 
     public boolean isKeepAliveLimitReached(final IntStream keepAlive) {
-        return batchKeepAliveIterations.map(it -> keepAlive.allMatch(v -> v >= it)).orElse(false);
+        return batchKeepAliveIterations.map(it -> keepAlive.allMatch(v -> v >= it) && it > 0).orElse(false);
     }
 
     public Client getConsumingClient() {

--- a/src/test/java/org/zalando/nakadi/service/subscription/StreamParametersTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/StreamParametersTest.java
@@ -71,6 +71,14 @@ public class StreamParametersTest {
     }
 
     @Test
+    public void checkIsKeepAliveLimitReachedIndefinitely() throws Exception {
+        final StreamParameters streamParameters = createStreamParameters(1, null, 0, null, 0, 0, 0, mock(Client.class));
+
+        assertThat(streamParameters.isKeepAliveLimitReached(IntStream.of(5, 7, 6, 12)), is(false));
+        assertThat(streamParameters.isKeepAliveLimitReached(IntStream.of(5, 7, 4, 12)), is(false));
+    }
+
+    @Test
     public void checkGetMessagesAllowedToSend() throws Exception {
         final StreamParameters streamParameters = createStreamParameters(1, 200L, 0, null, null, 0, 0,
                 mock(Client.class));


### PR DESCRIPTION
# Interpret `0` as indefinitely stream “keep-alives”

> Zalando ticket : ARUHA-2159

## Description
If a stream is configured with `stream_keep_alive_limit` as `0` the related check `isKeepAliveLimitReached` always returned `true` instead of `false`.

## Review
- [x] Tests
- [ ] Documentation

## Deployment Notes
Nothing to add here
