### PR TITLE
take only active timelines

### DIFF
--- a/src/main/java/org/zalando/nakadi/service/timeline/TimelineService.java
+++ b/src/main/java/org/zalando/nakadi/service/timeline/TimelineService.java
@@ -158,11 +158,11 @@ public class TimelineService {
 
     public void updateTimeLineForRepartition(final EventType eventType, final int partitions)
             throws NakadiBaseException {
-        for (final Timeline timeline : getAllTimelinesOrdered(eventType.getName())) {
+        for (final Timeline timeline : getActiveTimelinesOrdered(eventType.getName())) {
             getTopicRepository(eventType).repartition(timeline.getTopic(), partitions);
         }
 
-        for (final Timeline timeline : getAllTimelinesOrdered(eventType.getName())) {
+        for (final Timeline timeline : getActiveTimelinesOrdered(eventType.getName())) {
             final Timeline.KafkaStoragePosition latestPosition = StaticStorageWorkerFactory.get(timeline)
                     .getLatestPosition(timeline);
             if (latestPosition == null) {


### PR DESCRIPTION
# One-line summary
Only active timelines have to be taken for repartitioning
