### PR TITLE
Add scheduler for refresh topology

### DIFF
--- a/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -234,9 +234,14 @@ public class StreamingContext implements SubscriptionStreamer {
 
     public void registerSession() throws NakadiRuntimeException {
         log.info("Registering session {}", session);
-        // Install rebalance hook on client list change.
-        sessionListSubscription = zkClient.subscribeForSessionListChanges(() -> addTask(this::rebalance));
         zkClient.registerSession(session);
+    }
+
+    public void installHookAndTriggerRebalance() throws NakadiRuntimeException {
+        // Install re-balance hook on client list change.
+        sessionListSubscription = zkClient.subscribeForSessionListChanges(() -> addTask(this::rebalance));
+        // Trigger re-balance explicitly as session list might have changed before scheduling hook
+        rebalance();
     }
 
     public void unregisterSession() {

--- a/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -237,7 +237,7 @@ public class StreamingContext implements SubscriptionStreamer {
         zkClient.registerSession(session);
     }
 
-    public void installHookAndTriggerRebalance() throws NakadiRuntimeException {
+    public void subscribeToSessionListChangeAndRebalance() throws NakadiRuntimeException {
         // Install re-balance hook on client list change.
         sessionListSubscription = zkClient.subscribeForSessionListChanges(() -> addTask(this::rebalance));
         // Trigger re-balance explicitly as session list might have changed before scheduling hook

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -92,8 +92,8 @@ class StreamingState extends State {
         this.eventConsumer = getContext().getTimelineService().createEventConsumer(null);
 
         recreateTopologySubscription();
-        addTask(this::initializeStream);
         addTask(this::recheckTopology);
+        addTask(this::initializeStream);
         addTask(this::pollDataFromKafka);
         scheduleTask(this::checkBatchTimeouts, getParameters().batchTimeoutMillis, TimeUnit.MILLISECONDS);
 

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -76,6 +76,18 @@ class StreamingState extends State {
      */
     private long lastCommitMillis;
 
+
+    /**
+     * 1. Collects names and prepares to send metrics for bytes streamed
+     * <p>
+     * 2. On entering, triggers re-balance for this session
+     * <p>
+     * 3. Refreshes topology and sends headers to the user
+     * <p>
+     * 4. Adds tasks for actions if change in topology, sessions list and cursor reset
+     * <p>
+     * 5. Schedules tasks for providing events batch to output based on params, and for checking commit timeouts
+     */
     @Override
     public void onEnter() {
         final String kafkaFlushedBytesMetricName = MetricUtils.metricNameForHiLAStream(
@@ -87,6 +99,7 @@ class StreamingState extends State {
         lastKpiEventSent = System.currentTimeMillis();
         kpiDataPerEventType = this.getContext().getSubscription().getEventTypes().stream()
                 .collect(Collectors.toMap(et -> et, et -> new StreamKpiData()));
+        addTask(() -> getContext().installHookAndTriggerRebalance());
 
         idleStreamWatcher = new IdleStreamWatcher(getParameters().commitTimeoutMillis * 2);
         this.eventConsumer = getContext().getTimelineService().createEventConsumer(null);

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -99,7 +99,7 @@ class StreamingState extends State {
         lastKpiEventSent = System.currentTimeMillis();
         kpiDataPerEventType = this.getContext().getSubscription().getEventTypes().stream()
                 .collect(Collectors.toMap(et -> et, et -> new StreamKpiData()));
-        addTask(() -> getContext().installHookAndTriggerRebalance());
+        addTask(() -> getContext().subscribeToSessionListChangeAndRebalance());
 
         idleStreamWatcher = new IdleStreamWatcher(getParameters().commitTimeoutMillis * 2);
         this.eventConsumer = getContext().getTimelineService().createEventConsumer(null);


### PR DESCRIPTION
At the end of the StartingState, we schedule rebalance on changes to the session list, and then, secondly register the session.

This fires in an event to re-balance via zookeeper watches. Once the rebalance finishes, the session gets the partitions it needs to stream from.
 
Re-balance might finish later than sending the headers and due to this, the check of offsets will happen only after the re-balance assigns a partition to the session. 

This improves the rate at which 200s will be returned, but there can be still a few 200s, if the rebalance finishes after sending the headers. (There is an listener scheduled for changing topology before sending the headers, using this change)

If we make sending the headers blocking after re-balance finishes, the response time will increase. What do you suggest? 

[Edit]: Now, as suggested, we send the headers only after doing rebalance/and checking the assigned partitions and offsets to stream from (once when the stream is opened) The tasks that the three main states perform is described below: 
```
Starting State -> it does validation checks and registers the current session id in zookeeper.

Streaming State -> it does tasks for doing rebalance once on Enter, checking the assigned partitions,
scheduling tasks for topology and session changes, and polls data from Kafka, and streams to the output based on parameters. It also listens for commit timeout.
This state also sends out the headers to the client (stream-id, status_code) once it finishes the rebalance and checking the current partitions assigned to this session.

Cleanup State -> Cleans the zookeeper for sessions and closes the connection. Throws exception and proper response to the client if it can. 
```