### PR TITLE
Introduce batch_timespan consumption parameter

### DIFF
--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -1395,6 +1395,23 @@ paths:
                 type: number
                 format: int32
                 default: 30
+              batch_timespan:
+                description: |
+                  Useful for batching events based on their received_at timestamp. For example, if `batch_timespan` is 5
+                  seconds then Nakadi would flush a batch as soon as the difference in time between the first and the
+                  last event in the batch exceeds 5 seconds. It waits for an event outside of the window to signal the
+                  closure of a batch.
+
+                  This is different from `batch_flush_timeout` as it takes into consideration the `received_at`
+                  timestamp of events and not the time when the stream was open. This becomes clear considering there is
+                  an accumulated backlog of more than 5 seconds. Using `batch_timespan` would cause a batch to be
+                  flushed immediately, while `batch_flush_timeout` would wait for 5 seconds and flush the backglog plus
+                  the events that might have arrived since the stream was open.
+
+                  If 0 then this criteria is not used to close batches.
+                type: number
+                format: int32
+                default: 0
               stream_timeout:
                 description: |
                   Maximum time in seconds a stream will live before connection is closed by the server.

--- a/src/main/java/org/zalando/nakadi/controller/SubscriptionStreamController.java
+++ b/src/main/java/org/zalando/nakadi/controller/SubscriptionStreamController.java
@@ -178,14 +178,16 @@ public class SubscriptionStreamController {
                     maxUncommittedEvents,
             @Nullable @RequestParam(value = "batch_limit", required = false) final Integer batchLimit,
             @Nullable @RequestParam(value = "stream_limit", required = false) final Long streamLimit,
+            @Nullable @RequestParam(value = "batch_timespan", required = false) final Long batchTimespan,
             @Nullable @RequestParam(value = "batch_flush_timeout", required = false) final Integer batchTimeout,
             @Nullable @RequestParam(value = "stream_timeout", required = false) final Long streamTimeout,
             @Nullable @RequestParam(value = "stream_keep_alive_limit", required = false) final Integer
                     streamKeepAliveLimit,
             @Nullable @RequestParam(value = "commit_timeout", required = false) final Long commitTimeout,
             final HttpServletRequest request, final HttpServletResponse response, final Client client) {
-        final UserStreamParameters userParameters = new UserStreamParameters(batchLimit, streamLimit, batchTimeout,
-                streamTimeout, streamKeepAliveLimit, maxUncommittedEvents, ImmutableList.of(), commitTimeout);
+        final UserStreamParameters userParameters = new UserStreamParameters(batchLimit, streamLimit, batchTimespan,
+                batchTimeout, streamTimeout, streamKeepAliveLimit, maxUncommittedEvents, ImmutableList.of(),
+                commitTimeout);
 
         final StreamParameters streamParameters = StreamParameters.of(userParameters,
                 nakadiSettings.getMaxCommitTimeout(), client);

--- a/src/main/java/org/zalando/nakadi/service/subscription/StreamParameters.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/StreamParameters.java
@@ -21,6 +21,10 @@ public class StreamParameters {
      */
     private final Optional<Long> streamLimitEvents;
     /**
+     * Number of seconds to be batched based on Kafka record timestamp.
+     */
+    public final long batchTimespan;
+    /**
      * Timeout for collecting {@code batchLimitEvents} events. If not collected - send either not full batch
      * or keep alive message.
      */
@@ -55,6 +59,7 @@ public class StreamParameters {
             throw new WrongStreamParametersException("batch_limit can't be lower than 1");
         }
         this.streamLimitEvents = userParameters.getStreamLimit().filter(v -> v != 0);
+        this.batchTimespan = TimeUnit.SECONDS.toMillis(userParameters.getBatchTimespan().orElse(0L));
         this.batchTimeoutMillis = TimeUnit.SECONDS.toMillis(userParameters.getBatchFlushTimeout().orElse(30));
         this.streamTimeoutMillis = TimeUnit.SECONDS.toMillis(
                 userParameters.getStreamTimeout()

--- a/src/main/java/org/zalando/nakadi/service/subscription/StreamParameters.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/StreamParameters.java
@@ -21,7 +21,7 @@ public class StreamParameters {
      */
     private final Optional<Long> streamLimitEvents;
     /**
-     * Number of seconds to be batched based on Kafka record timestamp.
+     * Number of milliseconds to be batched based on Kafka record timestamp.
      */
     public final long batchTimespan;
     /**

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java
@@ -80,10 +80,8 @@ class PartitionData {
         final boolean timeReached = (currentTimeMillis - lastSendMillis) >= batchTimeoutMillis;
 
         if (batchTimespanMillis > 0 && lastRecordTimestamp() >= batchWindowEndTimestamp()) {
-            final long batchWindowEndTimestamp = batchWindowStartTimestamp + batchTimespanMillis;
-            batchWindowStartTimestamp = batchWindowEndTimestamp;
             lastSendMillis = currentTimeMillis;
-            return extractTimespan(batchWindowEndTimestamp);
+            return extractTimespan(batchWindowEndTimestamp());
         } else if (countReached || timeReached) {
             lastSendMillis = currentTimeMillis;
             batchWindowStartTimestamp = lastSendMillis;
@@ -115,6 +113,7 @@ class PartitionData {
     }
 
     private List<ConsumedEvent> extractTimespan(final long batchWindowEndTimestamp) {
+        batchWindowStartTimestamp = batchWindowEndTimestamp;
         return extract((i) -> nakadiEvents.get(0).getTimestamp() < batchWindowEndTimestamp);
     }
 

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -241,6 +241,7 @@ class StreamingState extends State {
             List<ConsumedEvent> toSend;
             while (null != (toSend = e.getValue().takeEventsToStream(
                     currentTimeMillis,
+                    getParameters().batchTimespan,
                     Math.min(getParameters().batchLimitEvents, messagesAllowedToSend),
                     getParameters().batchTimeoutMillis,
                     streamTimeoutReached))) {

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -241,7 +241,6 @@ class StreamingState extends State {
             List<ConsumedEvent> toSend;
             while (null != (toSend = e.getValue().takeEventsToStream(
                     currentTimeMillis,
-                    getParameters().batchTimespan,
                     Math.min(getParameters().batchLimitEvents, messagesAllowedToSend),
                     getParameters().batchTimeoutMillis,
                     streamTimeoutReached))) {
@@ -634,7 +633,8 @@ class StreamingState extends State {
                 cursor,
                 LoggerFactory.getLogger(LogPathBuilder.build(
                         getContext().getSubscription().getId(), getSessionId(), String.valueOf(partition.getKey()))),
-                System.currentTimeMillis());
+                System.currentTimeMillis(), this.getContext().getParameters().batchTimeoutMillis
+                );
 
         offsets.put(partition.getKey(), pd);
     }

--- a/src/main/java/org/zalando/nakadi/view/UserStreamParameters.java
+++ b/src/main/java/org/zalando/nakadi/view/UserStreamParameters.java
@@ -15,6 +15,8 @@ public class UserStreamParameters {
 
     private final Optional<Long> streamLimit;
 
+    private final Optional<Long> batchTimespan;
+
     private final Optional<Integer> batchFlushTimeout;
 
     private final Optional<Long> streamTimeout;
@@ -27,9 +29,11 @@ public class UserStreamParameters {
 
     private final Optional<Long> commitTimeoutSeconds;
 
+
     @JsonCreator
     public UserStreamParameters(@JsonProperty("batch_limit") @Nullable final Integer batchLimit,
                                 @JsonProperty("stream_limit") @Nullable final Long streamLimit,
+                                @JsonProperty("batch_timespan") @Nullable final Long batchTimespan,
                                 @JsonProperty("batch_flush_timeout") @Nullable final Integer batchFlushTimeout,
                                 @JsonProperty("stream_timeout") @Nullable final Long streamTimeout,
                                 @JsonProperty("stream_keep_alive_limit") @Nullable final Integer streamKeepAliveLimit,
@@ -38,6 +42,7 @@ public class UserStreamParameters {
                                 @JsonProperty("commit_timeout") @Nullable final Long commitTimeoutSeconds) {
         this.batchLimit = Optional.ofNullable(batchLimit);
         this.streamLimit = Optional.ofNullable(streamLimit);
+        this.batchTimespan = Optional.ofNullable(batchTimespan);
         this.batchFlushTimeout = Optional.ofNullable(batchFlushTimeout);
         this.streamTimeout = Optional.ofNullable(streamTimeout);
         this.streamKeepAliveLimit = Optional.ofNullable(streamKeepAliveLimit);
@@ -52,6 +57,10 @@ public class UserStreamParameters {
 
     public Optional<Long> getStreamLimit() {
         return streamLimit;
+    }
+
+    public Optional<Long> getBatchTimespan() {
+        return batchTimespan;
     }
 
     public Optional<Integer> getBatchFlushTimeout() {

--- a/src/test/java/org/zalando/nakadi/service/subscription/StreamParametersTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/StreamParametersTest.java
@@ -64,7 +64,8 @@ public class StreamParametersTest {
 
     @Test
     public void checkIsKeepAliveLimitReached() throws Exception {
-        final StreamParameters streamParameters = createStreamParameters(1, null, 0L, 0, null, 5, 0, 0, mock(Client.class));
+        final StreamParameters streamParameters = createStreamParameters(1, null, 0L, 0, null, 5, 0, 0,
+                mock(Client.class));
 
         assertThat(streamParameters.isKeepAliveLimitReached(IntStream.of(5, 7, 6, 12)), is(true));
         assertThat(streamParameters.isKeepAliveLimitReached(IntStream.of(5, 7, 4, 12)), is(false));
@@ -72,7 +73,8 @@ public class StreamParametersTest {
 
     @Test
     public void checkIsKeepAliveLimitReachedIndefinitely() throws Exception {
-        final StreamParameters streamParameters = createStreamParameters(1, null, 0L, 0, null, 0, 0, 0, mock(Client.class));
+        final StreamParameters streamParameters = createStreamParameters(1, null, 0L, 0, null, 0, 0, 0,
+                mock(Client.class));
 
         assertThat(streamParameters.isKeepAliveLimitReached(IntStream.of(5, 7, 6, 12)), is(false));
         assertThat(streamParameters.isKeepAliveLimitReached(IntStream.of(5, 7, 4, 12)), is(false));

--- a/src/test/java/org/zalando/nakadi/service/subscription/StreamParametersTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/StreamParametersTest.java
@@ -21,12 +21,12 @@ public class StreamParametersTest {
 
     @Test(expected = WrongStreamParametersException.class)
     public void whenBatchLimitLowerOrEqualToZeroTheException() throws Exception {
-        createStreamParameters(0, null, 0, null, null, 0, 0, mock(Client.class));
+        createStreamParameters(0, null, 0L, 0, null, null, 0, 0, mock(Client.class));
     }
 
     @Test
     public void checkParamsAreTransformedCorrectly() throws Exception {
-        final StreamParameters streamParameters = createStreamParameters(1, null, 10, 60L, null, 1000, 20,
+        final StreamParameters streamParameters = createStreamParameters(1, null, 0L, 10, 60L, null, 1000, 20,
                 mock(Client.class));
 
         assertThat(streamParameters.batchLimitEvents, equalTo(1));
@@ -38,7 +38,7 @@ public class StreamParametersTest {
 
     @Test
     public void whenStreamTimeoutOmittedThenItIsGenerated() throws Exception {
-        final StreamParameters streamParameters = createStreamParameters(1, null, 0, null, null, 0, 0,
+        final StreamParameters streamParameters = createStreamParameters(1, null, 0L, 0, null, null, 0, 0,
                 mock(Client.class));
 
         checkStreamTimeoutIsGeneratedCorrectly(streamParameters);
@@ -46,7 +46,7 @@ public class StreamParametersTest {
 
     @Test
     public void whenStreamTimeoutIsGreaterThanMaxThenItIsGenerated() throws Exception {
-        final StreamParameters streamParameters = createStreamParameters(1, null, 0,
+        final StreamParameters streamParameters = createStreamParameters(1, null, 0L, 0,
                 EventStreamConfig.MAX_STREAM_TIMEOUT + 1L, null, 0, 0, mock(Client.class));
 
         checkStreamTimeoutIsGeneratedCorrectly(streamParameters);
@@ -54,7 +54,7 @@ public class StreamParametersTest {
 
     @Test
     public void checkIsStreamLimitReached() throws Exception {
-        final StreamParameters streamParameters = createStreamParameters(1, 150L, 0, null, null, 0, 0,
+        final StreamParameters streamParameters = createStreamParameters(1, 150L, 0L, 0, null, null, 0, 0,
                 mock(Client.class));
 
         assertThat(streamParameters.isStreamLimitReached(140), is(false));
@@ -64,7 +64,7 @@ public class StreamParametersTest {
 
     @Test
     public void checkIsKeepAliveLimitReached() throws Exception {
-        final StreamParameters streamParameters = createStreamParameters(1, null, 0, null, 5, 0, 0, mock(Client.class));
+        final StreamParameters streamParameters = createStreamParameters(1, null, 0L, 0, null, 5, 0, 0, mock(Client.class));
 
         assertThat(streamParameters.isKeepAliveLimitReached(IntStream.of(5, 7, 6, 12)), is(true));
         assertThat(streamParameters.isKeepAliveLimitReached(IntStream.of(5, 7, 4, 12)), is(false));
@@ -72,7 +72,7 @@ public class StreamParametersTest {
 
     @Test
     public void checkIsKeepAliveLimitReachedIndefinitely() throws Exception {
-        final StreamParameters streamParameters = createStreamParameters(1, null, 0, null, 0, 0, 0, mock(Client.class));
+        final StreamParameters streamParameters = createStreamParameters(1, null, 0L, 0, null, 0, 0, 0, mock(Client.class));
 
         assertThat(streamParameters.isKeepAliveLimitReached(IntStream.of(5, 7, 6, 12)), is(false));
         assertThat(streamParameters.isKeepAliveLimitReached(IntStream.of(5, 7, 4, 12)), is(false));
@@ -80,7 +80,7 @@ public class StreamParametersTest {
 
     @Test
     public void checkGetMessagesAllowedToSend() throws Exception {
-        final StreamParameters streamParameters = createStreamParameters(1, 200L, 0, null, null, 0, 0,
+        final StreamParameters streamParameters = createStreamParameters(1, 200L, 0L,0, null, null, 0, 0,
                 mock(Client.class));
 
         assertThat(streamParameters.getMessagesAllowedToSend(50, 190), equalTo(10L));
@@ -96,6 +96,7 @@ public class StreamParametersTest {
 
     public static StreamParameters createStreamParameters(final int batchLimitEvents,
                                                           final Long streamLimitEvents,
+                                                          final Long batchTimespan,
                                                           final int batchTimeoutSeconds,
                                                           final Long streamTimeoutSeconds,
                                                           final Integer batchKeepAliveIterations,
@@ -103,8 +104,8 @@ public class StreamParametersTest {
                                                           final long commitTimeoutSeconds,
                                                           final Client client) throws WrongStreamParametersException {
         final UserStreamParameters userParams = new UserStreamParameters(batchLimitEvents, streamLimitEvents,
-                batchTimeoutSeconds, streamTimeoutSeconds, batchKeepAliveIterations, maxUncommittedMessages,
-                ImmutableList.of(), commitTimeoutSeconds);
+                batchTimespan, batchTimeoutSeconds, streamTimeoutSeconds, batchKeepAliveIterations,
+                maxUncommittedMessages, ImmutableList.of(), commitTimeoutSeconds);
         return StreamParameters.of(userParams, commitTimeoutSeconds, client);
     }
 }

--- a/src/test/java/org/zalando/nakadi/service/subscription/state/PartitionDataTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/state/PartitionDataTest.java
@@ -160,6 +160,30 @@ public class PartitionDataTest {
     }
 
     @Test
+    public void testBatchTimespanIsTriggeredByLastEventsTimestamp() {
+        final PartitionData pd = new PartitionData(COMP, null, createCursor(100L), System.currentTimeMillis(), 5);
+        final long timeout = TimeUnit.SECONDS.toMillis(100);
+
+        // under some circumstances, Kafka might contain events with out of order timestamps. But since the
+        // batch_timespan parameter is based on seconds, small inconsistencies in timestamp should not be a problem.
+        final int[] timestamps = new int[]{ 2, 3, 4, 5, 2, 4, 4, 2, 9, 1 };
+
+        for (int i = 0; i < timestamps.length; ++i) {
+            pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i), timestamps[i]));
+        }
+
+        // Nothing is streamed, even though there is one event whose timestamp is 9 (higher than the minimum of 7
+        // required to stream 5 milliseconds of data, given the first event has timestamp 2)
+        assertEquals(null, pd.takeEventsToStream(currentTimeMillis(), 100, timeout, false));
+
+        // Even though 7 triggers the flushing, it only streams until it finds 9
+        pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(timestamps.length), 8));
+        assertEquals(8, pd.takeEventsToStream(currentTimeMillis(), 100, timeout, false)
+                .size()); // [2, 7)
+
+    }
+
+    @Test
     public void eventsShouldBeStreamedOnStreamTimeout() {
         final long timeout = TimeUnit.SECONDS.toMillis(100);
         final PartitionData pd = new PartitionData(COMP, null, createCursor(100L), System.currentTimeMillis());

--- a/src/test/java/org/zalando/nakadi/service/subscription/state/PartitionDataTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/state/PartitionDataTest.java
@@ -63,7 +63,7 @@ public class PartitionDataTest {
             pd.addEvent(new ConsumedEvent(("test_" + i).getBytes(), createCursor(100L + i + 1), 0));
         }
         // Now say to it that it was sent
-        pd.takeEventsToStream(currentTimeMillis(), 1000, 0L, false);
+        pd.takeEventsToStream(currentTimeMillis(), 0, 1000, 0L, false);
         assertEquals(100L, pd.getUnconfirmed());
         for (long i = 0; i < 10; ++i) {
             final PartitionData.CommitResult cr = pd.onCommitOffset(createCursor(110L + i * 10L));
@@ -77,14 +77,14 @@ public class PartitionDataTest {
     public void keepAliveCountShouldIncreaseOnEachEmptyCall() {
         final PartitionData pd = new PartitionData(COMP, null, createCursor(100L), System.currentTimeMillis());
         for (int i = 0; i < 100; ++i) {
-            pd.takeEventsToStream(currentTimeMillis(), 10, 0L, false);
+            pd.takeEventsToStream(currentTimeMillis(), 0, 10, 0L, false);
             assertEquals(i + 1, pd.getKeepAliveInARow());
         }
         pd.addEvent(new ConsumedEvent("".getBytes(), createCursor(101L), 0));
         assertEquals(100, pd.getKeepAliveInARow());
-        pd.takeEventsToStream(currentTimeMillis(), 10, 0L, false);
+        pd.takeEventsToStream(currentTimeMillis(), 0, 10, 0L, false);
         assertEquals(0, pd.getKeepAliveInARow());
-        pd.takeEventsToStream(currentTimeMillis(), 10, 0L, false);
+        pd.takeEventsToStream(currentTimeMillis(), 0, 10, 0L, false);
         assertEquals(1, pd.getKeepAliveInARow());
     }
 
@@ -97,26 +97,26 @@ public class PartitionDataTest {
         for (int i = 0; i < 100; ++i) {
             pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i + 100L + 1), 0));
         }
-        List<ConsumedEvent> data = pd.takeEventsToStream(currentTime, 1000, timeout, false);
+        List<ConsumedEvent> data = pd.takeEventsToStream(currentTime, 0, 1000, timeout, false);
         assertNull(data);
         assertEquals(0, pd.getKeepAliveInARow());
 
         currentTime += timeout + 1;
 
-        data = pd.takeEventsToStream(currentTime, 1000, timeout, false);
+        data = pd.takeEventsToStream(currentTime, 0, 1000, timeout, false);
         assertNotNull(data);
         assertEquals(100, data.size());
 
         for (int i = 100; i < 200; ++i) {
             pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i + 100L + 1), 0));
         }
-        data = pd.takeEventsToStream(currentTime, 1000, timeout, false);
+        data = pd.takeEventsToStream(currentTime, 0, 1000, timeout, false);
         assertNull(data);
         assertEquals(0, pd.getKeepAliveInARow());
 
         currentTime += timeout + 1;
 
-        data = pd.takeEventsToStream(currentTime, 1000, timeout, false);
+        data = pd.takeEventsToStream(currentTime, 0, 1000, timeout, false);
         assertNotNull(data);
         assertEquals(100, data.size());
     }
@@ -128,10 +128,25 @@ public class PartitionDataTest {
         for (int i = 0; i < 100; ++i) {
             pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i + 100L + 1), 0));
         }
-        assertNull(pd.takeEventsToStream(currentTimeMillis(), 1000, timeout, false));
-        final List<ConsumedEvent> eventsToStream = pd.takeEventsToStream(currentTimeMillis(), 99, timeout, false);
+        assertNull(pd.takeEventsToStream(currentTimeMillis(), 0, 1000, timeout, false));
+        final List<ConsumedEvent> eventsToStream = pd.takeEventsToStream(currentTimeMillis(), 0, 99, timeout, false);
         assertNotNull(eventsToStream);
         assertEquals(99, eventsToStream.size());
+    }
+
+    @Test
+    public void eventsShouldBeStreamedOnTimespanReached() {
+        final PartitionData pd = new PartitionData(COMP, null, createCursor(100L), System.currentTimeMillis());
+        final long timeout = TimeUnit.SECONDS.toMillis(100);
+
+        for (int i = 2; i < 20; ++i) {
+            pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i), i));
+        }
+
+        assertEquals(6, pd.takeEventsToStream(currentTimeMillis(), 5, 100, timeout, true).size());
+        assertEquals(5, pd.takeEventsToStream(currentTimeMillis(), 5, 100, timeout, true).size());
+        assertEquals(5, pd.takeEventsToStream(currentTimeMillis(), 5, 100, timeout, true).size());
+        assertEquals(2, pd.takeEventsToStream(currentTimeMillis(), 5, 100, timeout, true).size()); // stream timeout
     }
 
     @Test
@@ -141,7 +156,7 @@ public class PartitionDataTest {
         for (int i = 0; i < 10; ++i) {
             pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i), 0));
         }
-        assertEquals(10, pd.takeEventsToStream(currentTimeMillis(), 100, timeout, true).size());
+        assertEquals(10, pd.takeEventsToStream(currentTimeMillis(), 0, 100, timeout, true).size());
     }
 
     @Test
@@ -151,6 +166,6 @@ public class PartitionDataTest {
         for (int i = 0; i < 10; ++i) {
             pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i), 0));
         }
-        assertNull(pd.takeEventsToStream(currentTimeMillis(), 0, timeout, true));
+        assertNull(pd.takeEventsToStream(currentTimeMillis(), 0, 0, timeout, true));
     }
 }

--- a/src/test/java/org/zalando/nakadi/service/subscription/state/PartitionDataTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/state/PartitionDataTest.java
@@ -143,10 +143,10 @@ public class PartitionDataTest {
             pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i), i));
         }
 
-        assertEquals(6, pd.takeEventsToStream(currentTimeMillis(), 5, 100, timeout, true).size());
         assertEquals(5, pd.takeEventsToStream(currentTimeMillis(), 5, 100, timeout, true).size());
         assertEquals(5, pd.takeEventsToStream(currentTimeMillis(), 5, 100, timeout, true).size());
-        assertEquals(2, pd.takeEventsToStream(currentTimeMillis(), 5, 100, timeout, true).size()); // stream timeout
+        assertEquals(5, pd.takeEventsToStream(currentTimeMillis(), 5, 100, timeout, true).size());
+        assertEquals(3, pd.takeEventsToStream(currentTimeMillis(), 5, 100, timeout, true).size()); // stream timeout
     }
 
     @Test

--- a/src/test/java/org/zalando/nakadi/service/subscription/state/PartitionDataTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/state/PartitionDataTest.java
@@ -63,7 +63,7 @@ public class PartitionDataTest {
             pd.addEvent(new ConsumedEvent(("test_" + i).getBytes(), createCursor(100L + i + 1), 0));
         }
         // Now say to it that it was sent
-        pd.takeEventsToStream(currentTimeMillis(), 0, 1000, 0L, false);
+        pd.takeEventsToStream(currentTimeMillis(), 1000, 0L, false);
         assertEquals(100L, pd.getUnconfirmed());
         for (long i = 0; i < 10; ++i) {
             final PartitionData.CommitResult cr = pd.onCommitOffset(createCursor(110L + i * 10L));
@@ -77,14 +77,14 @@ public class PartitionDataTest {
     public void keepAliveCountShouldIncreaseOnEachEmptyCall() {
         final PartitionData pd = new PartitionData(COMP, null, createCursor(100L), System.currentTimeMillis());
         for (int i = 0; i < 100; ++i) {
-            pd.takeEventsToStream(currentTimeMillis(), 0, 10, 0L, false);
+            pd.takeEventsToStream(currentTimeMillis(), 10, 0L, false);
             assertEquals(i + 1, pd.getKeepAliveInARow());
         }
         pd.addEvent(new ConsumedEvent("".getBytes(), createCursor(101L), 0));
         assertEquals(100, pd.getKeepAliveInARow());
-        pd.takeEventsToStream(currentTimeMillis(), 0, 10, 0L, false);
+        pd.takeEventsToStream(currentTimeMillis(), 10, 0L, false);
         assertEquals(0, pd.getKeepAliveInARow());
-        pd.takeEventsToStream(currentTimeMillis(), 0, 10, 0L, false);
+        pd.takeEventsToStream(currentTimeMillis(), 10, 0L, false);
         assertEquals(1, pd.getKeepAliveInARow());
     }
 
@@ -97,26 +97,26 @@ public class PartitionDataTest {
         for (int i = 0; i < 100; ++i) {
             pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i + 100L + 1), 0));
         }
-        List<ConsumedEvent> data = pd.takeEventsToStream(currentTime, 0, 1000, timeout, false);
+        List<ConsumedEvent> data = pd.takeEventsToStream(currentTime, 1000, timeout, false);
         assertNull(data);
         assertEquals(0, pd.getKeepAliveInARow());
 
         currentTime += timeout + 1;
 
-        data = pd.takeEventsToStream(currentTime, 0, 1000, timeout, false);
+        data = pd.takeEventsToStream(currentTime, 1000, timeout, false);
         assertNotNull(data);
         assertEquals(100, data.size());
 
         for (int i = 100; i < 200; ++i) {
             pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i + 100L + 1), 0));
         }
-        data = pd.takeEventsToStream(currentTime, 0, 1000, timeout, false);
+        data = pd.takeEventsToStream(currentTime, 1000, timeout, false);
         assertNull(data);
         assertEquals(0, pd.getKeepAliveInARow());
 
         currentTime += timeout + 1;
 
-        data = pd.takeEventsToStream(currentTime, 0, 1000, timeout, false);
+        data = pd.takeEventsToStream(currentTime, 1000, timeout, false);
         assertNotNull(data);
         assertEquals(100, data.size());
     }
@@ -128,25 +128,25 @@ public class PartitionDataTest {
         for (int i = 0; i < 100; ++i) {
             pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i + 100L + 1), 0));
         }
-        assertNull(pd.takeEventsToStream(currentTimeMillis(), 0, 1000, timeout, false));
-        final List<ConsumedEvent> eventsToStream = pd.takeEventsToStream(currentTimeMillis(), 0, 99, timeout, false);
+        assertNull(pd.takeEventsToStream(currentTimeMillis(), 1000, timeout, false));
+        final List<ConsumedEvent> eventsToStream = pd.takeEventsToStream(currentTimeMillis(), 99, timeout, false);
         assertNotNull(eventsToStream);
         assertEquals(99, eventsToStream.size());
     }
 
     @Test
     public void eventsShouldBeStreamedOnTimespanReached() {
-        final PartitionData pd = new PartitionData(COMP, null, createCursor(100L), System.currentTimeMillis());
+        final PartitionData pd = new PartitionData(COMP, null, createCursor(100L), System.currentTimeMillis(), 5);
         final long timeout = TimeUnit.SECONDS.toMillis(100);
 
         for (int i = 2; i < 20; ++i) {
             pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i), i));
         }
 
-        assertEquals(5, pd.takeEventsToStream(currentTimeMillis(), 5, 100, timeout, true).size());
-        assertEquals(5, pd.takeEventsToStream(currentTimeMillis(), 5, 100, timeout, true).size());
-        assertEquals(5, pd.takeEventsToStream(currentTimeMillis(), 5, 100, timeout, true).size());
-        assertEquals(3, pd.takeEventsToStream(currentTimeMillis(), 5, 100, timeout, true).size()); // stream timeout
+        assertEquals(5, pd.takeEventsToStream(currentTimeMillis(), 100, timeout, true).size());
+        assertEquals(5, pd.takeEventsToStream(currentTimeMillis(), 100, timeout, true).size());
+        assertEquals(5, pd.takeEventsToStream(currentTimeMillis(), 100, timeout, true).size());
+        assertEquals(3, pd.takeEventsToStream(currentTimeMillis(), 100, timeout, true).size()); // stream timeout
     }
 
     @Test
@@ -156,7 +156,7 @@ public class PartitionDataTest {
         for (int i = 0; i < 10; ++i) {
             pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i), 0));
         }
-        assertEquals(10, pd.takeEventsToStream(currentTimeMillis(), 0, 100, timeout, true).size());
+        assertEquals(10, pd.takeEventsToStream(currentTimeMillis(), 100, timeout, true).size());
     }
 
     @Test
@@ -166,6 +166,6 @@ public class PartitionDataTest {
         for (int i = 0; i < 10; ++i) {
             pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i), 0));
         }
-        assertNull(pd.takeEventsToStream(currentTimeMillis(), 0, 0, timeout, true));
+        assertNull(pd.takeEventsToStream(currentTimeMillis(), 0, timeout, true));
     }
 }

--- a/src/test/java/org/zalando/nakadi/service/subscription/state/PartitionDataTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/state/PartitionDataTest.java
@@ -139,14 +139,24 @@ public class PartitionDataTest {
         final PartitionData pd = new PartitionData(COMP, null, createCursor(100L), System.currentTimeMillis(), 5);
         final long timeout = TimeUnit.SECONDS.toMillis(100);
 
-        for (int i = 2; i < 20; ++i) {
-            pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i), i));
+        final int[] timestamps = new int[]{ 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 14, 17, 19, 20, 30 };
+
+        for (int i = 0; i < timestamps.length; ++i) {
+            pd.addEvent(new ConsumedEvent("test".getBytes(), createCursor(i), timestamps[i]));
         }
 
-        assertEquals(5, pd.takeEventsToStream(currentTimeMillis(), 100, timeout, true).size());
-        assertEquals(5, pd.takeEventsToStream(currentTimeMillis(), 100, timeout, true).size());
-        assertEquals(5, pd.takeEventsToStream(currentTimeMillis(), 100, timeout, true).size());
-        assertEquals(3, pd.takeEventsToStream(currentTimeMillis(), 100, timeout, true).size()); // stream timeout
+        final int[] sizes = new int[] {
+               5, // [2, 7) = 2, 3, 4, 5, 6
+               4, // [7, 12) = 7, 9, 10, 11
+               2, // [12, 17) = 12, 14
+               3, // [17, 22) = 17, 19, 20
+               0, // [22, 27) = [],
+               1 // [27, 32) = 30
+        };
+
+        for (int i = 0; i < sizes.length; i++) {
+            assertEquals(sizes[i], pd.takeEventsToStream(currentTimeMillis(), 100, timeout, true).size());
+        }
     }
 
     @Test

--- a/src/test/java/org/zalando/nakadi/service/subscription/state/StreamingStateTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/state/StreamingStateTest.java
@@ -77,6 +77,7 @@ public class StreamingStateTest {
         final StreamParameters spMock = createStreamParameters(
                 1000,
                 100L,
+                0L,
                 100,
                 100L,
                 100,


### PR DESCRIPTION
This is an API extension proposal.

In order to improve the SLO from Nakadi archiver, we are introducing a
new parameter that makes slicing events in 5 minutes window possible.

As it's explained in the description of the parameter, using
`batch_flush_timeout` alone is not enough and it leads to the
accumulation of events produced throughout a longer timespan than the
desired 5 minutes window.

To further illustrate when this happens consider the following
sequence of events:

1. events are produced one per minute starting at minute 0
2. a stream to read these events is not openned until minute 10. This
   stream has batch_flush_timeout of 5 minutes.
3. at minute 15 a batch is flushed containing the events produced from
minute 0 to minute 15 (15 events).

This is not the desired behaviour for Nakadi archiver. Archiver would
like to get events from minute 0 to minute 5, another from minute 5 to minute
10 and finally a third from minute 10 to minute 15. Its goal is to slice
the topic by time.

This new parameter makes it possible.

# edit 1

Just o clarify, this doesn't mean that events would be deserialized on the consumption path. Instead of using `receive_at` we would use https://kafka.apache.org/0100/javadoc/org/apache/kafka/clients/consumer/ConsumerRecord.html#timestamp() which would have no noticeable performance impact.

# edit 2

This change would have another benefit: the batches produced are always the same regardless of the start time of stream. This would lead to fewer duplicates on Nakadi archiver, as failed attempts to process a batch would result in the exact same batch being streamed again, which would result in the same batch being upload to S3, e.g. Archiver becomes idempotent.
