### PR TITLE
Set health check interval to 10 ms (default 500ms) trigger circuit breaker

### DIFF
--- a/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -103,6 +103,7 @@ public class KafkaTopicRepositoryTest {
 
     @SuppressWarnings("unchecked")
     public KafkaTopicRepositoryTest() {
+        System.setProperty("hystrix.command.1.metrics.healthSnapshot.intervalInMilliseconds", "10");
         kafkaProducer = mock(KafkaProducer.class);
         when(kafkaProducer.partitionsFor(anyString())).then(
                 invocation -> partitionsOfTopic((String) invocation.getArguments()[0])
@@ -327,7 +328,7 @@ public class KafkaTopicRepositoryTest {
         });
 
         final List<BatchItem> batches = new LinkedList<>();
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 100; i++) {
             try {
                 final BatchItem batchItem = new BatchItem("{}",
                         BatchItem.EmptyInjectionConfiguration.build(1, true),


### PR DESCRIPTION
# One-line summary
Set health check interval to 10 ms (default 500ms) to trigger circuit breaker.

Fix https://github.com/zalando/nakadi/issues/741

## Description
Health check emits events once in a fixed period of time (see com.netflix.hystrix.metric.consumer.HealthCountsStream for more info). Default period is 500 ms which is enough for all 1000 batch items to be sent without health check being emitted. Hence the test `whenKafkaPublishTimeoutThenCircuitIsOpened` fails. 

## Review
- [ ] Tests
- [ ] Documentation

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
