### PR TITLE
ARUHA-2637 Use transactions while creating event type

### DIFF
--- a/src/main/java/org/zalando/nakadi/repository/EventTypeRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/EventTypeRepository.java
@@ -2,9 +2,9 @@ package org.zalando.nakadi.repository;
 
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeBase;
+import org.zalando.nakadi.exceptions.runtime.DuplicatedEventTypeNameException;
 import org.zalando.nakadi.exceptions.runtime.InternalNakadiException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchEventTypeException;
-import org.zalando.nakadi.exceptions.runtime.DuplicatedEventTypeNameException;
 
 import java.util.List;
 import java.util.Optional;
@@ -20,6 +20,8 @@ public interface EventTypeRepository {
     List<EventType> list();
 
     void removeEventType(String name) throws InternalNakadiException, NoSuchEventTypeException;
+
+    void notifyUpdated(String name);
 
     default Optional<EventType> findByNameO(final String eventTypeName) throws InternalNakadiException {
         try {

--- a/src/main/java/org/zalando/nakadi/repository/db/CachingEventTypeRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/db/CachingEventTypeRepository.java
@@ -34,20 +34,7 @@ public class CachingEventTypeRepository implements EventTypeRepository {
     @Override
     public EventType saveEventType(final EventTypeBase eventTypeBase) throws InternalNakadiException,
             DuplicatedEventTypeNameException {
-        final EventType eventType = this.repository.saveEventType(eventTypeBase);
-
-        try {
-            this.cache.created(eventTypeBase.getName());
-            return eventType;
-        } catch (Exception e) {
-            LOG.error("Failed to create new cache entry for event type '" + eventTypeBase.getName() + "'", e);
-            try {
-                this.repository.removeEventType(eventTypeBase.getName());
-            } catch (NoSuchEventTypeException e1) {
-                LOG.error("Failed to revert event type db persistence", e1);
-            }
-            throw new InternalNakadiException("Failed to save event type", e);
-        }
+        return this.repository.saveEventType(eventTypeBase);
     }
 
     @Override
@@ -57,16 +44,8 @@ public class CachingEventTypeRepository implements EventTypeRepository {
 
     @Override
     public void update(final EventType eventType) throws InternalNakadiException, NoSuchEventTypeException {
-        final EventType original = this.repository.findByName(eventType.getName());
+        this.repository.findByName(eventType.getName());
         this.repository.update(eventType);
-
-        try {
-            this.cache.updated(eventType.getName());
-        } catch (Exception e) {
-            LOG.error("Failed to update cache for event type '" + eventType.getName() + "'", e);
-            this.repository.update(original);
-            throw new InternalNakadiException("Failed to update event type", e);
-        }
     }
 
     @Override
@@ -76,21 +55,12 @@ public class CachingEventTypeRepository implements EventTypeRepository {
 
     @Override
     public void removeEventType(final String name) throws InternalNakadiException, NoSuchEventTypeException {
-        final EventType original = this.repository.findByName(name);
-
+        this.repository.findByName(name);
         this.repository.removeEventType(name);
+    }
 
-        try {
-            this.cache.removed(name);
-        } catch (Exception e) {
-            LOG.error("Failed to remove entry from cache '" + name + "'");
-            try {
-                this.repository.saveEventType(original);
-            } catch (DuplicatedEventTypeNameException e1) {
-                LOG.error("Failed to rollback db removal", e);
-            }
-            throw new InternalNakadiException("Failed to remove event type", e);
-        }
-
+    @Override
+    public void notifyUpdated(final String name) {
+        this.cache.updated(name);
     }
 }

--- a/src/main/java/org/zalando/nakadi/repository/db/EventTypeDbRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/db/EventTypeDbRepository.java
@@ -189,6 +189,10 @@ public class EventTypeDbRepository extends AbstractDbRepository implements Event
         } catch (DataAccessException e) {
             throw new InternalNakadiException("Error occurred when deleting EventType " + name, e);
         }
+    }
 
+    @Override
+    public void notifyUpdated(final String name) {
+        // Do nothing. Database is always in sync
     }
 }

--- a/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -37,6 +37,7 @@ import org.zalando.nakadi.exceptions.runtime.FeatureNotAvailableException;
 import org.zalando.nakadi.exceptions.runtime.InconsistentStateException;
 import org.zalando.nakadi.exceptions.runtime.InternalNakadiException;
 import org.zalando.nakadi.exceptions.runtime.InvalidEventTypeException;
+import org.zalando.nakadi.exceptions.runtime.NakadiBaseException;
 import org.zalando.nakadi.exceptions.runtime.NakadiRuntimeException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchEventTypeException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchPartitionStrategyException;
@@ -203,7 +204,11 @@ public class EventTypeService {
                     LOG.warn("Failed to rollback event type creation (which is highly expected)", ex2);
                 }
             }
-            throw ex;
+            if (ex instanceof NakadiBaseException) {
+                throw ex;
+            } else {
+                throw new InternalNakadiException("Failed to create event type: " + ex.getMessage(), ex);
+            }
         }
         nakadiKpiPublisher.publish(etLogEventType, () -> new JSONObject()
                 .put("event_type", eventType.getName())

--- a/src/main/java/org/zalando/nakadi/service/job/TimelineCleanupJob.java
+++ b/src/main/java/org/zalando/nakadi/service/job/TimelineCleanupJob.java
@@ -11,7 +11,6 @@ import org.zalando.nakadi.exceptions.runtime.InconsistentStateException;
 import org.zalando.nakadi.exceptions.runtime.RepositoryProblemException;
 import org.zalando.nakadi.exceptions.runtime.TopicDeletionException;
 import org.zalando.nakadi.repository.TopicRepository;
-import org.zalando.nakadi.repository.db.EventTypeCache;
 import org.zalando.nakadi.repository.db.TimelineDbRepository;
 import org.zalando.nakadi.service.FeatureToggleService;
 import org.zalando.nakadi.service.timeline.TimelineService;
@@ -26,7 +25,6 @@ public class TimelineCleanupJob {
 
     private static final Logger LOG = LoggerFactory.getLogger(TimelineCleanupJob.class);
 
-    private final EventTypeCache eventTypeCache;
     private final TimelineDbRepository timelineDbRepository;
     private final TimelineService timelineService;
     private final FeatureToggleService featureToggleService;
@@ -34,14 +32,12 @@ public class TimelineCleanupJob {
     private final long deletionDelayMs;
 
     @Autowired
-    public TimelineCleanupJob(final EventTypeCache eventTypeCache,
-                              final TimelineDbRepository timelineDbRepository,
+    public TimelineCleanupJob(final TimelineDbRepository timelineDbRepository,
                               final TimelineService timelineService,
                               final FeatureToggleService featureToggleService,
                               final JobWrapperFactory jobWrapperFactory,
                               @Value("${nakadi.jobs.timelineCleanup.runPeriodMs}") final int periodMs,
                               @Value("${nakadi.jobs.timelineCleanup.deletionDelayMs}") final long deletionDelayMs) {
-        this.eventTypeCache = eventTypeCache;
         this.timelineDbRepository = timelineDbRepository;
         this.timelineService = timelineService;
         this.jobWrapper = jobWrapperFactory.createExclusiveJobWrapper(JOB_NAME, periodMs);
@@ -92,31 +88,15 @@ public class TimelineCleanupJob {
     }
 
     private void markTimelineDeleted(final Timeline timeline) {
-        boolean timelineUpdatedInDB = false;
-        boolean cacheUpdated = false;
         try {
             timeline.setDeleted(true);
             timelineDbRepository.updateTimelime(timeline);
-            timelineUpdatedInDB = true;
-
-            eventTypeCache.updated(timeline.getEventType());
-            cacheUpdated = true;
         } catch (final InconsistentStateException e) {
             LOG.error("Failed to serialize timeline to DB when marking timeline as deleted", e);
         } catch (final RepositoryProblemException e) {
             LOG.error("DB failure when marking timeline as deleted", e);
         } catch (Exception e) {
             LOG.error("ZK error occurred when updating ET cache", e);
-        } finally {
-            // revert timeline state in a case if cache wasn't updated successfully
-            if (timelineUpdatedInDB && !cacheUpdated) {
-                try {
-                    timeline.setDeleted(false);
-                    timelineDbRepository.updateTimelime(timeline);
-                } catch (final Exception e) {
-                    LOG.error("Failed to revert timeline state", e);
-                }
-            }
         }
     }
 

--- a/src/main/java/org/zalando/nakadi/service/timeline/TimelineService.java
+++ b/src/main/java/org/zalando/nakadi/service/timeline/TimelineService.java
@@ -173,12 +173,6 @@ public class TimelineService {
             }
             timelineDbRepository.updateTimelime(timeline);
         }
-
-        try {
-            eventTypeCache.updated(eventType.getName());
-        } catch (Exception e) {
-            throw new NakadiBaseException(e.getMessage(), e);
-        }
     }
 
     public Timeline createDefaultTimeline(final EventTypeBase eventType, final int partitionsCount)
@@ -210,7 +204,6 @@ public class TimelineService {
             final Timeline timeline = Timeline.createTimeline(eventType.getName(), 1, storage, topic, new Date());
             timeline.setSwitchedAt(new Date());
             timelineDbRepository.createTimeline(timeline);
-            eventTypeCache.updated(eventType.getName());
             return timeline;
         } catch (final InconsistentStateException | RepositoryProblemException | DuplicatedTimelineException e) {
             rollbackTopic(repository, topic);

--- a/src/main/java/org/zalando/nakadi/service/timeline/TimelineService.java
+++ b/src/main/java/org/zalando/nakadi/service/timeline/TimelineService.java
@@ -221,6 +221,11 @@ public class TimelineService {
         }
     }
 
+    public void rollbackTopic(final Timeline timeline) {
+        final TopicRepository repo = topicRepositoryHolder.getTopicRepository(timeline.getStorage());
+        repo.deleteTopic(timeline.getTopic());
+    }
+
     private void rollbackTopic(final TopicRepository repository, final String topic) {
         try {
             repository.deleteTopic(topic);

--- a/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
@@ -684,6 +684,7 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
         final EventType et = buildDefaultEventType();
         doThrow(TopicCreationException.class).when(timelineService)
                 .createDefaultTimeline(any(), anyInt());
+        when(eventTypeRepository.saveEventType(any())).thenReturn(et);
         final Problem expectedProblem = Problem.valueOf(SERVICE_UNAVAILABLE);
 
         postEventType(et).andExpect(status().isServiceUnavailable())

--- a/src/test/java/org/zalando/nakadi/repository/db/CachingEventTypeRepositoryTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/db/CachingEventTypeRepositoryTest.java
@@ -17,7 +17,7 @@ public class CachingEventTypeRepositoryTest {
     private final EventTypeRepository cachedRepo;
     private final EventType et = mock(EventType.class);
 
-    public CachingEventTypeRepositoryTest() throws Exception {
+    public CachingEventTypeRepositoryTest() {
         this.cachedRepo = new CachingEventTypeRepository(dbRepo, cache);
 
         Mockito
@@ -27,15 +27,14 @@ public class CachingEventTypeRepositoryTest {
     }
 
     @Test
-    public void whenDbPersistenceSucceedThenNotifyCache() throws Exception {
+    public void whenDbPersistenceSucceedThenNotifyCache() {
         cachedRepo.saveEventType(et);
 
         verify(dbRepo, times(1)).saveEventType(et);
-        verify(cache, times(1)).created(et.getName());
     }
 
     @Test
-    public void whenCacheFailsThenRollbackEventPersistence() throws Exception {
+    public void whenCacheFailsThenRollbackEventPersistence() {
         Mockito
                 .doThrow(Exception.class)
                 .when(cache)
@@ -49,15 +48,14 @@ public class CachingEventTypeRepositoryTest {
     }
 
     @Test
-    public void whenDbUpdateSucceedThenNotifyCache() throws Exception {
+    public void whenDbUpdateSucceedThenNotifyCache() {
         cachedRepo.update(et);
 
         verify(dbRepo, times(1)).update(et);
-        verify(cache, times(1)).updated("event-name");
     }
 
     @Test
-    public void whenUpdateCacheFailThenRollbackDbPersistence() throws Exception {
+    public void whenUpdateCacheFailThenRollbackDbPersistence() {
         Mockito
                 .doThrow(Exception.class)
                 .when(cache)
@@ -78,15 +76,14 @@ public class CachingEventTypeRepositoryTest {
     }
 
     @Test
-    public void removeFromDbSucceedNotifyCache() throws Exception {
+    public void removeFromDbSucceedNotifyCache() {
         cachedRepo.removeEventType("event-name");
 
         verify(dbRepo, times(1)).removeEventType("event-name");
-        verify(cache, times(1)).removed("event-name");
     }
 
     @Test
-    public void whenRemoveCacheEntryFailsThenRollbackDbRemoval() throws Exception {
+    public void whenRemoveCacheEntryFailsThenRollbackDbRemoval() {
         Mockito
                 .doThrow(Exception.class)
                 .when(cache)

--- a/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
+++ b/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
@@ -243,6 +243,7 @@ public class EventTypeServiceTest {
     @Test
     public void shouldRemoveEventTypeWhenTimelineCreationFails() {
         final EventType eventType = buildDefaultEventType();
+        when(eventTypeRepository.saveEventType(any())).thenReturn(eventType);
         when(timelineService.createDefaultTimeline(any(), anyInt()))
                 .thenThrow(new TopicCreationException("Failed to create topic"));
         try {


### PR DESCRIPTION
ARUHA-2637 Use transactions while creating event type

Also, As a part of the same problem - do not reset cache during transaction, run event type cache update only after successful transaction commit, as updating cache in the middle of transaction only leads to bugs.
