### PR TITLE
ARUHA-2538: repartitioning itself combined

### DIFF
--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRepartitionAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRepartitionAT.java
@@ -1,15 +1,26 @@
 package org.zalando.nakadi.webservice.hila;
 
 import org.apache.curator.framework.CuratorFramework;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.zalando.nakadi.domain.EventType;
+import org.zalando.nakadi.domain.Subscription;
+import org.zalando.nakadi.domain.SubscriptionBase;
 import org.zalando.nakadi.repository.zookeeper.ZooKeeperHolder;
 import org.zalando.nakadi.service.subscription.model.Partition;
 import org.zalando.nakadi.service.subscription.zk.NewZkSubscriptionClient;
 import org.zalando.nakadi.service.subscription.zk.ZkSubscriptionClient;
+import org.zalando.nakadi.utils.RandomSubscriptionBuilder;
 import org.zalando.nakadi.utils.TestUtils;
+import org.zalando.nakadi.view.SubscriptionCursor;
 import org.zalando.nakadi.webservice.BaseAT;
+import org.zalando.nakadi.webservice.utils.NakadiTestUtils;
+import org.zalando.nakadi.webservice.utils.TestStreamingClient;
 import org.zalando.nakadi.webservice.utils.ZookeeperTestUtils;
 
 import java.util.Arrays;
@@ -19,7 +30,9 @@ import java.util.stream.Collectors;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.when;
 
+
 public class HilaRepartitionAT extends BaseAT {
+    private static final Logger LOG = LoggerFactory.getLogger(HilaRepartitionAT.class);
     private static final CuratorFramework CURATOR = ZookeeperTestUtils.createCurator(ZOOKEEPER_URL);
     private ZooKeeperHolder zooKeeperHolder;
     private final String sid = TestUtils.randomUUID();
@@ -103,4 +116,39 @@ public class HilaRepartitionAT extends BaseAT {
             CURATOR.setData().forPath(topologyPath, topologyData);
         }
     }
+
+    @Test(timeout = 30000)
+    public void whenEventTypeRepartitionedSubscriptionStartsStreamNewPartitions() throws Exception {
+        final EventType eventType = NakadiTestUtils.createBusinessEventTypeWithPartitions(1);
+        final Subscription subscription = NakadiTestUtils.createSubscription(
+                RandomSubscriptionBuilder.builder()
+                        .withEventType(eventType.getName())
+                        .withStartFrom(SubscriptionBase.InitialPosition.BEGIN)
+                        .buildSubscriptionBase());
+
+        NakadiTestUtils.publishBusinessEventWithUserDefinedPartition(
+                eventType.getName(), 1, x -> "{\"foo\":\"bar\"}", p -> "0");
+
+        // create session, read from subscription and wait for events to be sent
+        final TestStreamingClient client = TestStreamingClient
+                .create(URL, subscription.getId(), "")
+                .startWithAutocommit(streamBatches -> LOG.info("{}", streamBatches));
+
+        TestUtils.waitFor(() -> MatcherAssert.assertThat(client.getBatches(), Matchers.hasSize(1)));
+        Assert.assertEquals("0", client.getBatches().get(0).getCursor().getPartition());
+
+        NakadiTestUtils.repartitionEventType(eventType, 2);
+        TestUtils.waitFor(() -> MatcherAssert.assertThat(client.isRunning(), Matchers.is(false)));
+
+        final TestStreamingClient clientAfterRepartitioning = TestStreamingClient
+                .create(URL, subscription.getId(), "")
+                .startWithAutocommit(streamBatches -> LOG.info("{}", streamBatches));
+
+        NakadiTestUtils.publishBusinessEventWithUserDefinedPartition(
+                eventType.getName(), 1, x -> "{\"foo\":\"bar" + x + "\"}", p -> "1");
+
+        TestUtils.waitFor(() -> MatcherAssert.assertThat(clientAfterRepartitioning.getBatches(), Matchers.hasSize(1)));
+        Assert.assertEquals("1", clientAfterRepartitioning.getBatches().get(0).getCursor().getPartition());
+    }
+
 }

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRepartitionAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRepartitionAT.java
@@ -17,7 +17,6 @@ import org.zalando.nakadi.service.subscription.zk.NewZkSubscriptionClient;
 import org.zalando.nakadi.service.subscription.zk.ZkSubscriptionClient;
 import org.zalando.nakadi.utils.RandomSubscriptionBuilder;
 import org.zalando.nakadi.utils.TestUtils;
-import org.zalando.nakadi.view.SubscriptionCursor;
 import org.zalando.nakadi.webservice.BaseAT;
 import org.zalando.nakadi.webservice.utils.NakadiTestUtils;
 import org.zalando.nakadi.webservice.utils.TestStreamingClient;

--- a/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -72,6 +72,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
@@ -576,7 +577,7 @@ public class EventTypeService {
             zkClient.repartitionTopology(eventType.getName(), partitions);
             zkClient.closeSubscriptionStreams(
                     () -> LOG.info("subscription streams were closed, after repartitioning"),
-                    nakadiSettings.getMaxCommitTimeout());
+                    TimeUnit.SECONDS.toMillis(nakadiSettings.getMaxCommitTimeout()));
         }
     }
 

--- a/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -104,25 +104,27 @@ public class EventTypeService {
     private final Integer repartitioningSubscriptionsLimit;
 
     @Autowired
-    public EventTypeService(final EventTypeRepository eventTypeRepository,
-                            final TimelineService timelineService,
-                            final PartitionResolver partitionResolver,
-                            final Enrichment enrichment,
-                            final SubscriptionDbRepository subscriptionRepository,
-                            final SchemaEvolutionService schemaEvolutionService,
-                            final PartitionsCalculator partitionsCalculator,
-                            final FeatureToggleService featureToggleService,
-                            final AuthorizationValidator authorizationValidator,
-                            final TimelineSync timelineSync,
-                            final TransactionTemplate transactionTemplate,
-                            final NakadiSettings nakadiSettings,
-                            final NakadiKpiPublisher nakadiKpiPublisher,
-                            @Value("${nakadi.kpi.event-types.nakadiEventTypeLog}") final String etLogEventType,
-                            final NakadiAuditLogPublisher nakadiAuditLogPublisher,
-                            final EventTypeOptionsValidator eventTypeOptionsValidator,
-                            final AdminService adminService,
-                            final SubscriptionClientFactory subscriptionClientFactory,
-                            @Value("${nakadi.repartitioning.subscriptions.limit:1000}") final Integer repartitioningSubscriptionsLimit) {
+    public EventTypeService(
+            final EventTypeRepository eventTypeRepository,
+            final TimelineService timelineService,
+            final PartitionResolver partitionResolver,
+            final Enrichment enrichment,
+            final SubscriptionDbRepository subscriptionRepository,
+            final SchemaEvolutionService schemaEvolutionService,
+            final PartitionsCalculator partitionsCalculator,
+            final FeatureToggleService featureToggleService,
+            final AuthorizationValidator authorizationValidator,
+            final TimelineSync timelineSync,
+            final TransactionTemplate transactionTemplate,
+            final NakadiSettings nakadiSettings,
+            final NakadiKpiPublisher nakadiKpiPublisher,
+            @Value("${nakadi.kpi.event-types.nakadiEventTypeLog}") final String etLogEventType,
+            final NakadiAuditLogPublisher nakadiAuditLogPublisher,
+            final EventTypeOptionsValidator eventTypeOptionsValidator,
+            final AdminService adminService,
+            final SubscriptionClientFactory subscriptionClientFactory,
+            @Value("${nakadi.repartitioning.subscriptions.limit:1000}")
+            final Integer repartitioningSubscriptionsLimit) {
         this.eventTypeRepository = eventTypeRepository;
         this.timelineService = timelineService;
         this.partitionResolver = partitionResolver;
@@ -573,7 +575,8 @@ public class EventTypeService {
                     LogPathBuilder.build(subscription.getId(), "repartition"));
             zkClient.repartitionTopology(eventType.getName(), partitions);
             zkClient.closeSubscriptionStreams(
-                    () -> LOG.info("subscription streams were closed, after repartitioning"), nakadiSettings.getMaxCommitTimeout());
+                    () -> LOG.info("subscription streams were closed, after repartitioning"),
+                    nakadiSettings.getMaxCommitTimeout());
         }
     }
 

--- a/src/main/java/org/zalando/nakadi/service/subscription/zk/NewZkSubscriptionClient.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/zk/NewZkSubscriptionClient.java
@@ -238,7 +238,8 @@ public class NewZkSubscriptionClient extends AbstractZkSubscriptionClient {
 
             try {
                 getCurator().create().creatingParentsIfNeeded().forPath(
-                        getOffsetPath(new EventTypePartition(eventTypeName, partition)));
+                        getOffsetPath(new EventTypePartition(eventTypeName, partition)),
+                        "-1".getBytes(UTF_8));
             } catch (final Exception e) {
                 throw new NakadiRuntimeException(e);
             }

--- a/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
@@ -118,7 +118,7 @@ public class EventTypeControllerTestCase {
                 partitionResolver, enrichment, subscriptionRepository, schemaEvolutionService, partitionsCalculator,
                 featureToggleService, authorizationValidator, timelineSync, transactionTemplate, nakadiSettings,
                 nakadiKpiPublisher, "et-log-event-type", nakadiAuditLogPublisher, eventTypeOptionsValidator,
-                adminService, mock(SubscriptionClientFactory.class));
+                adminService, mock(SubscriptionClientFactory.class), 1000);
         final EventTypeController controller = new EventTypeController(eventTypeService, featureToggleService,
                 adminService, nakadiSettings);
         doReturn(randomUUID).when(uuid).randomUUID();

--- a/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
@@ -32,6 +32,7 @@ import org.zalando.nakadi.service.EventTypeService;
 import org.zalando.nakadi.service.FeatureToggleService;
 import org.zalando.nakadi.service.NakadiAuditLogPublisher;
 import org.zalando.nakadi.service.NakadiKpiPublisher;
+import org.zalando.nakadi.service.subscription.zk.SubscriptionClientFactory;
 import org.zalando.nakadi.service.timeline.TimelineService;
 import org.zalando.nakadi.service.timeline.TimelineSync;
 import org.zalando.nakadi.service.validation.EventTypeOptionsValidator;
@@ -117,7 +118,7 @@ public class EventTypeControllerTestCase {
                 partitionResolver, enrichment, subscriptionRepository, schemaEvolutionService, partitionsCalculator,
                 featureToggleService, authorizationValidator, timelineSync, transactionTemplate, nakadiSettings,
                 nakadiKpiPublisher, "et-log-event-type", nakadiAuditLogPublisher, eventTypeOptionsValidator,
-                adminService);
+                adminService, mock(SubscriptionClientFactory.class));
         final EventTypeController controller = new EventTypeController(eventTypeService, featureToggleService,
                 adminService, nakadiSettings);
         doReturn(randomUUID).when(uuid).randomUUID();

--- a/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
+++ b/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
@@ -23,6 +23,7 @@ import org.zalando.nakadi.repository.EventTypeRepository;
 import org.zalando.nakadi.repository.TopicRepository;
 import org.zalando.nakadi.repository.db.SubscriptionDbRepository;
 import org.zalando.nakadi.repository.kafka.PartitionsCalculator;
+import org.zalando.nakadi.service.subscription.zk.SubscriptionClientFactory;
 import org.zalando.nakadi.service.timeline.TimelineService;
 import org.zalando.nakadi.service.timeline.TimelineSync;
 import org.zalando.nakadi.service.validation.EventTypeOptionsValidator;
@@ -76,7 +77,7 @@ public class EventTypeServiceTest {
                 subscriptionDbRepository, schemaEvolutionService, partitionsCalculator, featureToggleService,
                 authorizationValidator, timelineSync, transactionTemplate, nakadiSettings, nakadiKpiPublisher,
                 KPI_ET_LOG_EVENT_TYPE, nakadiAuditLogPublisher, eventTypeOptionsValidator,
-                adminService);
+                adminService, mock(SubscriptionClientFactory.class));
         when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
             final TransactionCallback callback = (TransactionCallback) invocation.getArguments()[0];
             return callback.doInTransaction(null);

--- a/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
+++ b/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
@@ -77,7 +77,7 @@ public class EventTypeServiceTest {
                 subscriptionDbRepository, schemaEvolutionService, partitionsCalculator, featureToggleService,
                 authorizationValidator, timelineSync, transactionTemplate, nakadiSettings, nakadiKpiPublisher,
                 KPI_ET_LOG_EVENT_TYPE, nakadiAuditLogPublisher, eventTypeOptionsValidator,
-                adminService, mock(SubscriptionClientFactory.class));
+                adminService, mock(SubscriptionClientFactory.class), 1000);
         when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
             final TransactionCallback callback = (TransactionCallback) invocation.getArguments()[0];
             return callback.doInTransaction(null);


### PR DESCRIPTION
# One-line summary
Combine depended tasks interface to repartition event type

Add partitions to active timeline Kafka topic
Update timelines of the event type to have offsets for partitions added
Update event type cache
Close streaming connections for the subscriptions