### PR TITLE
Switch state immediately to DEAD state if exception/do not schedule it

### DIFF
--- a/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -215,12 +215,11 @@ public class StreamingContext implements SubscriptionStreamer {
     }
 
     public void switchStateImmediately(final State newState) {
-
-        log.info("Switching state immediately from {} to {}",
+        log.info("Cleaning task queue & Switching state immediately from {} to {}",
                 currentState.getClass().getSimpleName(),
                 newState.getClass().getSimpleName());
-        exitCurrentStateAndEnter(newState);
-
+        taskQueue.clear();
+        switchState(newState);
     }
 
     private void exitCurrentStateAndEnter(final State newState) {

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/CleanupState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/CleanupState.java
@@ -32,11 +32,7 @@ public class CleanupState extends State {
                 getContext().unregisterSession();
 
             } finally {
-                if (null != exception) {
-                    getContext().switchStateImmediately(StreamingContext.DEAD_STATE);
-                } else{
-                    switchState(StreamingContext.DEAD_STATE);
-                }
+                switchState(StreamingContext.DEAD_STATE);
             }
 
             try {

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/CleanupState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/CleanupState.java
@@ -32,7 +32,11 @@ public class CleanupState extends State {
                 getContext().unregisterSession();
 
             } finally {
-                switchState(StreamingContext.DEAD_STATE);
+                if (null != exception) {
+                    getContext().switchStateImmediately(StreamingContext.DEAD_STATE);
+                } else{
+                    switchState(StreamingContext.DEAD_STATE);
+                }
             }
 
             try {


### PR DESCRIPTION
Switch state to DEAD state in case of exception without scheduling it in the task queue. One cleaner way to achieve the same is using priority queue for tasks, but I do not see where we need to handle tasks with priority other than during an exception.