### PR TITLE
ARUHA-2536: Add new partitions to topology for subscription

### DIFF
--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRepartitionAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRepartitionAT.java
@@ -1,0 +1,105 @@
+package org.zalando.nakadi.webservice.hila;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.zalando.nakadi.repository.zookeeper.ZooKeeperHolder;
+import org.zalando.nakadi.service.subscription.model.Partition;
+import org.zalando.nakadi.service.subscription.zk.NewZkSubscriptionClient;
+import org.zalando.nakadi.service.subscription.zk.ZkSubscriptionClient;
+import org.zalando.nakadi.utils.TestUtils;
+import org.zalando.nakadi.webservice.BaseAT;
+import org.zalando.nakadi.webservice.utils.ZookeeperTestUtils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.when;
+
+public class HilaRepartitionAT extends BaseAT {
+    private static final CuratorFramework CURATOR = ZookeeperTestUtils.createCurator(ZOOKEEPER_URL);
+    private ZooKeeperHolder zooKeeperHolder;
+    private final String sid = TestUtils.randomUUID();
+    private final String subscriptionId = TestUtils.randomUUID();
+    private final String eventTypeName = "random";
+    private final String secondEventTypeName = "random_et_2";
+
+    @Test
+    public void testSubscriptionRepartitioningWithSingleEventType() throws Exception {
+        zooKeeperHolder = Mockito.mock(ZooKeeperHolder.class);
+        Mockito.when(zooKeeperHolder.get()).thenReturn(CURATOR);
+        when(zooKeeperHolder.getSubscriptionCurator(anyInt()))
+                .thenReturn(new ZooKeeperHolder.DisposableCuratorFramework(CURATOR));
+
+        final ZkSubscriptionClient subscriptionClient = new NewZkSubscriptionClient(
+                subscriptionId,
+                zooKeeperHolder,
+                String.format("%s.%s", subscriptionId, sid),
+                MAPPER,
+                30000
+        );
+
+        final Partition[] eventTypePartitions = {new Partition(
+                eventTypeName, "0", null, null, Partition.State.ASSIGNED)};
+        setInitialTopology(eventTypePartitions);
+        subscriptionClient.repartitionTopology(eventTypeName, 2);
+
+        Assert.assertEquals(subscriptionClient.getTopology().getPartitions().length, 2);
+        Assert.assertEquals(subscriptionClient.getTopology().getPartitions()[1].getPartition(), "1");
+        Assert.assertEquals(subscriptionClient.getTopology().getPartitions()[0].getState(), Partition.State.UNASSIGNED);
+
+        // test that offset path was created for new partition
+        Assert.assertNotNull(CURATOR.checkExists().forPath(getOffsetPath(eventTypeName, "1")));
+    }
+
+    @Test
+    public void testSubscriptionRepartitioningWithMultipleEventTypes() throws Exception {
+        zooKeeperHolder = Mockito.mock(ZooKeeperHolder.class);
+        Mockito.when(zooKeeperHolder.get()).thenReturn(CURATOR);
+        when(zooKeeperHolder.getSubscriptionCurator(anyInt()))
+                .thenReturn(new ZooKeeperHolder.DisposableCuratorFramework(CURATOR));
+
+        final ZkSubscriptionClient subscriptionClient = new NewZkSubscriptionClient(
+                subscriptionId,
+                zooKeeperHolder,
+                String.format("%s.%s", subscriptionId, sid),
+                MAPPER,
+                30000
+        );
+
+        final Partition[] eventTypePartitions = {
+                new Partition(eventTypeName, "0", null, null, Partition.State.ASSIGNED),
+                new Partition(secondEventTypeName, "0", null, null, Partition.State.ASSIGNED)};
+        setInitialTopology(eventTypePartitions);
+        subscriptionClient.repartitionTopology(eventTypeName, 2);
+
+        Assert.assertEquals(subscriptionClient.getTopology().getPartitions().length, 3);
+        final List<Partition> eTPartitions =
+                Arrays.stream(subscriptionClient.getTopology().getPartitions())
+                        .filter(p -> p.getEventType().equals(secondEventTypeName)).collect(Collectors.toList());
+        Assert.assertEquals(eTPartitions.get(0).getState(), Partition.State.UNASSIGNED);
+    }
+
+    private String subscriptionPath() {
+        final String parentPath = "/nakadi/subscriptions";
+        return String.format("%s/%s", parentPath, subscriptionId);
+    }
+
+    private String getOffsetPath(final String eventTypeName, final String partition) {
+        return String.format("%s/offsets/%s/%s", subscriptionPath(), eventTypeName, partition);
+    }
+
+    private void setInitialTopology(final Partition[] partitions) throws Exception {
+        final String topologyPath = subscriptionPath() + "/topology";
+        final byte[] topologyData = MAPPER.writeValueAsBytes(
+                new NewZkSubscriptionClient.Topology(partitions, null, 0));
+        if (null == CURATOR.checkExists().forPath(topologyPath)) {
+            CURATOR.create().creatingParentsIfNeeded().forPath(topologyPath, topologyData);
+        } else {
+            CURATOR.setData().forPath(topologyPath, topologyData);
+        }
+    }
+}

--- a/src/main/java/org/zalando/nakadi/service/subscription/zk/NewZkSubscriptionClient.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/zk/NewZkSubscriptionClient.java
@@ -3,6 +3,7 @@ package org.zalando.nakadi.service.subscription.zk;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import org.apache.zookeeper.KeeperException;
 import org.zalando.nakadi.domain.EventTypePartition;
 import org.zalando.nakadi.exceptions.runtime.NakadiRuntimeException;
@@ -18,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -214,6 +216,52 @@ public class NewZkSubscriptionClient extends AbstractZkSubscriptionClient {
             updatePartitionsConfiguration(
                     topology.getSessionsHash(),
                     changeSet.toArray(new Partition[changeSet.size()]));
+        }
+    }
+
+    @Override
+    public void repartitionTopology(final String eventTypeName, final int newPartitionsCount)
+            throws NakadiRuntimeException {
+        final Topology currentTopology = getTopology();
+        final List<Partition> partitionsList = Lists.newArrayList(currentTopology.getPartitions());
+        final List<Partition> newPartitionsList = new ArrayList<>();
+
+        // Set other event type's partition state to unassigned
+        for (final Partition partition : partitionsList) {
+            if (!partition.getEventType().equals(eventTypeName)) {
+                newPartitionsList.add(
+                        partition.toState(Partition.State.UNASSIGNED, null, null));
+            }
+        }
+
+        // Set this event type's partitions to unassigned, create nodes for partitions' offset if not present
+        for (int index=0; index < newPartitionsCount; index++) {
+            final String partition = String.valueOf(index);
+            newPartitionsList.add(new Partition(
+                    eventTypeName, partition, null, null, Partition.State.UNASSIGNED
+            ));
+
+            try {
+                getCurator().create().creatingParentsIfNeeded().forPath(
+                        getOffsetPath(new EventTypePartition(eventTypeName, partition)));
+            } catch (final Exception e) {
+                throw new NakadiRuntimeException(e);
+            }
+        }
+
+        final Topology partitionedTopology = new Topology(
+                newPartitionsList.toArray(new Partition[0]),
+                currentTopology.getSessionsHash(),
+                Optional.ofNullable(currentTopology.getVersion()).map(v -> v+1).orElse(0)
+        );
+
+        try {
+            getLog().info("Updating topology due to repartitioning event type: {} to {}", eventTypeName,
+                    partitionedTopology);
+            getCurator().setData().forPath(getSubscriptionPath(NODE_TOPOLOGY),
+                    objectMapper.writeValueAsBytes(partitionedTopology));
+        } catch (final Exception exception) {
+            throw new NakadiRuntimeException(exception);
         }
     }
 }

--- a/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClient.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClient.java
@@ -162,6 +162,15 @@ public interface ZkSubscriptionClient extends Closeable {
             throws NakadiRuntimeException, UnsupportedOperationException;
 
     /**
+     * Extends topology for subscription after event type partitions increased
+     *
+     * @param eventTypeName Name of the event-type that was repartitioned
+     * @param newPartitionsCount Count of the number of partitions of the event type after repartitioning
+     */
+    void repartitionTopology(String eventTypeName, int newPartitionsCount)
+            throws NakadiRuntimeException;
+
+    /**
      * Gets current status of cursor reset request.
      *
      * @return true if cursor reset in progress
@@ -270,6 +279,10 @@ public interface ZkSubscriptionClient extends Closeable {
 
         public String getSessionsHash() {
             return sessionsHash;
+        }
+
+        public Integer getVersion() {
+            return version;
         }
     }
 }


### PR DESCRIPTION

> Zalando ticket : ARUHA-2536 (https://jira.zalando.net/browse/ARUHA-2536)

## Description
Edit Zookeeper topology for subscriptions if event type is re-partitioned.
## Review
- [x] Tests