### PR TITLE
Detect changes to ArraySchema

### DIFF
--- a/src/main/java/org/zalando/nakadi/validation/schema/diff/SchemaDiff.java
+++ b/src/main/java/org/zalando/nakadi/validation/schema/diff/SchemaDiff.java
@@ -43,6 +43,11 @@ public class SchemaDiff {
             return;
         }
 
+        if (originalIn == null) {
+            state.addChange(SCHEMA_REMOVED);
+            return;
+        }
+
         final Schema original;
         final Schema update;
         if (!originalIn.getClass().equals(updateIn.getClass())) {

--- a/src/test/resources/org/zalando/nakadi/validation/invalid-schema-evolution-examples.json
+++ b/src/test/resources/org/zalando/nakadi/validation/invalid-schema-evolution-examples.json
@@ -610,5 +610,41 @@
       }
     },
     "errors": ["TYPE_CHANGED #/additionalItems"]
+  },
+  {
+    "description": "Detect changes from schema per item to all items",
+    "original_schema": {
+      "type": "array",
+      "items": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "update_schema": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "errors": ["SCHEMA_REMOVED #/items", "NUMBER_OF_ITEMS_CHANGED #/"]
+  },
+  {
+    "description": "Detect changes from all items schema to per item",
+    "original_schema": {
+      "type": "array",
+      "items": {
+          "type": "string"
+        }
+    },
+    "update_schema": {
+      "type": "array",
+      "items": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "errors": ["SCHEMA_REMOVED #/items", "NUMBER_OF_ITEMS_CHANGED #/"]
   }
 ]


### PR DESCRIPTION
https://jira.zalando.net/browse/ARUHA-2282

This fixes a NPE changing an ArraySchema through generalization: an
array that used to define schemas for each item specifically now has a
single schema for all items.

We also added tests for the other way around: a schema that used to
have a single definition for all items now has a per item schema.
