### PR TITLE
Upgrade library versions as much as we can

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import java.util.concurrent.TimeUnit
 
 buildscript {
     ext {
-        springBootVersion = '1.5.15.RELEASE'
+        springBootVersion = '1.5.20.RELEASE'
     }
 
     repositories {
@@ -84,8 +84,10 @@ findbugs {
 dependencies {
     ext {
         dropwizardVersion = '3.1.3'
-        curatorVersion = '4.0.1'
-        zookeeperVersion = '3.4.10'
+        curatorVersion = '4.2.0'
+        zookeeperVersion = '3.4.14'
+        jacksonVersion = '2.9.8'
+        springFrameworkVersion = '4.3.23.RELEASE'
     }
     // Override spring-boot BOM versions
     ext['json.version'] = '20180130'
@@ -98,13 +100,13 @@ dependencies {
         exclude module: 'log4j-over-slf4j'
         exclude module: 'spring-boot-starter-tomcat'
     }
-    compile "org.springframework:spring-context"
-    compile "org.springframework:spring-web"
-    compile "org.springframework:spring-webmvc"
+    compile "org.springframework:spring-context:$springFrameworkVersion"
+    compile "org.springframework:spring-web:$springFrameworkVersion"
+    compile "org.springframework:spring-webmvc:$springFrameworkVersion"
     compile "org.springframework.boot:spring-boot-starter-jetty"
 
     // oauth
-    compile('org.springframework.security.oauth:spring-security-oauth2') {
+    compile('org.springframework.security.oauth:spring-security-oauth2:2.3.5.RELEASE') {
         exclude module: 'spring-beans'
         exclude module: 'spring-core'
         exclude module: 'spring-context'
@@ -131,7 +133,7 @@ dependencies {
     compile 'org.zalando:jackson-datatype-problem:0.22.0'
     compile 'org.zalando:problem:0.22.0'
     compile 'org.zalando:problem-spring-web:0.23.0'
-    compile 'com.google.guava:guava:25.1-jre'
+    compile 'com.google.guava:guava:27.1-jre'
     compile 'org.slf4j:slf4j-log4j12'
     compile "io.dropwizard.metrics:metrics-core:$dropwizardVersion"
     compile "com.ryantenney.metrics:metrics-spring:$dropwizardVersion"
@@ -155,16 +157,16 @@ dependencies {
     compile('com.github.everit-org.json-schema:org.everit.json.schema:1.8.0') {
         exclude module: "json"
     }
-    compile("com.fasterxml.jackson.datatype:jackson-datatype-json-org") {
+    compile("com.fasterxml.jackson.datatype:jackson-datatype-json-org:$jacksonVersion") {
         exclude module: "json"
     }
-    compile "com.fasterxml.jackson.core:jackson-annotations"
-    compile "com.fasterxml.jackson.core:jackson-core"
-    compile "com.fasterxml.jackson.core:jackson-databind"
-    compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-    compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
-    compile "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-    compile "com.fasterxml.jackson.module:jackson-module-afterburner"
+    compile "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
+    compile "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
+    compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
+    compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
+    compile "com.fasterxml.jackson.datatype:jackson-datatype-joda:$jacksonVersion"
+    compile "com.fasterxml.jackson.module:jackson-module-afterburner:$jacksonVersion"
     compile 'org.zalando:twintip-spring-web:1.1.0'
     compile 'org.json:json:20180130'
 


### PR DESCRIPTION
https://jira.zalando.net/browse/ARUHA-2262

Some dependencies could not be easily updated due to major version
incompatibility. Once we proceed with spring boot update we should
cover most of the remaining threats.