### PR TITLE
Aruha 2537 1

### DIFF
--- a/src/main/java/org/zalando/nakadi/service/CursorsService.java
+++ b/src/main/java/org/zalando/nakadi/service/CursorsService.java
@@ -203,7 +203,7 @@ public class CursorsService {
                     .map(cursorConverter::convertToNoToken)
                     .collect(Collectors.toList());
 
-            zkClient.resetCursors(newCursors, timeout);
+            zkClient.closeSubscriptionStreams(() -> zkClient.forceCommitOffsets(newCursors), timeout);
 
             auditLogPublisher.publish(
                     Optional.of(new ItemsWrapper<>(oldCursors)),

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StartingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StartingState.java
@@ -86,7 +86,7 @@ public class StartingState extends State {
             }
         }
 
-        if (getZk().isCursorResetInProgress()) {
+        if (getZk().isCloseSubscriptionStreamsInProgress()) {
             switchState(new CleanupState(
                     new ConflictException("Resetting subscription cursors request is still in progress")));
             return;

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -107,7 +107,7 @@ class StreamingState extends State {
         this.lastCommitMillis = System.currentTimeMillis();
         scheduleTask(this::checkCommitTimeout, getParameters().commitTimeoutMillis, TimeUnit.MILLISECONDS);
 
-        cursorResetSubscription = getZk().subscribeForCursorsReset(
+        cursorResetSubscription = getZk().subscribeForStreamClose(
                 () -> addTask(this::resetSubscriptionCursorsCallback));
     }
 

--- a/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClient.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClient.java
@@ -127,7 +127,7 @@ public interface ZkSubscriptionClient extends Closeable {
      * @param cursors - offsets to set for subscription
      * @throws Exception
      */
-    void forceCommitOffsets(final List<SubscriptionCursorWithoutToken> cursors) throws NakadiRuntimeException;
+    void forceCommitOffsets(List<SubscriptionCursorWithoutToken> cursors) throws NakadiRuntimeException;
 
     List<Boolean> commitOffsets(List<SubscriptionCursorWithoutToken> cursors,
                                 Comparator<SubscriptionCursorWithoutToken> comparator);

--- a/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClient.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClient.java
@@ -121,6 +121,14 @@ public interface ZkSubscriptionClient extends Closeable {
     Map<EventTypePartition, SubscriptionCursorWithoutToken> getOffsets(Collection<EventTypePartition> keys)
             throws NakadiRuntimeException;
 
+    /**
+     * Forcefully set commits offsets specified in {@link SubscriptionCursorWithoutToken}
+     *
+     * @param cursors - offsets to set for subscription
+     * @throws Exception
+     */
+    void forceCommitOffsets(final List<SubscriptionCursorWithoutToken> cursors) throws NakadiRuntimeException;
+
     List<Boolean> commitOffsets(List<SubscriptionCursorWithoutToken> cursors,
                                 Comparator<SubscriptionCursorWithoutToken> comparator);
 
@@ -153,39 +161,39 @@ public interface ZkSubscriptionClient extends Closeable {
             throws SubscriptionNotInitializedException, NakadiRuntimeException;
 
     /**
-     * Subscribes to cursor reset event.
+     * Subscribes for subscription stream close event.
      *
-     * @param listener callback which is called when cursor reset happens
+     * @param listener callback which is called when stream is closed
      * @return {@link Closeable}
      */
-    Closeable subscribeForCursorsReset(Runnable listener)
+    Closeable subscribeForStreamClose(Runnable listener)
             throws NakadiRuntimeException, UnsupportedOperationException;
 
     /**
      * Extends topology for subscription after event type partitions increased
      *
-     * @param eventTypeName Name of the event-type that was repartitioned
+     * @param eventTypeName      Name of the event-type that was repartitioned
      * @param newPartitionsCount Count of the number of partitions of the event type after repartitioning
      */
     void repartitionTopology(String eventTypeName, int newPartitionsCount)
             throws NakadiRuntimeException;
 
     /**
-     * Gets current status of cursor reset request.
+     * Gets current status of subscription stream closing.
      *
      * @return true if cursor reset in progress
      */
-    boolean isCursorResetInProgress();
+    boolean isCloseSubscriptionStreamsInProgress();
 
     /**
-     * Resets subscription offsets for provided cursors.
+     * Close subscription streams and perform provided action when streams are closed.
      *
-     * @param cursors cursors to reset to
+     * @param action  perform action once streams are closed
      * @param timeout wait until give up resetting
      * @throws OperationTimeoutException
      * @throws ZookeeperException
      */
-    void resetCursors(List<SubscriptionCursorWithoutToken> cursors, long timeout)
+    void closeSubscriptionStreams(Runnable action, long timeout)
             throws OperationTimeoutException, ZookeeperException;
 
     class Topology {


### PR DESCRIPTION
# One-line summary
Rework of subscription reset cursor to apply action for subscription streams close. It is required in order to close streaming subscription after re-partitioning.