### PR TITLE
Validating informational fields against effective schema

### DIFF
--- a/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -239,7 +239,7 @@ public class KafkaRepositoryAT extends BaseAT {
 
         final KafkaFactory factory = mock(KafkaFactory.class);
         when(factory.getConsumer()).thenReturn(consumer);
-
+        final KafkaLocationManager kafkaLocationManager = mock(KafkaLocationManager.class);
         Mockito
                 .doReturn(kafkaHelper.createProducer())
                 .when(factory)
@@ -250,7 +250,7 @@ public class KafkaRepositoryAT extends BaseAT {
                 nakadiSettings,
                 kafkaSettings,
                 zookeeperSettings,
-                kafkaTopicConfigFactory);
+                kafkaTopicConfigFactory, kafkaLocationManager);
     }
 
 }

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/UserJourneyAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/UserJourneyAT.java
@@ -59,6 +59,7 @@ public class UserJourneyAT extends RealEnvironmentAT {
 
     private String eventTypeBody;
     private String eventTypeBodyUpdate;
+    private String eventTypeRepartitionUpdate;
 
     public static String getEventTypeJsonFromFile(final String resourceName, final String eventTypeName,
                                                   final String owningApp)
@@ -74,6 +75,8 @@ public class UserJourneyAT extends RealEnvironmentAT {
         eventTypeName = randomValidEventTypeName();
         eventTypeBody = getEventTypeJsonFromFile("sample-event-type.json", eventTypeName, owningApp);
         eventTypeBodyUpdate = getEventTypeJsonFromFile("sample-event-type-update.json", eventTypeName, owningApp);
+        eventTypeRepartitionUpdate = getEventTypeJsonFromFile("sample-event-type-repartition.json",
+                eventTypeName, owningApp);
         createEventType();
     }
 
@@ -209,6 +212,27 @@ public class UserJourneyAT extends RealEnvironmentAT {
                 .body("unconsumed_events[0]", equalTo(1));
     }
 
+    @Test(timeout = 3000)
+    public void testRepartition(){
+        //repartition Event Type
+        jsonRequestSpec()
+                .body(eventTypeRepartitionUpdate)
+                .when()
+                .put("/event-types/" + eventTypeName)
+                .then()
+                .body(equalTo(""))
+                .statusCode(OK.value());
+
+        // check number of partitions is 3
+        jsonRequestSpec()
+                .when()
+                .get("/event-types/" + eventTypeName + "/partitions")
+                .then()
+                .statusCode(OK.value())
+                .body("size()", equalTo(3));
+
+
+    }
     @Test(timeout = 3000)
     public void testEventTypeDeletion() {
         // The reason for separating this test is https://issues.apache.org/jira/browse/KAFKA-2948

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRepartitionAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRepartitionAT.java
@@ -1,0 +1,153 @@
+package org.zalando.nakadi.webservice.hila;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.zalando.nakadi.domain.EventType;
+import org.zalando.nakadi.domain.Subscription;
+import org.zalando.nakadi.domain.SubscriptionBase;
+import org.zalando.nakadi.repository.zookeeper.ZooKeeperHolder;
+import org.zalando.nakadi.service.subscription.model.Partition;
+import org.zalando.nakadi.service.subscription.zk.NewZkSubscriptionClient;
+import org.zalando.nakadi.service.subscription.zk.ZkSubscriptionClient;
+import org.zalando.nakadi.utils.RandomSubscriptionBuilder;
+import org.zalando.nakadi.utils.TestUtils;
+import org.zalando.nakadi.webservice.BaseAT;
+import org.zalando.nakadi.webservice.utils.NakadiTestUtils;
+import org.zalando.nakadi.webservice.utils.TestStreamingClient;
+import org.zalando.nakadi.webservice.utils.ZookeeperTestUtils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.when;
+
+
+public class HilaRepartitionAT extends BaseAT {
+    private static final Logger LOG = LoggerFactory.getLogger(HilaRepartitionAT.class);
+    private static final CuratorFramework CURATOR = ZookeeperTestUtils.createCurator(ZOOKEEPER_URL);
+    private ZooKeeperHolder zooKeeperHolder;
+    private final String sid = TestUtils.randomUUID();
+    private final String subscriptionId = TestUtils.randomUUID();
+    private final String eventTypeName = "random";
+    private final String secondEventTypeName = "random_et_2";
+
+    @Test
+    public void testSubscriptionRepartitioningWithSingleEventType() throws Exception {
+        zooKeeperHolder = Mockito.mock(ZooKeeperHolder.class);
+        Mockito.when(zooKeeperHolder.get()).thenReturn(CURATOR);
+        when(zooKeeperHolder.getSubscriptionCurator(anyInt()))
+                .thenReturn(new ZooKeeperHolder.DisposableCuratorFramework(CURATOR));
+
+        final ZkSubscriptionClient subscriptionClient = new NewZkSubscriptionClient(
+                subscriptionId,
+                zooKeeperHolder,
+                String.format("%s.%s", subscriptionId, sid),
+                MAPPER,
+                30000
+        );
+
+        final Partition[] eventTypePartitions = {new Partition(
+                eventTypeName, "0", null, null, Partition.State.ASSIGNED)};
+        setInitialTopology(eventTypePartitions);
+        subscriptionClient.repartitionTopology(eventTypeName, 2);
+
+        Assert.assertEquals(subscriptionClient.getTopology().getPartitions().length, 2);
+        Assert.assertEquals(subscriptionClient.getTopology().getPartitions()[1].getPartition(), "1");
+        Assert.assertEquals(subscriptionClient.getTopology().getPartitions()[1].getState(), Partition.State.UNASSIGNED);
+        Assert.assertEquals(subscriptionClient.getTopology().getPartitions()[0].getState(), Partition.State.ASSIGNED);
+
+        // test that offset path was created for new partition
+        Assert.assertNotNull(CURATOR.checkExists().forPath(getOffsetPath(eventTypeName, "1")));
+    }
+
+    @Test
+    public void testSubscriptionRepartitioningWithMultipleEventTypes() throws Exception {
+        zooKeeperHolder = Mockito.mock(ZooKeeperHolder.class);
+        Mockito.when(zooKeeperHolder.get()).thenReturn(CURATOR);
+        when(zooKeeperHolder.getSubscriptionCurator(anyInt()))
+                .thenReturn(new ZooKeeperHolder.DisposableCuratorFramework(CURATOR));
+
+        final ZkSubscriptionClient subscriptionClient = new NewZkSubscriptionClient(
+                subscriptionId,
+                zooKeeperHolder,
+                String.format("%s.%s", subscriptionId, sid),
+                MAPPER,
+                30000
+        );
+
+        final Partition[] eventTypePartitions = {
+                new Partition(eventTypeName, "0", null, null, Partition.State.ASSIGNED),
+                new Partition(secondEventTypeName, "0", null, null, Partition.State.ASSIGNED)};
+        setInitialTopology(eventTypePartitions);
+        subscriptionClient.repartitionTopology(eventTypeName, 2);
+
+        Assert.assertEquals(subscriptionClient.getTopology().getPartitions().length, 3);
+        final List<Partition> eTPartitions =
+                Arrays.stream(subscriptionClient.getTopology().getPartitions())
+                        .filter(p -> p.getEventType().equals(secondEventTypeName)).collect(Collectors.toList());
+        Assert.assertEquals(eTPartitions.get(0).getState(), Partition.State.ASSIGNED);
+    }
+
+    private String subscriptionPath() {
+        final String parentPath = "/nakadi/subscriptions";
+        return String.format("%s/%s", parentPath, subscriptionId);
+    }
+
+    private String getOffsetPath(final String eventTypeName, final String partition) {
+        return String.format("%s/offsets/%s/%s", subscriptionPath(), eventTypeName, partition);
+    }
+
+    private void setInitialTopology(final Partition[] partitions) throws Exception {
+        final String topologyPath = subscriptionPath() + "/topology";
+        final byte[] topologyData = MAPPER.writeValueAsBytes(
+                new NewZkSubscriptionClient.Topology(partitions, null, 0));
+        if (null == CURATOR.checkExists().forPath(topologyPath)) {
+            CURATOR.create().creatingParentsIfNeeded().forPath(topologyPath, topologyData);
+        } else {
+            CURATOR.setData().forPath(topologyPath, topologyData);
+        }
+    }
+
+    @Test(timeout = 30000)
+    public void whenEventTypeRepartitionedSubscriptionStartsStreamNewPartitions() throws Exception {
+        final EventType eventType = NakadiTestUtils.createBusinessEventTypeWithPartitions(1);
+        final Subscription subscription = NakadiTestUtils.createSubscription(
+                RandomSubscriptionBuilder.builder()
+                        .withEventType(eventType.getName())
+                        .withStartFrom(SubscriptionBase.InitialPosition.BEGIN)
+                        .buildSubscriptionBase());
+
+        NakadiTestUtils.publishBusinessEventWithUserDefinedPartition(
+                eventType.getName(), 1, x -> "{\"foo\":\"bar\"}", p -> "0");
+
+        // create session, read from subscription and wait for events to be sent
+        final TestStreamingClient client = TestStreamingClient
+                .create(URL, subscription.getId(), "")
+                .startWithAutocommit(streamBatches -> LOG.info("{}", streamBatches));
+
+        TestUtils.waitFor(() -> MatcherAssert.assertThat(client.getBatches(), Matchers.hasSize(1)));
+        Assert.assertEquals("0", client.getBatches().get(0).getCursor().getPartition());
+
+        NakadiTestUtils.repartitionEventType(eventType, 2);
+        TestUtils.waitFor(() -> MatcherAssert.assertThat(client.isRunning(), Matchers.is(false)));
+
+        final TestStreamingClient clientAfterRepartitioning = TestStreamingClient
+                .create(URL, subscription.getId(), "")
+                .startWithAutocommit(streamBatches -> LOG.info("{}", streamBatches));
+
+        NakadiTestUtils.publishBusinessEventWithUserDefinedPartition(
+                eventType.getName(), 1, x -> "{\"foo\":\"bar" + x + "\"}", p -> "1");
+
+        TestUtils.waitFor(() -> MatcherAssert.assertThat(clientAfterRepartitioning.getBatches(), Matchers.hasSize(1)));
+        Assert.assertEquals("1", clientAfterRepartitioning.getBatches().get(0).getCursor().getPartition());
+    }
+
+}

--- a/src/acceptance-test/java/org/zalando/nakadi/webservice/utils/NakadiTestUtils.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/webservice/utils/NakadiTestUtils.java
@@ -104,6 +104,22 @@ public class NakadiTestUtils {
                 .post(format("/event-types/{0}/events", eventType));
     }
 
+    public static void repartitionEventType(final EventType eventType, final int partitionsNumber)
+            throws JsonProcessingException {
+        final EventTypeStatistics defaultStatistic = eventType.getDefaultStatistic();
+        defaultStatistic.setReadParallelism(partitionsNumber);
+        defaultStatistic.setWriteParallelism(partitionsNumber);
+        eventType.setDefaultStatistic(defaultStatistic);
+        final int statusCode = given()
+                .body(MAPPER.writeValueAsString(eventType))
+                .contentType(JSON)
+                .put(format("/event-types/{0}", eventType.getName()))
+                .getStatusCode();
+        if (statusCode != 200) {
+            throw new RuntimeException("Failed to repartition event type");
+        }
+    }
+
     public static void createTimeline(final String eventType) {
         given()
                 .body("{\"storage_id\": \"default\"}")

--- a/src/main/java/org/zalando/nakadi/domain/EventTypeStatistics.java
+++ b/src/main/java/org/zalando/nakadi/domain/EventTypeStatistics.java
@@ -68,7 +68,6 @@ public class EventTypeStatistics {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         final EventTypeStatistics that = (EventTypeStatistics) o;
         return Objects.equals(messagesPerMinute, that.messagesPerMinute)
                 && Objects.equals(messageSize, that.messageSize)

--- a/src/main/java/org/zalando/nakadi/exceptions/runtime/CannotAddPartitionToTopicException.java
+++ b/src/main/java/org/zalando/nakadi/exceptions/runtime/CannotAddPartitionToTopicException.java
@@ -1,0 +1,7 @@
+package org.zalando.nakadi.exceptions.runtime;
+
+public class CannotAddPartitionToTopicException extends NakadiBaseException {
+    public CannotAddPartitionToTopicException(final String msg, final Exception cause) {
+        super(msg, cause);
+    }
+}

--- a/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
+++ b/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
@@ -231,7 +231,8 @@ public class LoggingFilter extends OncePerRequestFilter {
                 .put("event_type", eventType)
                 .put("http.status_code", statusCode)
                 .put("slo_bucket", sloBucket)
-                .put("content_length", requestLogInfo.contentLength).build());
+                .put("content_length", requestLogInfo.contentLength)
+                .put("error", statusCode == 207 || statusCode >= 500).build());
     }
 
     private boolean isSuccessPublishingRequest(final RequestLogInfo requestLogInfo, final int statusCode) {
@@ -241,6 +242,12 @@ public class LoggingFilter extends OncePerRequestFilter {
     private boolean isPublishingRequest(final RequestLogInfo requestLogInfo) {
         return requestLogInfo.path != null && "POST".equals(requestLogInfo.method) &&
                 requestLogInfo.path.startsWith("/event-types/") &&
+                (requestLogInfo.path.endsWith("/events") || requestLogInfo.path.endsWith("/events/"));
+    }
+
+    private boolean isConsumptionRequest(final RequestLogInfo requestLogInfo) {
+        return requestLogInfo.path != null && "GET".equals(requestLogInfo.method) &&
+                requestLogInfo.path.startsWith("/subscriptions/") &&
                 (requestLogInfo.path.endsWith("/events") || requestLogInfo.path.endsWith("/events/"));
     }
 }

--- a/src/main/java/org/zalando/nakadi/repository/KafkaRepositoryCreator.java
+++ b/src/main/java/org/zalando/nakadi/repository/KafkaRepositoryCreator.java
@@ -59,11 +59,13 @@ public class KafkaRepositoryCreator implements TopicRepositoryCreator {
                     zookeeperSettings.getZkSessionTimeoutMs(),
                     zookeeperSettings.getZkConnectionTimeoutMs(),
                     nakadiSettings);
+            final KafkaLocationManager kafkaLocationManager = new KafkaLocationManager(zooKeeperHolder, kafkaSettings);
             final KafkaFactory kafkaFactory =
                     new KafkaFactory(new KafkaLocationManager(zooKeeperHolder, kafkaSettings), metricRegistry);
             final KafkaZookeeper zk = new KafkaZookeeper(zooKeeperHolder, objectMapper);
             final KafkaTopicRepository kafkaTopicRepository = new KafkaTopicRepository(zk,
-                    kafkaFactory, nakadiSettings, kafkaSettings, zookeeperSettings, kafkaTopicConfigFactory);
+                    kafkaFactory, nakadiSettings, kafkaSettings, zookeeperSettings, kafkaTopicConfigFactory,
+                    kafkaLocationManager);
             // check that it does work
             kafkaTopicRepository.listTopics();
             return kafkaTopicRepository;

--- a/src/main/java/org/zalando/nakadi/repository/TopicRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/TopicRepository.java
@@ -7,6 +7,7 @@ import org.zalando.nakadi.domain.PartitionEndStatistics;
 import org.zalando.nakadi.domain.PartitionStatistics;
 import org.zalando.nakadi.domain.Timeline;
 import org.zalando.nakadi.domain.TopicPartition;
+import org.zalando.nakadi.exceptions.runtime.CannotAddPartitionToTopicException;
 import org.zalando.nakadi.exceptions.runtime.EventPublishingException;
 import org.zalando.nakadi.exceptions.runtime.InvalidCursorException;
 import org.zalando.nakadi.exceptions.runtime.ServiceTemporarilyUnavailableException;
@@ -49,6 +50,9 @@ public interface TopicRepository {
     void syncPostBatch(String topicId, List<BatchItem> batch, Span parentSpan, String eventTypeName)
             throws EventPublishingException;
 
+    void repartition(String topic, int partitionsNumber) throws CannotAddPartitionToTopicException,
+            TopicConfigException;
+    
     Optional<PartitionStatistics> loadPartitionStatistics(Timeline timeline, String partition)
             throws ServiceTemporarilyUnavailableException;
 

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -52,6 +52,10 @@ public class KafkaLocationManager {
         }
     }
 
+    public Properties getProperties() {
+        return (Properties) kafkaProperties.clone();
+    }
+
     private void updateBootstrapServers(final boolean createWatcher) {
         final List<Broker> brokers = new ArrayList<>();
         try {

--- a/src/main/java/org/zalando/nakadi/service/CursorsService.java
+++ b/src/main/java/org/zalando/nakadi/service/CursorsService.java
@@ -203,7 +203,7 @@ public class CursorsService {
                     .map(cursorConverter::convertToNoToken)
                     .collect(Collectors.toList());
 
-            zkClient.resetCursors(newCursors, timeout);
+            zkClient.closeSubscriptionStreams(() -> zkClient.forceCommitOffsets(newCursors), timeout);
 
             auditLogPublisher.publish(
                     Optional.of(new ItemsWrapper<>(oldCursors)),

--- a/src/main/java/org/zalando/nakadi/service/EventPublisher.java
+++ b/src/main/java/org/zalando/nakadi/service/EventPublisher.java
@@ -215,6 +215,8 @@ public class EventPublisher {
             throws EventValidationException, InternalNakadiException, NoSuchEventTypeException {
         final Span validationSpan = TracingService.getNewSpan("validation", System.currentTimeMillis(),
                 parentSpan);
+        TracingService.setCustomTags(validationSpan, ImmutableMap.<String, Object>builder()
+                .put("event_type", eventType).build());
         try (Scope validationScope = TracingService.activateSpan(validationSpan, false)) {
             for (final BatchItem item : batch) {
                 item.setStep(EventPublishingStep.VALIDATING);

--- a/src/main/java/org/zalando/nakadi/service/StaticStorageWorkerFactory.java
+++ b/src/main/java/org/zalando/nakadi/service/StaticStorageWorkerFactory.java
@@ -13,7 +13,7 @@ public class StaticStorageWorkerFactory {
         long totalEventsInPartition(Timeline timeline, String partitionString);
 
         String getBeforeFirstOffset();
-
+        Timeline.KafkaStoragePosition getLatestPosition(Timeline timeline);
     }
 
     public static StaticStorageWorker get(final Storage storage) {
@@ -42,6 +42,11 @@ public class StaticStorageWorkerFactory {
         @Override
         public String getBeforeFirstOffset() {
             return "-1"; // Yes, it is always like that for kafka.
+        }
+
+        @Override
+        public Timeline.KafkaStoragePosition getLatestPosition(final Timeline timeline) {
+            return (Timeline.KafkaStoragePosition) timeline.getLatestPosition();
         }
 
     }

--- a/src/main/java/org/zalando/nakadi/service/TracingService.java
+++ b/src/main/java/org/zalando/nakadi/service/TracingService.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableMap;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
-import io.opentracing.tag.Tags;
 import io.opentracing.util.GlobalTracer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,20 +17,25 @@ import java.util.concurrent.TimeUnit;
 public class TracingService {
     private static final Logger LOG = LoggerFactory.getLogger(TracingService.class);
 
-    public static Scope getScope(final String operationName, final boolean autoCloseSpan, final Span parent,
-                                 final String... eventType) {
-        final Scope scope = GlobalTracer.get().buildSpan(operationName)
-                .asChildOf(parent).startActive(autoCloseSpan);
-        if (eventType.length > 0) {
-            scope.span().setTag("event_type", eventType[0]);
-        }
-        return scope;
-    }
-
-    public static void setErrorTags(final Scope scope, final String error) {
-        Tags.ERROR.set(scope.span(), true);
+    public static void logErrorInSpan(final Scope scope, final String error) {
         if (error != null) {
             scope.span().log(ImmutableMap.of("error:", error));
+        }
+    }
+
+    public static void setCustomTags(final Span span, final Map<String, Object> tags) {
+
+        for (final Map.Entry<String, Object> entry : tags.entrySet()) {
+            if (entry.getValue() instanceof Boolean) {
+                span.setTag(entry.getKey(), (Boolean) entry.getValue());
+            } else if (entry.getValue() instanceof Number) {
+                span.setTag(entry.getKey(), (Number) entry.getValue());
+            } else if (entry.getValue() instanceof String) {
+                span.setTag(entry.getKey(), (String) entry.getValue());
+            } else {
+                LOG.warn("Tag is not of the expected type");
+                continue;
+            }
         }
     }
 

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StartingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StartingState.java
@@ -86,7 +86,7 @@ public class StartingState extends State {
             }
         }
 
-        if (getZk().isCursorResetInProgress()) {
+        if (getZk().isCloseSubscriptionStreamsInProgress()) {
             switchState(new CleanupState(
                     new ConflictException("Resetting subscription cursors request is still in progress")));
             return;

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -107,7 +107,7 @@ class StreamingState extends State {
         this.lastCommitMillis = System.currentTimeMillis();
         scheduleTask(this::checkCommitTimeout, getParameters().commitTimeoutMillis, TimeUnit.MILLISECONDS);
 
-        cursorResetSubscription = getZk().subscribeForCursorsReset(
+        cursorResetSubscription = getZk().subscribeForStreamClose(
                 () -> addTask(this::resetSubscriptionCursorsCallback));
     }
 

--- a/src/main/java/org/zalando/nakadi/validation/JsonSchemaEnrichment.java
+++ b/src/main/java/org/zalando/nakadi/validation/JsonSchemaEnrichment.java
@@ -6,7 +6,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.zalando.nakadi.domain.CleanupPolicy;
 import org.zalando.nakadi.domain.CompatibilityMode;
-import org.zalando.nakadi.domain.EventType;
+import org.zalando.nakadi.domain.EventTypeBase;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,7 +31,7 @@ public class JsonSchemaEnrichment {
             "items");
     private static final List<String> COMPOSED_SCHEMA_KEYWORDS = ImmutableList.of("anyOf", "allOf", "oneOf");
 
-    public JSONObject effectiveSchema(final EventType eventType) throws JSONException {
+    public JSONObject effectiveSchema(final EventTypeBase eventType) throws JSONException {
         final JSONObject schema = new JSONObject(eventType.getSchema().getSchema());
 
         if (eventType.getCompatibilityMode().equals(CompatibilityMode.COMPATIBLE)) {
@@ -116,7 +116,7 @@ public class JsonSchemaEnrichment {
         );
     }
 
-    private static JSONObject wrapSchemaInData(final JSONObject schema, final EventType eventType) {
+    private static JSONObject wrapSchemaInData(final JSONObject schema, final EventTypeBase eventType) {
         final JSONObject wrapper = new JSONObject();
 
         normalizeSchema(wrapper);
@@ -147,7 +147,7 @@ public class JsonSchemaEnrichment {
         }
     }
 
-    private static JSONObject addMetadata(final JSONObject schema, final EventType eventType) {
+    private static JSONObject addMetadata(final JSONObject schema, final EventTypeBase eventType) {
         normalizeSchema(schema);
 
         final JSONObject metadata = new JSONObject();

--- a/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
@@ -21,6 +21,7 @@ import org.zalando.nakadi.domain.EventCategory;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeBase;
 import org.zalando.nakadi.domain.EventTypeOptions;
+import org.zalando.nakadi.domain.EventTypeStatistics;
 import org.zalando.nakadi.domain.ResourceAuthorization;
 import org.zalando.nakadi.domain.ResourceAuthorizationAttribute;
 import org.zalando.nakadi.domain.Subscription;
@@ -137,6 +138,64 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
         eventType.getSchema().setSchema("{}");
         postEventType(eventType).andExpect(status().isCreated()).andExpect(
                 header().string("Warning", "299 nakadi \"I am warning you. I am warning you, even more\""));
+    }
+
+    @Test
+    public void whenChangeDefaultStatiticsWithoutAnyChangeInPartitionThen422() throws Exception {
+        final EventType originalEventType = EventTypeTestBuilder.builder()
+                .build();
+
+        final EventType updatedEventType = EventTypeTestBuilder.builder()
+                .name(originalEventType.getName())
+                .defaultStatistic(new EventTypeStatistics(0,1))
+                .build();
+
+        doReturn(originalEventType).when(eventTypeRepository).findByName(any());
+
+        putEventType(updatedEventType, originalEventType.getName())
+                .andExpect(status().isUnprocessableEntity());
+
+        final EventType updatedEventType1 = EventTypeTestBuilder.builder()
+                .name(originalEventType.getName())
+                .defaultStatistic(new EventTypeStatistics(100, 100))
+                .build();
+        putEventType(updatedEventType1, originalEventType.getName())
+                .andExpect(status().isUnprocessableEntity());
+
+    }
+
+    @Test
+    public void whenIncreaseNumberOfPartitionThen200() throws Exception {
+        final EventType originalEventType = EventTypeTestBuilder.builder()
+                .build();
+
+        final EventType updatedEventType = EventTypeTestBuilder.builder()
+                .name(originalEventType.getName())
+                .defaultStatistic(new EventTypeStatistics(3, 3))
+                .build();
+
+        doReturn(originalEventType).when(eventTypeRepository).findByName(any());
+
+        putEventType(updatedEventType, originalEventType.getName())
+                .andExpect(status().isOk());
+
+        final EventType updatedEventType1 = EventTypeTestBuilder.builder()
+                .name(originalEventType.getName())
+                .defaultStatistic(new EventTypeStatistics(1, 1))
+                .build();
+
+        putEventType(updatedEventType1, originalEventType.getName())
+                .andExpect(status().isOk());
+
+        final EventType updatedEventType2 = EventTypeTestBuilder.builder()
+                .name(originalEventType.getName())
+                .defaultStatistic(null)
+                .build();
+
+        doReturn(originalEventType).when(eventTypeRepository).findByName(any());
+
+        putEventType(updatedEventType2, originalEventType.getName())
+                .andExpect(status().isOk());
     }
 
     @Test

--- a/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
@@ -32,6 +32,7 @@ import org.zalando.nakadi.service.EventTypeService;
 import org.zalando.nakadi.service.FeatureToggleService;
 import org.zalando.nakadi.service.NakadiAuditLogPublisher;
 import org.zalando.nakadi.service.NakadiKpiPublisher;
+import org.zalando.nakadi.service.subscription.zk.SubscriptionClientFactory;
 import org.zalando.nakadi.service.TracingService;
 import org.zalando.nakadi.service.timeline.TimelineService;
 import org.zalando.nakadi.service.timeline.TimelineSync;
@@ -98,7 +99,7 @@ public class EventTypeControllerTestCase {
     @Before
     public void init() throws Exception {
 
-        final NakadiSettings nakadiSettings = new NakadiSettings(0, 0, 0, TOPIC_RETENTION_TIME_MS, 0, 60,
+        final NakadiSettings nakadiSettings = new NakadiSettings(32, 0, 0, TOPIC_RETENTION_TIME_MS, 0, 60,
                 NAKADI_POLL_TIMEOUT, NAKADI_SEND_TIMEOUT, 0, NAKADI_EVENT_MAX_BYTES,
                 NAKADI_SUBSCRIPTION_MAX_PARTITIONS, "service", "nakadi", "I am warning you",
                 "I am warning you, even more", "nakadi_archiver", "nakadi_to_s3");
@@ -118,7 +119,7 @@ public class EventTypeControllerTestCase {
                 partitionResolver, enrichment, subscriptionRepository, schemaEvolutionService, partitionsCalculator,
                 featureToggleService, authorizationValidator, timelineSync, transactionTemplate, nakadiSettings,
                 nakadiKpiPublisher, "et-log-event-type", nakadiAuditLogPublisher,
-                eventTypeOptionsValidator, adminService);
+                eventTypeOptionsValidator, adminService, mock(SubscriptionClientFactory.class), 1000);
         final EventTypeController controller = new EventTypeController(eventTypeService, featureToggleService,
                 adminService, nakadiSettings);
         doReturn(randomUUID).when(uuid).randomUUID();

--- a/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -64,6 +64,7 @@ public class KafkaTopicRepositoryTest {
     private final KafkaSettings kafkaSettings = mock(KafkaSettings.class);
     private final ZookeeperSettings zookeeperSettings = mock(ZookeeperSettings.class);
     private final KafkaTopicConfigFactory kafkaTopicConfigFactory = mock(KafkaTopicConfigFactory.class);
+    private final KafkaLocationManager kafkaLocationManager = mock(KafkaLocationManager.class);
     private static final String KAFKA_CLIENT_ID = "application_name-topic_name";
 
     @SuppressWarnings("unchecked")
@@ -372,7 +373,7 @@ public class KafkaTopicRepositoryTest {
         stats2.get("t3").put("0", 222L);
         when(kz.getSizeStatsForBroker(eq("2"))).thenReturn(new BubukuSizeStats(null, stats2));
 
-        final KafkaTopicRepository ktr = new KafkaTopicRepository(kz, null, null, null, null, null);
+        final KafkaTopicRepository ktr = new KafkaTopicRepository(kz, null, null, null, null, null, null);
 
         final Map<TopicPartition, Long> result = ktr.getSizeStats();
 
@@ -394,7 +395,7 @@ public class KafkaTopicRepositoryTest {
                     nakadiSettings,
                     kafkaSettings,
                     zookeeperSettings,
-                    kafkaTopicConfigFactory);
+                    kafkaTopicConfigFactory, kafkaLocationManager);
         } catch (final Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/org/zalando/nakadi/service/CursorOperationsServiceTest.java
+++ b/src/test/java/org/zalando/nakadi/service/CursorOperationsServiceTest.java
@@ -10,6 +10,7 @@ import org.zalando.nakadi.domain.Timeline;
 import org.zalando.nakadi.exceptions.runtime.InvalidCursorOperation;
 import org.zalando.nakadi.repository.TopicRepository;
 import org.zalando.nakadi.repository.kafka.KafkaFactory;
+import org.zalando.nakadi.repository.kafka.KafkaLocationManager;
 import org.zalando.nakadi.repository.kafka.KafkaSettings;
 import org.zalando.nakadi.repository.kafka.KafkaTopicConfigFactory;
 import org.zalando.nakadi.repository.kafka.KafkaTopicRepository;
@@ -325,7 +326,8 @@ public class CursorOperationsServiceTest {
                 mock(NakadiSettings.class),
                 mock(KafkaSettings.class),
                 mock(ZookeeperSettings.class),
-                mock(KafkaTopicConfigFactory.class));
+                mock(KafkaTopicConfigFactory.class),
+                mock(KafkaLocationManager.class));
         when(timelineService.getTopicRepository(timeline)).thenReturn(repository);
         return timeline;
     }

--- a/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
+++ b/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
@@ -20,6 +20,7 @@ import org.zalando.nakadi.exceptions.runtime.ConflictException;
 import org.zalando.nakadi.exceptions.runtime.EventTypeDeletionException;
 import org.zalando.nakadi.exceptions.runtime.FeatureNotAvailableException;
 import org.zalando.nakadi.exceptions.runtime.InternalNakadiException;
+import org.zalando.nakadi.exceptions.runtime.InvalidEventTypeException;
 import org.zalando.nakadi.exceptions.runtime.TopicCreationException;
 import org.zalando.nakadi.partitioning.PartitionResolver;
 import org.zalando.nakadi.repository.EventTypeRepository;
@@ -219,13 +220,18 @@ public class EventTypeServiceTest {
     }
 
     @Test
-    public void testAllowCreatingEventTypeWithInformationalFieldsFromEffectiveSchema(){
+    public void testAllowCreatingEventTypeWithInformationalFieldsFromEffectiveSchema() {
         final EventType et = EventTypeTestBuilder.builder()
                 .category(EventCategory.DATA)
                 .build();
         et.setOrderingKeyFields(Collections.singletonList("metadata.occurred_at"));
         et.setOrderingInstanceIds(Collections.singletonList("metadata.partition"));
-        eventTypeService.create(et, true);
+
+        try {
+            eventTypeService.create(et, true);
+        } catch (final InvalidEventTypeException e) {
+            fail("Cannot create event with informational fields from effective schema");
+        }
     }
 
     @Test(expected = FeatureNotAvailableException.class)

--- a/src/test/java/org/zalando/nakadi/service/NakadiAuditLogPublisherTest.java
+++ b/src/test/java/org/zalando/nakadi/service/NakadiAuditLogPublisherTest.java
@@ -63,51 +63,38 @@ public class NakadiAuditLogPublisherTest {
                 NakadiAuditLogPublisher.ActionType.CREATED, "et-name");
 
         final ArgumentCaptor<JSONObject> supplierCaptor = ArgumentCaptor.forClass(JSONObject.class);
-        verify(processor, times(1)).enrichAndSubmit(eq("audit-event-type"), supplierCaptor.capture());
-
-        assertThat(new JSONObject("{" +
-                        "\"data_op\":\"C\"," +
-                        "\"data\":{" +
-                        "\"new_object\":{" +
-                        "\"schema\":{" +
-                        "\"schema\":\"{ \\\"properties\\\": { \\\"foo\\\": { \\\"type\\\": \\\"string\\\"" +
-                        " } } }\"," +
-                        "\"created_at\":\"2019-01-16T13:44:16.819Z\"," +
-                        "\"type\":\"json_schema\"," +
-                        "\"version\":\"1.0.0\"" +
-                        "}," +
-                        "\"compatibility_mode\":\"compatible\"," +
-                        "\"ordering_key_fields\":[]," +
-                        "\"created_at\":\"2019-01-16T13:44:16.819Z\"," +
-                        "\"cleanup_policy\":\"delete\"," +
-                        "\"ordering_instance_ids\":[]," +
-                        "\"authorization\":null," +
-                        "\"partition_key_fields\":[]," +
+        verify(processor, times(1)).enrichAndSubmit(eq("audit-event-type"),
+                supplierCaptor.capture());
+        assertThat(new JSONObject("{\"data_op\":\"C\",\"data\":{\"new_object\":{\"schema\":" +
+                        "{\"schema\":\"{ \\\"properties\\\": { \\\"foo\\\": { \\\"type\\\": \\\"string\\\" " +
+                        "} } }\",\"created_at\":\"2019-01-16T13:44:16.819Z\",\"type\":\"json_schema\"," +
+                        "\"version\":\"1.0.0\"},\"compatibility_mode\":\"compatible\",\"ordering_key_fields\":[]," +
+                        "\"created_at\":\"2019-01-16T13:44:16.819Z\",\"cleanup_policy\":\"delete\"," +
+                        "\"ordering_instance_ids\":[],\"authorization\":null,\"partition_key_fields\":[]," +
                         "\"updated_at\":\"2019-01-16T13:44:16.819Z\"," +
-                        "\"default_statistic\":null," +
-                        "\"name\":\"new-et-name\"," +
-                        "\"options\":{\"retention_time\":172800000}," +
-                        "\"partition_strategy\":\"random\"," +
-                        "\"owning_application\":\"event-producer-application\"," +
-                        "\"enrichment_strategies\":[]," +
-                        "\"category\":\"undefined\"" +
-                        "}," +
-                        "\"new_text\":\"{\\\"name\\\":\\\"new-et-name\\\",\\\"owning_application\\\":\\\"event" +
-                        "-producer-application\\\",\\\"category\\\":\\\"undefined\\\",\\\"enrichment_strategies\\\"" +
-                        ":[],\\\"partition_strategy\\\":\\\"random\\\",\\\"partition_key_fields\\\":[],\\\"cleanup" +
-                        "_policy\\\":\\\"delete\\\",\\\"ordering_key_fields\\\":[],\\\"ordering_instance_ids\\\":[" +
-                        "],\\\"schema\\\":{\\\"type\\\":\\\"json_schema\\\",\\\"schema\\\":\\\"{ \\\\\\\"propertie" +
-                        "s\\\\\\\": { \\\\\\\"foo\\\\\\\": { \\\\\\\"type\\\\\\\": \\\\\\\"string\\\\\\\" } } }\\\"" +
-                        ",\\\"version\\\":\\\"1.0.0\\\",\\\"created_at\\\":\\\"2019-01-16T13:44:16.819Z\\\"},\\\"d" +
-                        "efault_statistic\\\":null,\\\"options\\\":{\\\"retention_time\\\":172800000},\\\"authoriz" +
-                        "ation\\\":null,\\\"compatibility_mode\\\":\\\"compatible\\\",\\\"updated_at\\\":\\\"2019-" +
-                        "01-16T13:44:16.819Z\\\",\\\"created_at\\\":\\\"2019-01-16T13:44:16.819Z\\\"}\"," +
-                        "\"resource_type\":\"event_type\"," +
-                        "\"resource_id\":\"et-name\"," +
-                        "\"user\":\"user-name\"," +
-                        "\"user_hash\":\"89bc5f7398509d3ce86c013c138e11357ff7f589fca9d58cfce443c27f81956c\"" +
-                        "}," +
-                        "\"data_type\":\"event_type\"}").toString(),
+                        "\"default_statistic\":{\"read_parallelism\":1," +
+                        "\"messages_per_minute\":1,\"message_size\":1,\"write_parallelism\":1}," +
+                        "\"name\":\"new-et-name\",\"options\":{\"retention_time\":172800000}," +
+                        "\"partition_strategy\":\"random\",\"owning_application\":\"event-producer-application\"," +
+                        "\"enrichment_strategies\":[],\"category\":\"undefined\"}," +
+                        "\"new_text\":\"{\\\"name\\\":\\\"new-et-name\\\"," +
+                        "\\\"owning_application\\\":\\\"event-producer-application\\\"," +
+                        "\\\"category\\\":\\\"undefined\\\",\\\"enrichment_strategies\\\":[]," +
+                        "\\\"partition_strategy\\\":\\\"random\\\",\\\"partition_key_fields\\\":[]," +
+                        "\\\"cleanup_policy\\\":\\\"delete\\\",\\\"ordering_key_fields\\\":[]," +
+                        "\\\"ordering_instance_ids\\\":[],\\\"schema\\\":{\\\"type\\\":\\\"json_schema\\\"," +
+                        "\\\"schema\\\":\\\"{ \\\\\\\"properties\\\\\\\": { \\\\\\\"foo\\\\\\\": " +
+                        "{ \\\\\\\"type\\\\\\\": \\\\\\\"string\\\\\\\" } } }\\\",\\\"version\\\":\\\"1.0.0\\\"," +
+                        "\\\"created_at\\\":\\\"2019-01-16T13:44:16.819Z\\\"}," +
+                        "\\\"default_statistic\\\":{\\\"messages_per_minute\\\":1,\\\"message_size\\\":1," +
+                        "\\\"read_parallelism\\\":1,\\\"write_parallelism\\\":1}," +
+                        "\\\"options\\\":{\\\"retention_time\\\":172800000}," +
+                        "\\\"authorization\\\":null,\\\"compatibility_mode\\\":\\\"compatible\\\"," +
+                        "\\\"updated_at\\\":\\\"2019-01-16T13:44:16.819Z\\\"," +
+                        "\\\"created_at\\\":\\\"2019-01-16T13:44:16.819Z\\\"}\"," +
+                        "\"user_hash\":\"89bc5f7398509d3ce86c013c138e11357ff7f589fca9d58cfce443c27f81956c\"," +
+                        "\"resource_type\":\"event_type\",\"resource_id\":\"et-name\",\"user\":\"user-name\"}," +
+                        "\"data_type\":\"event_type\"}\n").toString(),
                 sameJSONAs(supplierCaptor.getValue().toString()));
     }
 

--- a/src/test/java/org/zalando/nakadi/utils/EventTypeTestBuilder.java
+++ b/src/test/java/org/zalando/nakadi/utils/EventTypeTestBuilder.java
@@ -57,6 +57,7 @@ public class EventTypeTestBuilder {
                 "1.0.0", randomDate());
         this.options = new EventTypeOptions();
         this.options.setRetentionTime(172800000L);
+        this.defaultStatistic = new EventTypeStatistics(1,1);
         this.compatibilityMode = CompatibilityMode.COMPATIBLE;
         this.cleanupPolicy = CleanupPolicy.DELETE;
         this.createdAt = new DateTime(DateTimeZone.UTC);

--- a/src/test/resources/sample-event-type-repartition.json
+++ b/src/test/resources/sample-event-type-repartition.json
@@ -8,8 +8,11 @@
     "type": "json_schema",
     "schema": "{\"type\": \"object\", \"properties\": {\"foo\": {\"type\": \"string\"}, \"bar\": {\"type\": \"object\", \"properties\": {\"baz\": {\"type\": \"string\"}}}}, \"required\": [\"foo\"]}"
   },
-  "options" : {
-    "retention_time": 86400000
+  "default_statistic": {
+    "messages_per_minute": 1000,
+    "message_size":	5,
+    "read_parallelism":	3,
+    "write_parallelism": 3
   },
   "audience": "external-public"
 }


### PR DESCRIPTION
# Validating informational fields (ordering_key_fields and ordering_instance_ids) against effective schema.

> Zalando ticket : [ARUHA-2048](https://jira.zalando.net/browse/ARUHA-2048)

## Description
Both ordering_key_fields and ordering_instance_ids are validated against the user-provided schema during event type creation, but the documentation (and the API guild) say that it should be validated against the effective schema, such that people could reference the metadata object, for example.

AC:
Both fields validated against the effective schema during event type creation.


## Review
- [ ] Tests
- [ ] Documentation

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
