### PR TITLE
Allow admins to delete event types

### DIFF
--- a/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -67,6 +67,8 @@ public class KafkaRepositoryAT extends BaseAT {
     private static final String DEFAULT_ADMIN_VALUE = "nakadi";
     private static final String DEFAULT_WARN_ALL_DATA_ACCESS_MESSAGE = "";
     private static final String DEFAULT_WARN_LOG_COMPACTION_MESSAGE = "";
+    private static final String DEFAULT_EVENT_TYPE_DELETABLE_SUBSCRIPTION_OWNING_APPLICATION = "nakadi_archiver";
+    private static final String DEFAULT_EVENT_TYPE_DELETABLE_SUBSCRIPTION_CONSUMER_GROUP = "nakadi_to_s3";
 
     private NakadiSettings nakadiSettings;
     private KafkaSettings kafkaSettings;
@@ -93,7 +95,9 @@ public class KafkaRepositoryAT extends BaseAT {
                 DEFAULT_ADMIN_DATA_TYPE,
                 DEFAULT_ADMIN_VALUE,
                 DEFAULT_WARN_ALL_DATA_ACCESS_MESSAGE,
-                DEFAULT_WARN_LOG_COMPACTION_MESSAGE);
+                DEFAULT_WARN_LOG_COMPACTION_MESSAGE,
+                DEFAULT_EVENT_TYPE_DELETABLE_SUBSCRIPTION_OWNING_APPLICATION,
+                DEFAULT_EVENT_TYPE_DELETABLE_SUBSCRIPTION_CONSUMER_GROUP);
 
         kafkaSettings = new KafkaSettings(KAFKA_REQUEST_TIMEOUT, KAFKA_BATCH_SIZE, KAFKA_BUFFER_MEMORY,
                 KAFKA_LINGER_MS, KAFKA_ENABLE_AUTO_COMMIT, KAFKA_MAX_REQUEST_SIZE,

--- a/src/main/java/org/zalando/nakadi/config/NakadiSettings.java
+++ b/src/main/java/org/zalando/nakadi/config/NakadiSettings.java
@@ -23,6 +23,8 @@ public class NakadiSettings {
     private final AuthorizationAttribute defaultAdmin;
     private final String warnAllDataAccessMessage;
     private final String logCompactionWarnMessage;
+    private final String deletableSubscriptionOwningApplication;
+    private final String deletableSubscriptionConsumerGroup;
 
     @Autowired
     public NakadiSettings(@Value("${nakadi.topic.max.partitionNum}") final int maxTopicPartitionCount,
@@ -39,7 +41,11 @@ public class NakadiSettings {
                           @Value("${nakadi.admin.default.dataType}") final String defaultAdminDataType,
                           @Value("${nakadi.admin.default.value}") final String defaultAdminValue,
                           @Value("${nakadi.authz.warnAllDataAccessMessage}") final String warnAllDataAccessMessage,
-                          @Value("${nakadi.topic.compacted.warnMessage}") final String logCompactionWarnMessage) {
+                          @Value("${nakadi.topic.compacted.warnMessage}") final String logCompactionWarnMessage,
+                          @Value("${nakadi.eventType.deletableSubscription.owningApplication}")
+                              final String deletableSubscriptionOwningApplication,
+                          @Value("${nakadi.eventType.deletableSubscription.consumerGroup}")
+                              final String deletableSubscriptionConsumerGroup) {
         this.maxTopicPartitionCount = maxTopicPartitionCount;
         this.defaultTopicPartitionCount = defaultTopicPartitionCount;
         this.defaultTopicReplicaFactor = defaultTopicReplicaFactor;
@@ -54,6 +60,8 @@ public class NakadiSettings {
         this.defaultAdmin = new ResourceAuthorizationAttribute(defaultAdminDataType, defaultAdminValue);
         this.warnAllDataAccessMessage = warnAllDataAccessMessage;
         this.logCompactionWarnMessage = logCompactionWarnMessage;
+        this.deletableSubscriptionOwningApplication = deletableSubscriptionOwningApplication;
+        this.deletableSubscriptionConsumerGroup = deletableSubscriptionConsumerGroup;
     }
 
     public int getDefaultTopicPartitionCount() {
@@ -110,5 +118,13 @@ public class NakadiSettings {
 
     public String getLogCompactionWarnMessage() {
         return logCompactionWarnMessage;
+    }
+
+    public String getDeletableSubscriptionOwningApplication() {
+        return deletableSubscriptionOwningApplication;
+    }
+
+    public String getDeletableSubscriptionConsumerGroup() {
+        return deletableSubscriptionConsumerGroup;
     }
 }

--- a/src/main/java/org/zalando/nakadi/repository/db/SubscriptionDbRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/db/SubscriptionDbRepository.java
@@ -148,11 +148,7 @@ public class SubscriptionDbRepository extends AbstractDbRepository {
         }
 
         queryBuilder.append(" ORDER BY s_subscription_object->>'created_at' DESC LIMIT ? OFFSET ? ");
-        if (limit >= 0) {
-            params.add(limit);
-        } else {
-            params.add("NULL");
-        }
+        params.add(limit);
         params.add(offset);
         try {
             return jdbcTemplate.query(queryBuilder.toString(), params.toArray(), rowMapper);

--- a/src/main/java/org/zalando/nakadi/repository/db/SubscriptionDbRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/db/SubscriptionDbRepository.java
@@ -148,7 +148,11 @@ public class SubscriptionDbRepository extends AbstractDbRepository {
         }
 
         queryBuilder.append(" ORDER BY s_subscription_object->>'created_at' DESC LIMIT ? OFFSET ? ");
-        params.add(limit);
+        if (limit >= 0) {
+            params.add(limit);
+        } else {
+            params.add("NULL");
+        }
         params.add(offset);
         try {
             return jdbcTemplate.query(queryBuilder.toString(), params.toArray(), rowMapper);

--- a/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -342,13 +342,19 @@ public class EventTypeService {
     }
 
     private boolean hasNonDeletableSubscriptions(final String eventTypeName) {
-        final List<Subscription> subs = subscriptionRepository.listSubscriptions(
-                ImmutableSet.of(eventTypeName), Optional.empty(), 0, -1);
-        for (final Subscription sub : subs) {
-            if (!sub.getConsumerGroup().equals(nakadiSettings.getDeletableSubscriptionConsumerGroup())
-                    || !sub.getOwningApplication().equals(nakadiSettings.getDeletableSubscriptionOwningApplication())) {
-                return true;
+        int offset = 0;
+        List<Subscription> subs = subscriptionRepository.listSubscriptions(
+                ImmutableSet.of(eventTypeName), Optional.empty(), offset, 20);
+        while (!subs.isEmpty()) {
+            for (final Subscription sub : subs) {
+                if (!sub.getConsumerGroup().equals(nakadiSettings.getDeletableSubscriptionConsumerGroup())
+                        || !sub.getOwningApplication().equals(nakadiSettings.getDeletableSubscriptionOwningApplication())) {
+                    return true;
+                }
             }
+            offset += 20;
+            subs = subscriptionRepository.listSubscriptions(
+                    ImmutableSet.of(eventTypeName), Optional.empty(), offset, 20);
         }
         return false;
     }

--- a/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -348,7 +348,8 @@ public class EventTypeService {
         while (!subs.isEmpty()) {
             for (final Subscription sub : subs) {
                 if (!sub.getConsumerGroup().equals(nakadiSettings.getDeletableSubscriptionConsumerGroup())
-                        || !sub.getOwningApplication().equals(nakadiSettings.getDeletableSubscriptionOwningApplication())) {
+                        || !sub.getOwningApplication()
+                        .equals(nakadiSettings.getDeletableSubscriptionOwningApplication())) {
                     return true;
                 }
             }

--- a/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -71,6 +71,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import static org.zalando.nakadi.service.FeatureToggleService.Feature.DELETE_EVENT_TYPE_WITH_SUBSCRIPTIONS;
+import static org.zalando.nakadi.service.FeatureToggleService.Feature.EVENT_TYPE_DELETION_ONLY_ADMINS;
 import static org.zalando.nakadi.service.FeatureToggleService.Feature.FORCE_EVENT_TYPE_AUTHZ;
 
 @Component
@@ -249,7 +250,14 @@ public class EventTypeService {
             authorizationValidator.authorizeEventTypeView(eventType);
             authorizationValidator.authorizeEventTypeAdmin(eventType);
 
-            if (featureToggleService.isFeatureEnabled(DELETE_EVENT_TYPE_WITH_SUBSCRIPTIONS)) {
+            if (featureToggleService.isFeatureEnabled(EVENT_TYPE_DELETION_ONLY_ADMINS)) {
+                if (eventType.getAuthorization() == null || hasNonDeletableSubscriptions(eventType.getName())) {
+                    throw new AccessDeniedException(eventType.asResource());
+                }
+            }
+
+            if (featureToggleService.isFeatureEnabled(DELETE_EVENT_TYPE_WITH_SUBSCRIPTIONS)
+                    || featureToggleService.isFeatureEnabled(EVENT_TYPE_DELETION_ONLY_ADMINS)) {
                 topicsToDelete = deleteEventTypeWithSubscriptions(eventTypeName);
             } else {
                 topicsToDelete = deleteEventTypeIfNoSubscriptions(eventTypeName);
@@ -331,6 +339,18 @@ public class EventTypeService {
         final List<Subscription> subs = subscriptionRepository.listSubscriptions(
                 ImmutableSet.of(eventTypeName), Optional.empty(), 0, 1);
         return !subs.isEmpty();
+    }
+
+    private boolean hasNonDeletableSubscriptions(final String eventTypeName) {
+        final List<Subscription> subs = subscriptionRepository.listSubscriptions(
+                ImmutableSet.of(eventTypeName), Optional.empty(), 0, -1);
+        for (final Subscription sub : subs) {
+            if (!sub.getConsumerGroup().equals(nakadiSettings.getDeletableSubscriptionConsumerGroup())
+                    || !sub.getOwningApplication().equals(nakadiSettings.getDeletableSubscriptionOwningApplication())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public void update(final String eventTypeName,

--- a/src/main/java/org/zalando/nakadi/service/FeatureToggleService.java
+++ b/src/main/java/org/zalando/nakadi/service/FeatureToggleService.java
@@ -34,6 +34,7 @@ public interface FeatureToggleService {
         DISABLE_EVENT_TYPE_CREATION("disable_event_type_creation"),
         DISABLE_EVENT_TYPE_DELETION("disable_event_type_deletion"),
         DELETE_EVENT_TYPE_WITH_SUBSCRIPTIONS("delete_event_type_with_subscriptions"),
+        EVENT_TYPE_DELETION_ONLY_ADMINS("event_type_deletion_only_admins"),
         DISABLE_SUBSCRIPTION_CREATION("disable_subscription_creation"),
         REMOTE_TOKENINFO("remote_tokeninfo"),
         KPI_COLLECTION("kpi_collection"),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,9 @@ nakadi:
     dataType: service
     value: stups_nakadi
   authz.warnAllDataAccessMessage: "Data access warning"
+  eventType.deletableSubscription:
+    owningApplication: "nakadi_archiver"
+    consumerGroup: "nakadi_to_s3"
   topic:
     min:
       retentionMs: 10800000 # 3 hours

--- a/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
@@ -100,7 +100,7 @@ public class EventTypeControllerTestCase {
         final NakadiSettings nakadiSettings = new NakadiSettings(0, 0, 0, TOPIC_RETENTION_TIME_MS, 0, 60,
                 NAKADI_POLL_TIMEOUT, NAKADI_SEND_TIMEOUT, 0, NAKADI_EVENT_MAX_BYTES,
                 NAKADI_SUBSCRIPTION_MAX_PARTITIONS, "service", "nakadi", "I am warning you",
-                "I am warning you, even more");
+                "I am warning you, even more", "nakadi_archiver", "nakadi_to_s3");
         final PartitionsCalculator partitionsCalculator = new KafkaConfig().createPartitionsCalculator(
                 "t2.large", TestUtils.OBJECT_MAPPER, nakadiSettings);
         when(timelineService.getTopicRepository((Timeline) any())).thenReturn(topicRepository);

--- a/src/test/java/org/zalando/nakadi/service/EventPublisherTest.java
+++ b/src/test/java/org/zalando/nakadi/service/EventPublisherTest.java
@@ -75,7 +75,7 @@ public class EventPublisherTest {
     private final AuthorizationValidator authzValidator = mock(AuthorizationValidator.class);
     private final NakadiSettings nakadiSettings = new NakadiSettings(0, 0, 0, TOPIC_RETENTION_TIME_MS, 0, 60,
             NAKADI_POLL_TIMEOUT, NAKADI_SEND_TIMEOUT, TIMELINE_WAIT_TIMEOUT_MS, NAKADI_EVENT_MAX_BYTES,
-            NAKADI_SUBSCRIPTION_MAX_PARTITIONS, "service", "nakadi", "", "");
+            NAKADI_SUBSCRIPTION_MAX_PARTITIONS, "service", "nakadi", "", "", "nakadi_archiver", "nakadi_to_s3");
     private final EventPublisher publisher;
 
     public EventPublisherTest() {

--- a/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
+++ b/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
@@ -3,6 +3,7 @@ package org.zalando.nakadi.service;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
+import org.assertj.core.util.Lists;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
@@ -145,7 +146,15 @@ public class EventTypeServiceTest {
         doReturn(Optional.of(eventType)).when(eventTypeRepository).findByNameO(eventType.getName());
         doReturn(ImmutableList.of(createSubscription("nakadi_archiver", "nakadi_to_s3")))
                 .when(subscriptionDbRepository)
+                .listSubscriptions(ImmutableSet.of(eventType.getName()), Optional.empty(), 0, 20);
+        doReturn(ImmutableList.of(createSubscription("nakadi_archiver", "nakadi_to_s3")))
+                .when(subscriptionDbRepository)
                 .listSubscriptions(ImmutableSet.of(eventType.getName()), Optional.empty(), 0, 1);
+        doReturn(Lists.emptyList())
+                .when(subscriptionDbRepository)
+                .listSubscriptions(ImmutableSet.of(eventType.getName()), Optional.empty(), 20, 20);
+        doReturn("nakadi_archiver").when(nakadiSettings).getDeletableSubscriptionOwningApplication();
+        doReturn("nakadi_to_s3").when(nakadiSettings).getDeletableSubscriptionConsumerGroup();
 
         when(featureToggleService.isFeatureEnabled(FeatureToggleService.Feature.EVENT_TYPE_DELETION_ONLY_ADMINS))
                 .thenReturn(true);
@@ -161,7 +170,12 @@ public class EventTypeServiceTest {
         doReturn(Optional.of(eventType)).when(eventTypeRepository).findByNameO(eventType.getName());
         doReturn(ImmutableList.of(createSubscription("nakadi_archiver", "nakadi_to_s3")))
                 .when(subscriptionDbRepository)
-                .listSubscriptions(ImmutableSet.of(eventType.getName()), Optional.empty(), 0, -1);
+                .listSubscriptions(ImmutableSet.of(eventType.getName()), Optional.empty(), 0, 20);
+        doReturn(Lists.emptyList())
+                .when(subscriptionDbRepository)
+                .listSubscriptions(ImmutableSet.of(eventType.getName()), Optional.empty(), 20, 20);
+        doReturn("nakadi_archiver").when(nakadiSettings).getDeletableSubscriptionOwningApplication();
+        doReturn("nakadi_to_s3").when(nakadiSettings).getDeletableSubscriptionConsumerGroup();
 
         when(featureToggleService.isFeatureEnabled(FeatureToggleService.Feature.EVENT_TYPE_DELETION_ONLY_ADMINS))
                 .thenReturn(true);
@@ -182,7 +196,12 @@ public class EventTypeServiceTest {
         doReturn(Optional.of(eventType)).when(eventTypeRepository).findByNameO(eventType.getName());
         doReturn(ImmutableList.of(createSubscription("someone", "something")))
                 .when(subscriptionDbRepository)
-                .listSubscriptions(ImmutableSet.of(eventType.getName()), Optional.empty(), 0, -1);
+                .listSubscriptions(ImmutableSet.of(eventType.getName()), Optional.empty(), 0, 20);
+        doReturn(Lists.emptyList())
+                .when(subscriptionDbRepository)
+                .listSubscriptions(ImmutableSet.of(eventType.getName()), Optional.empty(), 20, 20);
+        doReturn("nakadi_archiver").when(nakadiSettings).getDeletableSubscriptionOwningApplication();
+        doReturn("nakadi_to_s3").when(nakadiSettings).getDeletableSubscriptionConsumerGroup();
 
         when(featureToggleService.isFeatureEnabled(FeatureToggleService.Feature.EVENT_TYPE_DELETION_ONLY_ADMINS))
                 .thenReturn(true);

--- a/src/test/java/org/zalando/nakadi/utils/TestUtils.java
+++ b/src/test/java/org/zalando/nakadi/utils/TestUtils.java
@@ -19,10 +19,12 @@ import org.zalando.nakadi.config.JsonConfig;
 import org.zalando.nakadi.domain.BatchFactory;
 import org.zalando.nakadi.domain.BatchItem;
 import org.zalando.nakadi.domain.EventType;
-import org.zalando.nakadi.domain.storage.Storage;
+import org.zalando.nakadi.domain.ResourceAuthorization;
 import org.zalando.nakadi.domain.Subscription;
 import org.zalando.nakadi.domain.Timeline;
+import org.zalando.nakadi.domain.storage.Storage;
 import org.zalando.nakadi.exceptions.runtime.AccessDeniedException;
+import org.zalando.nakadi.plugin.api.authz.AuthorizationAttribute;
 import org.zalando.nakadi.plugin.api.authz.AuthorizationService;
 import org.zalando.nakadi.plugin.api.authz.Resource;
 import org.zalando.nakadi.problem.ValidationProblem;
@@ -30,6 +32,7 @@ import org.zalando.nakadi.service.NakadiKpiPublisher;
 import org.zalando.problem.Problem;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -141,6 +144,13 @@ public class TestUtils {
         return EventTypeTestBuilder.builder().build();
     }
 
+    public static ResourceAuthorization buildResourceAuthorization() {
+        final List<AuthorizationAttribute> admins = new ArrayList<>();
+        final List<AuthorizationAttribute> readers = new ArrayList<>();
+        final List<AuthorizationAttribute> writers = new ArrayList<>();
+        return new ResourceAuthorization(admins, readers, writers);
+    }
+
     public static AccessDeniedException mockAccessDeniedException() {
         final Resource resource = mock(Resource.class);
         when(resource.getName()).thenReturn("some-name");
@@ -222,6 +232,10 @@ public class TestUtils {
 
     public static List<Subscription> createRandomSubscriptions(final int count) {
         return createRandomSubscriptions(count, randomTextString());
+    }
+
+    public static Subscription createSubscription(final String owningApp, final String consumerGroup) {
+        return builder().withConsumerGroup(consumerGroup).withOwningApplication(owningApp).build();
     }
 
     public static Timeline buildTimeline(final String etName) {


### PR DESCRIPTION
To delete an event type if EVENT_TYPE_DELETION_ONLY_ADMINS, the following criteria must be met:
- the caller is in the admins section (possibly through a wildcard)
- there is an admin section
- the only subscriptions attached to the event type are subscriptions defined in the settings nakadi.eventType.deletableSubscription.owningApplication and nakadi.eventType.deletableSubscription.consumerGroup

