### PR TITLE
ARUHA-2642 Temporary allow deletion of events

### DIFF
--- a/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -218,7 +218,7 @@ public class KafkaRepositoryAT extends BaseAT {
             items.add(item);
         }
 
-        kafkaTopicRepository.syncPostBatch(topicId, items, null);
+        kafkaTopicRepository.syncPostBatch(topicId, items, null, false);
 
         for (int i = 0; i < 10; i++) {
             assertThat(items.get(i).getResponse().getPublishingStatus(), equalTo(EventPublishingStatus.SUBMITTED));

--- a/src/main/java/org/zalando/nakadi/repository/TopicRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/TopicRepository.java
@@ -46,7 +46,7 @@ public interface TopicRepository {
 
     boolean topicExists(String topic) throws TopicRepositoryException;
 
-    void syncPostBatch(String topicId, List<BatchItem> batch, String eventTypeName)
+    void syncPostBatch(String topicId, List<BatchItem> batch, String eventTypeName, boolean delete)
             throws EventPublishingException;
 
     void repartition(String topic, int partitionsNumber) throws CannotAddPartitionToTopicException,

--- a/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -109,14 +109,15 @@ public class KafkaTopicRepository implements TopicRepository {
             final Producer<String, String> producer,
             final String topicId,
             final BatchItem item,
-            final HystrixKafkaCircuitBreaker circuitBreaker) throws EventPublishingException {
+            final HystrixKafkaCircuitBreaker circuitBreaker,
+            final boolean delete) throws EventPublishingException {
         try {
             final CompletableFuture<Exception> result = new CompletableFuture<>();
             final ProducerRecord<String, String> kafkaRecord = new ProducerRecord<>(
                     topicId,
                     KafkaCursor.toKafkaPartition(item.getPartition()),
                     item.getEventKey(),
-                    item.dumpEventToString());
+                    delete ? null : item.dumpEventToString());
             circuitBreaker.markStart();
             producer.send(kafkaRecord, ((metadata, exception) -> {
                 if (null != exception) {
@@ -255,7 +256,8 @@ public class KafkaTopicRepository implements TopicRepository {
     }
 
     @Override
-    public void syncPostBatch(final String topicId, final List<BatchItem> batch, final String eventType)
+    public void syncPostBatch(
+            final String topicId, final List<BatchItem> batch, final String eventType, final boolean delete)
             throws EventPublishingException {
         final Producer<String, String> producer = kafkaFactory.takeProducer();
         try {
@@ -274,7 +276,7 @@ public class KafkaTopicRepository implements TopicRepository {
                 final HystrixKafkaCircuitBreaker circuitBreaker = circuitBreakers.computeIfAbsent(
                         item.getBrokerId(), brokerId -> new HystrixKafkaCircuitBreaker(brokerId));
                 if (circuitBreaker.attemptExecution()) {
-                    sendFutures.put(item, publishItem(producer, topicId, item, circuitBreaker));
+                    sendFutures.put(item, publishItem(producer, topicId, item, circuitBreaker, delete));
                 } else {
                     shortCircuited++;
                     item.updateStatusAndDetail(EventPublishingStatus.FAILED, "short circuited");

--- a/src/main/java/org/zalando/nakadi/service/EventsProcessor.java
+++ b/src/main/java/org/zalando/nakadi/service/EventsProcessor.java
@@ -81,7 +81,7 @@ public class EventsProcessor {
                     LOG.trace("No kpi events send to {}", etName);
                     return;
                 }
-                eventPublisher.publishInternal(jsonArray.toString(), etName, false, null);
+                eventPublisher.processInternal(jsonArray.toString(), etName, false, null, false);
                 LOG.trace("Published batch of {} to {}", eventsCount, etName);
             } catch (final Exception e) {
                 LOG.error("Error occurred while publishing events to {}, {}", etName, e.getMessage(), e);

--- a/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -244,7 +244,7 @@ public class KafkaTopicRepositoryTest {
                 .send(any(), any());
 
         try {
-            kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(), batch, "random");
+            kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(), batch, "random", false);
             fail();
         } catch (final EventPublishingException e) {
             assertThat(item.getResponse().getPublishingStatus(), equalTo(EventPublishingStatus.FAILED));
@@ -271,7 +271,7 @@ public class KafkaTopicRepositoryTest {
                 .send(any(), any());
 
         try {
-            kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(), batch, "random");
+            kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(), batch, "random", false);
             fail();
         } catch (final EventPublishingException e) {
             assertThat(item.getResponse().getPublishingStatus(), equalTo(EventPublishingStatus.FAILED));
@@ -308,7 +308,7 @@ public class KafkaTopicRepositoryTest {
         });
 
         try {
-            kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(), batch, "random");
+            kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(), batch, "random", false);
             fail();
         } catch (final EventPublishingException e) {
             assertThat(firstItem.getResponse().getPublishingStatus(), equalTo(EventPublishingStatus.SUBMITTED));
@@ -366,7 +366,7 @@ public class KafkaTopicRepositoryTest {
                 batches.add(batchItem);
                 TimeUnit.MILLISECONDS.sleep(5);
                 kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(),
-                        ImmutableList.of(batchItem), "random");
+                        ImmutableList.of(batchItem), "random", false);
             } catch (final EventPublishingException | InterruptedException ex) {
             }
         }

--- a/src/test/java/org/zalando/nakadi/service/EventPublisherTest.java
+++ b/src/test/java/org/zalando/nakadi/service/EventPublisherTest.java
@@ -45,6 +45,7 @@ import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
@@ -99,7 +100,7 @@ public class EventPublisherTest {
         final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null);
 
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.SUBMITTED));
-        verify(topicRepository, times(1)).syncPostBatch(any(), any(), any());
+        verify(topicRepository, times(1)).syncPostBatch(any(), any(), any(), eq(false));
     }
 
     @Test(expected = AccessDeniedException.class)
@@ -126,7 +127,7 @@ public class EventPublisherTest {
         final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null);
 
         assertThat(result.getResponses().get(0).getEid(), equalTo(event.getJSONObject("metadata").optString("eid")));
-        verify(topicRepository, times(1)).syncPostBatch(any(), any(), any());
+        verify(topicRepository, times(1)).syncPostBatch(any(), any(), any(), eq(false));
     }
 
     @Test
@@ -163,7 +164,7 @@ public class EventPublisherTest {
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.ABORTED));
         verify(enrichment, times(0)).enrich(createBatchItem(event), eventType);
         verify(partitionResolver, times(0)).resolvePartition(eventType, event);
-        verify(topicRepository, times(0)).syncPostBatch(any(), any(), any());
+        verify(topicRepository, times(0)).syncPostBatch(any(), any(), any(), anyBoolean());
     }
 
     @Test
@@ -203,7 +204,7 @@ public class EventPublisherTest {
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.ABORTED));
         verify(enrichment, times(0)).enrich(any(), any());
         verify(partitionResolver, times(0)).resolvePartition(any(), any());
-        verify(topicRepository, times(0)).syncPostBatch(any(), any(), any());
+        verify(topicRepository, times(0)).syncPostBatch(any(), any(), any(), anyBoolean());
     }
 
     @Test
@@ -284,7 +285,7 @@ public class EventPublisherTest {
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.SUBMITTED));
         verify(enrichment, times(1)).enrich(any(), any());
         verify(partitionResolver, times(1)).resolvePartition(any(), any());
-        verify(topicRepository, times(1)).syncPostBatch(any(), any(), any());
+        verify(topicRepository, times(1)).syncPostBatch(any(), any(), any(), eq(false));
     }
 
     @Test
@@ -299,7 +300,7 @@ public class EventPublisherTest {
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.ABORTED));
         verify(enrichment, times(0)).enrich(any(), any());
         verify(partitionResolver, times(0)).resolvePartition(any(), any());
-        verify(topicRepository, times(0)).syncPostBatch(any(), any(), any());
+        verify(topicRepository, times(0)).syncPostBatch(any(), any(), any(), anyBoolean());
     }
 
     @Test
@@ -314,7 +315,7 @@ public class EventPublisherTest {
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.ABORTED));
         verify(enrichment, times(0)).enrich(any(), any());
         verify(partitionResolver, times(0)).resolvePartition(any(), any());
-        verify(topicRepository, times(0)).syncPostBatch(any(), any(), any());
+        verify(topicRepository, times(0)).syncPostBatch(any(), any(), any(), anyBoolean());
     }
 
     @Test
@@ -329,7 +330,7 @@ public class EventPublisherTest {
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.SUBMITTED));
         verify(enrichment, times(1)).enrich(any(), any());
         verify(partitionResolver, times(1)).resolvePartition(any(), any());
-        verify(topicRepository, times(1)).syncPostBatch(any(), any(), any());
+        verify(topicRepository, times(1)).syncPostBatch(any(), any(), any(), eq(false));
     }
 
     @Test
@@ -389,7 +390,7 @@ public class EventPublisherTest {
         final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null);
 
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.FAILED));
-        verify(topicRepository, times(1)).syncPostBatch(any(), any(), any());
+        verify(topicRepository, times(1)).syncPostBatch(any(), any(), any(), eq(false));
     }
 
     @Test
@@ -407,7 +408,7 @@ public class EventPublisherTest {
         verify(cache, times(1)).getValidator(eventType.getName());
         verify(partitionResolver, times(1)).resolvePartition(any(), any());
         verify(enrichment, times(1)).enrich(any(), any());
-        verify(topicRepository, times(0)).syncPostBatch(any(), any(), any());
+        verify(topicRepository, times(0)).syncPostBatch(any(), any(), any(), anyBoolean());
     }
 
     @Test
@@ -466,7 +467,7 @@ public class EventPublisherTest {
     @SuppressWarnings("unchecked")
     private List<BatchItem> capturePublishedBatch() {
         final ArgumentCaptor<List> batchCaptor = ArgumentCaptor.forClass(List.class);
-        verify(topicRepository, atLeastOnce()).syncPostBatch(any(), batchCaptor.capture(), any());
+        verify(topicRepository, atLeastOnce()).syncPostBatch(any(), batchCaptor.capture(), any(), eq(false));
         return (List<BatchItem>) batchCaptor.getValue();
     }
 
@@ -510,7 +511,7 @@ public class EventPublisherTest {
         Mockito
                 .doThrow(EventPublishingException.class)
                 .when(topicRepository)
-                .syncPostBatch(any(), any(), any());
+                .syncPostBatch(any(), any(), any(), anyBoolean());
     }
 
     private void mockFaultPartition() throws PartitioningException {

--- a/src/test/java/org/zalando/nakadi/service/EventsProcessorTest.java
+++ b/src/test/java/org/zalando/nakadi/service/EventsProcessorTest.java
@@ -6,6 +6,9 @@ import org.mockito.Mockito;
 import org.zalando.nakadi.util.UUIDGenerator;
 import org.zalando.nakadi.utils.TestUtils;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+
 public class EventsProcessorTest {
 
     private final EventPublisher eventPublisher = Mockito.mock(EventPublisher.class);
@@ -19,8 +22,7 @@ public class EventsProcessorTest {
         eventsProcessor.enrichAndSubmit("test_et_name", event);
         TestUtils.waitFor(() -> {
             try {
-                Mockito.verify(eventPublisher).publishInternal(Mockito.any(), Mockito.any(),
-                        Mockito.eq(false), Mockito.any());
+                Mockito.verify(eventPublisher).processInternal(any(), any(), eq(false), any(), eq(false));
             } catch (final Exception e) {
                 throw new AssertionError(e);
             }


### PR DESCRIPTION
There are requests to delete a lot of events in a compacted event types, and right now nakadi basically lacks this functionality. 

I know that the code is not pretty, but in order to solve current needs of users, we can provide non-documented endpoint to allow deletion of events (the endpoint and service is not covered with unit tests), so my suggestion will be to merge this pr to master, tests it on data and then revert it, keeping this pr open in order to be able to rework it and allow this endpoint to everyone. 

The base idea is that publishing and deletion is almost the same - users have to publish the same events to different endpoint, and nakadi will publish null to kafka to remove events. 