### PR TITLE
Trigger repartitioning only if parallelism changes

### DIFF
--- a/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -546,8 +546,7 @@ public class EventTypeService {
             if (getMaxPartitions(newStatistics) == 1) {
                 return;
             } else {
-                updateNumberOfPartitions(original, newEventType, Math.max(newStatistics.getReadParallelism(),
-                        newStatistics.getWriteParallelism()));
+                updateNumberOfPartitions(original, newEventType, getMaxPartitions(newStatistics));
                 return;
             }
         }

--- a/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -542,20 +542,22 @@ public class EventTypeService {
         }
 
         if (existingStatistics == null) {
-            updateNumberOfPartitions(original, newEventType, Math.max(newStatistics.getReadParallelism(),
-                    newStatistics.getWriteParallelism()));
-            return;
+            // number of existing partitions = 1
+            if (getMaxPartitions(newStatistics) == 1) {
+                return;
+            } else {
+                updateNumberOfPartitions(original, newEventType, Math.max(newStatistics.getReadParallelism(),
+                        newStatistics.getWriteParallelism()));
+                return;
+            }
         }
-        if (existingStatistics.getReadParallelism().equals(newStatistics.getReadParallelism())
-                && existingStatistics.getWriteParallelism().equals(newStatistics.getWriteParallelism())) {
+
+        if (existingStatistics.equals(newStatistics)) {
             return;
         }
 
-        final int newMaxPartitions = Math.max(newStatistics.getReadParallelism(),
-                newStatistics.getWriteParallelism());
-
-        final int oldMaxPartitions = Math.max(existingStatistics.getReadParallelism(),
-                existingStatistics.getWriteParallelism());
+        final int newMaxPartitions = getMaxPartitions(newStatistics);
+        final int oldMaxPartitions = getMaxPartitions(existingStatistics);
 
 
         if (newMaxPartitions > nakadiSettings.getMaxTopicPartitionCount()) {
@@ -574,6 +576,10 @@ public class EventTypeService {
             }
         }
         updateNumberOfPartitions(original, newEventType, newMaxPartitions);
+    }
+
+    private int getMaxPartitions(final EventTypeStatistics eventTypeStatistics) {
+        return Math.max(eventTypeStatistics.getReadParallelism(), eventTypeStatistics.getWriteParallelism());
     }
 
     private void updateNumberOfPartitions(final EventType original, final EventType eventType, final int partitions)

--- a/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -546,7 +546,8 @@ public class EventTypeService {
                     newStatistics.getWriteParallelism()));
             return;
         }
-        if (existingStatistics.equals(newStatistics)) {
+        if (existingStatistics.getReadParallelism().equals(newStatistics.getReadParallelism())
+                && existingStatistics.getWriteParallelism().equals(newStatistics.getWriteParallelism())) {
             return;
         }
 


### PR DESCRIPTION
Change re-partitioning only if parallelism parameters of `default-statistics` change.
For this we return if they are equal.