### PR TITLE
Check old authorization attributes when updating

### DIFF
--- a/src/main/java/org/zalando/nakadi/service/AuthorizationValidator.java
+++ b/src/main/java/org/zalando/nakadi/service/AuthorizationValidator.java
@@ -226,6 +226,7 @@ public class AuthorizationValidator {
             return;
         }
 
+        validateAuthorization(oldValue);
         validateAuthorization(newValue);
     }
 }

--- a/src/main/java/org/zalando/nakadi/service/AuthorizationValidator.java
+++ b/src/main/java/org/zalando/nakadi/service/AuthorizationValidator.java
@@ -222,11 +222,10 @@ public class AuthorizationValidator {
                     "Changing authorization object to `null` is not possible due to existing one");
         }
 
-        if (oldAuth != null && oldAuth.equals(newAuth)) {
+        if (oldAuth != null) {
             return;
         }
 
-        validateAuthorization(oldValue);
         validateAuthorization(newValue);
     }
 }


### PR DESCRIPTION
Check that the attributes (and hence the admin `*`, `*` is checked for updates too).

## Description
Right now, it is not checked for updates on event-types and subscriptions that the admin doesn't contain wildcard.