### PR TITLE
reduced retention time

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,7 +39,7 @@ nakadi:
   authz.warnAllDataAccessMessage: "Data access warning"
   topic:
     min:
-      retentionMs: 86400000 # 1 days
+      retentionMs: 10800000 # 3 hours
     max:
       partitionNum: 8
       retentionMs: 345600000 # 4 days
@@ -47,7 +47,7 @@ nakadi:
       partitionNum: 1
       replicaFactor: 1
       retentionMs: 172800000 # 2 days
-      rotationMs: 86400000 # 1 day
+      rotationMs: 10800000 # 3 hours
     compacted:
       rotationMs: 10800000 # 3 hours
       segmentBytes: 1073741824 # 1 GB

--- a/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
@@ -822,12 +822,12 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
     @Test
     public void whenPostOptionsRetentionTimeSmallerThanMin() throws Exception {
         final EventType defaultEventType = buildDefaultEventType();
-        defaultEventType.getOptions().setRetentionTime(86399999L);
+        defaultEventType.getOptions().setRetentionTime(1079999L);
 
         postEventType(defaultEventType)
                 .andExpect(status().is4xxClientError())
                 .andExpect(content().string(new StringContains(
-                        "Field \\\"options.retention_time\\\" can not be less than 86400000")));
+                        "Field \\\"options.retention_time\\\" can not be less than 10800000")));
     }
 
     @Test

--- a/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
@@ -61,7 +61,7 @@ import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 
 public class EventTypeControllerTestCase {
 
-    protected static final long TOPIC_RETENTION_MIN_MS = 86400000;
+    protected static final long TOPIC_RETENTION_MIN_MS = 10800000;
     protected static final long TOPIC_RETENTION_MAX_MS = 345600000;
     protected static final long TOPIC_RETENTION_TIME_MS = 172800000;
     protected static final int NAKADI_SEND_TIMEOUT = 10000;

--- a/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
+++ b/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
@@ -48,7 +48,7 @@ import static org.zalando.nakadi.utils.TestUtils.checkKPIEventSubmitted;
 public class EventTypeServiceTest {
 
     private static final String KPI_ET_LOG_EVENT_TYPE = "et-log";
-    protected static final long TOPIC_RETENTION_MIN_MS = 86400000;
+    protected static final long TOPIC_RETENTION_MIN_MS = 10800000;
     protected static final long TOPIC_RETENTION_MAX_MS = 345600000;
 
     private final Enrichment enrichment = mock(Enrichment.class);


### PR DESCRIPTION
# One-line summary

> Zalando ticket: ARUHA-2439

With the new requirements in Nakadi SQL joins there is a need to reduce the retention time in Nakadi for an event type. This PR reduces the retention time from 1 day to 3 hours. 

