### PR TITLE
Cache admins and don't check VIEW for publish endpoint

### DIFF
--- a/src/main/java/org/zalando/nakadi/controller/EventPublishingController.java
+++ b/src/main/java/org/zalando/nakadi/controller/EventPublishingController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.zalando.nakadi.domain.EventPublishResult;
 import org.zalando.nakadi.domain.EventPublishingStatus;
-import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.exceptions.runtime.AccessDeniedException;
 import org.zalando.nakadi.exceptions.runtime.BlockedException;
 import org.zalando.nakadi.exceptions.runtime.EventTypeTimeoutException;
@@ -25,10 +24,8 @@ import org.zalando.nakadi.exceptions.runtime.ServiceTemporarilyUnavailableExcept
 import org.zalando.nakadi.metrics.EventTypeMetricRegistry;
 import org.zalando.nakadi.metrics.EventTypeMetrics;
 import org.zalando.nakadi.security.Client;
-import org.zalando.nakadi.service.AuthorizationValidator;
 import org.zalando.nakadi.service.BlacklistService;
 import org.zalando.nakadi.service.EventPublisher;
-import org.zalando.nakadi.service.EventTypeService;
 import org.zalando.nakadi.service.NakadiKpiPublisher;
 
 import java.util.concurrent.TimeUnit;
@@ -49,8 +46,6 @@ public class EventPublishingController {
     private final BlacklistService blacklistService;
     private final NakadiKpiPublisher nakadiKpiPublisher;
     private final String kpiBatchPublishedEventType;
-    private final EventTypeService eventTypeService;
-    private final AuthorizationValidator authorizationValidator;
 
     @Autowired
     public EventPublishingController(final EventPublisher publisher,
@@ -58,16 +53,12 @@ public class EventPublishingController {
                                      final BlacklistService blacklistService,
                                      final NakadiKpiPublisher nakadiKpiPublisher,
                                      @Value("${nakadi.kpi.event-types.nakadiBatchPublished}")
-                                         final String kpiBatchPublishedEventType,
-                                     final AuthorizationValidator authorizationValidator,
-                                     final EventTypeService eventTypeService) {
+                                         final String kpiBatchPublishedEventType) {
         this.publisher = publisher;
         this.eventTypeMetricRegistry = eventTypeMetricRegistry;
         this.blacklistService = blacklistService;
         this.nakadiKpiPublisher = nakadiKpiPublisher;
         this.kpiBatchPublishedEventType = kpiBatchPublishedEventType;
-        this.eventTypeService = eventTypeService;
-        this.authorizationValidator = authorizationValidator;
     }
 
     @RequestMapping(value = "/event-types/{eventTypeName}/events", method = POST)
@@ -78,9 +69,6 @@ public class EventPublishingController {
             throws AccessDeniedException, BlockedException, ServiceTemporarilyUnavailableException,
             InternalNakadiException, EventTypeTimeoutException, NoSuchEventTypeException {
         LOG.trace("Received event {} for event type {}", eventsAsString, eventTypeName);
-
-        final EventType eventType = eventTypeService.get(eventTypeName);
-        authorizationValidator.authorizeEventTypeView(eventType);
 
         final EventTypeMetrics eventTypeMetrics = eventTypeMetricRegistry.metricsFor(eventTypeName);
 

--- a/src/main/java/org/zalando/nakadi/service/AdminService.java
+++ b/src/main/java/org/zalando/nakadi/service/AdminService.java
@@ -53,12 +53,16 @@ public class AdminService {
         this.authorizationService = authorizationService;
         this.featureToggleService = featureToggleService;
         this.nakadiSettings = nakadiSettings;
-        this.resourceCache = CacheBuilder.newBuilder().expireAfterWrite(1, TimeUnit.MINUTES).build();
+        this.resourceCache = CacheBuilder.newBuilder().expireAfterWrite(5, TimeUnit.MINUTES).build();
         this.auditLogPublisher = auditLogPublisher;
     }
 
     public List<Permission> getAdmins() {
-        return addDefaultAdmin(authorizationDbRepository.listAdmins());
+        try {
+            return addDefaultAdmin(resourceCache.get(ADMIN_RESOURCE, authorizationDbRepository::listAdmins));
+        } catch (ExecutionException e) {
+            return addDefaultAdmin(authorizationDbRepository.listAdmins());
+        }
     }
 
     public void updateAdmins(final List<Permission> newAdmins)

--- a/src/test/java/org/zalando/nakadi/controller/EventPublishingControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventPublishingControllerTest.java
@@ -25,10 +25,8 @@ import org.zalando.nakadi.metrics.EventTypeMetricRegistry;
 import org.zalando.nakadi.metrics.EventTypeMetrics;
 import org.zalando.nakadi.plugin.api.authz.AuthorizationService;
 import org.zalando.nakadi.security.ClientResolver;
-import org.zalando.nakadi.service.AuthorizationValidator;
 import org.zalando.nakadi.service.BlacklistService;
 import org.zalando.nakadi.service.EventPublisher;
-import org.zalando.nakadi.service.EventTypeService;
 import org.zalando.nakadi.service.NakadiKpiPublisher;
 import org.zalando.nakadi.utils.TestUtils;
 
@@ -75,8 +73,6 @@ public class EventPublishingControllerTest {
     private NakadiKpiPublisher kpiPublisher;
     private BlacklistService blacklistService;
     private AuthorizationService authorizationService;
-    private EventTypeService eventTypeService;
-    private AuthorizationValidator authorizationValidator;
 
     @Before
     public void setUp() {
@@ -86,8 +82,6 @@ public class EventPublishingControllerTest {
         kpiPublisher = mock(NakadiKpiPublisher.class);
         settings = mock(SecuritySettings.class);
         authorizationService = mock(AuthorizationService.class);
-        eventTypeService = mock(EventTypeService.class);
-        authorizationValidator = mock(AuthorizationValidator.class);
         when(authorizationService.getSubject()).thenReturn(Optional.of(() ->  "adminClientId"));
         when(settings.getAuthMode()).thenReturn(OFF);
         when(settings.getAdminClientId()).thenReturn("adminClientId");
@@ -97,7 +91,7 @@ public class EventPublishingControllerTest {
 
         final EventPublishingController controller =
                 new EventPublishingController(publisher, eventTypeMetricRegistry, blacklistService, kpiPublisher,
-                        "kpiEventTypeName", authorizationValidator, eventTypeService);
+                        "kpiEventTypeName");
 
         mockMvc = standaloneSetup(controller)
                 .setMessageConverters(new StringHttpMessageConverter(), TestUtils.JACKSON_2_HTTP_MESSAGE_CONVERTER)


### PR DESCRIPTION
## https://jira.zalando.net/browse/ARUHA-2187

Cache when fetching admins from the database and don't check for `VIEW` operation on publish event endpoint.

## Review
- [ ] Tests
- [ ] Documentation