### PR TITLE
Fix kafka circuit breaker to switch to open state multiple times

### DIFF
--- a/src/main/java/org/zalando/nakadi/repository/kafka/HystrixKafkaCircuitBreaker.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/HystrixKafkaCircuitBreaker.java
@@ -44,9 +44,9 @@ public class HystrixKafkaCircuitBreaker {
                 hystrixCommandMetrics);
         concurrentExecutionCount = new AtomicInteger();
     }
-
-    public boolean allowRequest() {
-        return circuitBreaker.allowRequest();
+    
+    public boolean attemptExecution() {
+        return circuitBreaker.attemptExecution();
     }
 
     public void markStart() {
@@ -66,6 +66,7 @@ public class HystrixKafkaCircuitBreaker {
         concurrentExecutionCount.decrementAndGet();
         HystrixThreadEventStream.getInstance()
                 .executionDone(ExecutionResult.from(HystrixEventType.FAILURE), commandKey, threadPoolKey);
+        circuitBreaker.markNonSuccess();
     }
 
     public String getMetrics() {

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -242,7 +242,7 @@ public class KafkaTopicRepository implements TopicRepository {
                 item.setStep(EventPublishingStep.PUBLISHING);
                 final HystrixKafkaCircuitBreaker circuitBreaker = circuitBreakers.computeIfAbsent(
                         item.getBrokerId(), brokerId -> new HystrixKafkaCircuitBreaker(brokerId));
-                if (circuitBreaker.allowRequest()) {
+                if (circuitBreaker.attemptExecution()) {
                     sendFutures.put(item, publishItem(producer, topicId, item, circuitBreaker));
                 } else {
                     shortCircuited++;

--- a/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -343,7 +343,7 @@ public class KafkaTopicRepositoryTest {
         assertThat(lastItem.getResponse().getDetail(), equalTo("short circuited"));
     }
 
-    private List<BatchItem> setupResponseAndSendBatches(Exception e) throws InterruptedException {
+    private List<BatchItem> setupResponseAndSendBatches(final Exception e) throws InterruptedException {
         when(kafkaProducer.send(any(), any())).thenAnswer(invocation -> {
             final Callback callback = (Callback) invocation.getArguments()[1];
             // null checking since `when(kafkaProducer.send(any(), any()))` triggers stub with null arguments

--- a/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -105,6 +105,8 @@ public class KafkaTopicRepositoryTest {
     @SuppressWarnings("unchecked")
     public KafkaTopicRepositoryTest() {
         System.setProperty("hystrix.command.1.metrics.healthSnapshot.intervalInMilliseconds", "10");
+        System.setProperty("hystrix.command.1.metrics.rollingStats.timeInMilliseconds", "500");
+        System.setProperty("hystrix.command.1.circuitBreaker.sleepWindowInMilliseconds", "500");
         kafkaProducer = mock(KafkaProducer.class);
         when(kafkaProducer.partitionsFor(anyString())).then(
                 invocation -> partitionsOfTopic((String) invocation.getArguments()[0])
@@ -364,8 +366,9 @@ public class KafkaTopicRepositoryTest {
                         Collections.emptyList());
                 batchItem.setPartition("1");
                 batches.add(batchItem);
-                kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(), ImmutableList.of(batchItem));
-            } catch (final EventPublishingException ex) {
+	            TimeUnit.MILLISECONDS.sleep(5);
+	            kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(), ImmutableList.of(batchItem));
+            } catch (final EventPublishingException | InterruptedException ex) {
             }
         }
 


### PR DESCRIPTION
# One-line summary
Fix kafka circuit breaker to switch to open state multiple times.

## Description
Once transit to `Open` state KafkaCircuitBreaker will preserve this state forever.  

There are two problems:
- `HystrixKafkaCircuitBreaker` doesn't update `circuitOpened` on fail. This causes `com.netflix.hystrix.HystrixCircuitBreaker.HystrixCircuitBreakerImpl#isAfterSleepWindow` always passes and `allowRequest` will always return true after the window.
Fixed by adding `circuitBreaker.markNonSuccess();`
- `KafkaTopicRepository` uses `allowRequest`. This is the reason why the circuit breaker will never transit from `Open` to `HalfOpen` state and from `HalfOpen` to `Close`. Fixed by using `attemptExecution` instead.

To reproduce the issue checkout the branch, revert changes in `HystrixKafkaCircuitBreaker` and `KafkaTopicRepository` and run `KafkaTopicRepositoryTest#whenKafkaPublishTimeoutThenCircuitIsOpened`. 

Relates to https://github.com/zalando/nakadi/issues/741:
It is better to use shrinked health check interval instead of thread sleep because current implementation takes 15 seconds to run tests. It can be fixed after merge of #741 to master.

Relates to #1037:
 I would prefer to write a separate test on this issue, but it is a lot of redundant and misleading code since `KafkaTopicRepositoryTest` uses a shared circuit. So I crammed the circuit breaker's state test to the existing test.

## Review
- [ ] Tests
- [ ] Documentation

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
