### PR TITLE
Add default charset to UTF-8 for incoming messages

### DIFF
--- a/src/main/java/org/zalando/nakadi/config/WebConfig.java
+++ b/src/main/java/org/zalando/nakadi/config/WebConfig.java
@@ -23,6 +23,7 @@ import org.zalando.nakadi.util.FlowIdRequestFilter;
 import org.zalando.nakadi.util.GzipBodyRequestFilter;
 
 import javax.servlet.Filter;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 @Configuration
@@ -68,7 +69,7 @@ public class WebConfig extends WebMvcConfigurationSupport {
 
     @Override
     protected void configureMessageConverters(final List<HttpMessageConverter<?>> converters) {
-        final StringHttpMessageConverter stringConverter = new StringHttpMessageConverter();
+        final StringHttpMessageConverter stringConverter = new StringHttpMessageConverter(StandardCharsets.UTF_8);
         stringConverter.setWriteAcceptCharset(false);
 
         converters.add(new ByteArrayHttpMessageConverter());


### PR DESCRIPTION
Fixes #1065
# Unicode characters are received corrupted if a default "application/json" content type is set

## Description
The change to the default charset of UTF-8 should support unicode symbols in the incoming messages

## Review
- [ ] Tests
- [ ] Documentation

## Deployment Notes
As per developer's recommendations
