### PR TITLE
Aruha 2637

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ ADD api/nakadi-event-bus-api.yaml api/nakadi-event-bus-api.yaml
 
 EXPOSE 8080
 
-ENTRYPOINT exec java -Djava.security.egd=file:/dev/./urandom -jar nakadi.jar
+ENTRYPOINT exec java -Djava.security.egd=file:/dev/./urandom -Dspring.jdbc.getParameterType.ignore=true -jar nakadi.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,12 +22,12 @@ services:
       - NAKADI_FEATURES_DEFAULT_FEATURES_DISABLE_LOG_COMPACTION
       - NAKADI_FEATURES_DEFAULT_FEATURES_REPARTITIONING
       - NAKADI_ZOOKEEPER_BROKERS=zookeeper:2181
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/local_nakadi_db
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/local_nakadi_db?preferQueryMode=simple
       - SPRING_DATASOURCE_USERNAME=nakadi
       - SPRING_DATASOURCE_PASSWORD=nakadi
 
   postgres:
-    image: postgres:9.5
+    image: postgres:9.6.16
     ports:
       - "5432:5432"
     volumes:

--- a/src/main/java/org/zalando/nakadi/repository/EventTypeRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/EventTypeRepository.java
@@ -2,9 +2,9 @@ package org.zalando.nakadi.repository;
 
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeBase;
+import org.zalando.nakadi.exceptions.runtime.DuplicatedEventTypeNameException;
 import org.zalando.nakadi.exceptions.runtime.InternalNakadiException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchEventTypeException;
-import org.zalando.nakadi.exceptions.runtime.DuplicatedEventTypeNameException;
 
 import java.util.List;
 import java.util.Optional;
@@ -20,6 +20,8 @@ public interface EventTypeRepository {
     List<EventType> list();
 
     void removeEventType(String name) throws InternalNakadiException, NoSuchEventTypeException;
+
+    void notifyUpdated(String name);
 
     default Optional<EventType> findByNameO(final String eventTypeName) throws InternalNakadiException {
         try {

--- a/src/main/java/org/zalando/nakadi/repository/db/CachingEventTypeRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/db/CachingEventTypeRepository.java
@@ -34,20 +34,7 @@ public class CachingEventTypeRepository implements EventTypeRepository {
     @Override
     public EventType saveEventType(final EventTypeBase eventTypeBase) throws InternalNakadiException,
             DuplicatedEventTypeNameException {
-        final EventType eventType = this.repository.saveEventType(eventTypeBase);
-
-        try {
-            this.cache.created(eventTypeBase.getName());
-            return eventType;
-        } catch (Exception e) {
-            LOG.error("Failed to create new cache entry for event type '" + eventTypeBase.getName() + "'", e);
-            try {
-                this.repository.removeEventType(eventTypeBase.getName());
-            } catch (NoSuchEventTypeException e1) {
-                LOG.error("Failed to revert event type db persistence", e1);
-            }
-            throw new InternalNakadiException("Failed to save event type", e);
-        }
+        return this.repository.saveEventType(eventTypeBase);
     }
 
     @Override
@@ -57,16 +44,8 @@ public class CachingEventTypeRepository implements EventTypeRepository {
 
     @Override
     public void update(final EventType eventType) throws InternalNakadiException, NoSuchEventTypeException {
-        final EventType original = this.repository.findByName(eventType.getName());
+        this.repository.findByName(eventType.getName());
         this.repository.update(eventType);
-
-        try {
-            this.cache.updated(eventType.getName());
-        } catch (Exception e) {
-            LOG.error("Failed to update cache for event type '" + eventType.getName() + "'", e);
-            this.repository.update(original);
-            throw new InternalNakadiException("Failed to update event type", e);
-        }
     }
 
     @Override
@@ -76,21 +55,12 @@ public class CachingEventTypeRepository implements EventTypeRepository {
 
     @Override
     public void removeEventType(final String name) throws InternalNakadiException, NoSuchEventTypeException {
-        final EventType original = this.repository.findByName(name);
-
+        this.repository.findByName(name);
         this.repository.removeEventType(name);
+    }
 
-        try {
-            this.cache.removed(name);
-        } catch (Exception e) {
-            LOG.error("Failed to remove entry from cache '" + name + "'");
-            try {
-                this.repository.saveEventType(original);
-            } catch (DuplicatedEventTypeNameException e1) {
-                LOG.error("Failed to rollback db removal", e);
-            }
-            throw new InternalNakadiException("Failed to remove event type", e);
-        }
-
+    @Override
+    public void notifyUpdated(final String name) {
+        this.cache.updated(name);
     }
 }

--- a/src/main/java/org/zalando/nakadi/repository/db/EventTypeDbRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/db/EventTypeDbRepository.java
@@ -11,7 +11,6 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 import org.zalando.nakadi.annotations.DB;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeBase;
@@ -39,7 +38,6 @@ public class EventTypeDbRepository extends AbstractDbRepository implements Event
     }
 
     @Override
-    @Transactional
     public EventType saveEventType(final EventTypeBase eventTypeBase) throws InternalNakadiException,
             DuplicatedEventTypeNameException {
         try {
@@ -70,7 +68,6 @@ public class EventTypeDbRepository extends AbstractDbRepository implements Event
     }
 
     @Override
-    @Transactional
     public void update(final EventType eventType) throws InternalNakadiException {
         try {
             final String sql = "SELECT et_event_type_object -> 'schema' ->> 'version' " +
@@ -178,7 +175,6 @@ public class EventTypeDbRepository extends AbstractDbRepository implements Event
     }
 
     @Override
-    @Transactional
     public void removeEventType(final String name) throws NoSuchEventTypeException, InternalNakadiException {
         try {
             jdbcTemplate.update("DELETE FROM zn_data.event_type_schema WHERE ets_event_type_name = ?", name);

--- a/src/main/java/org/zalando/nakadi/repository/db/EventTypeDbRepository.java
+++ b/src/main/java/org/zalando/nakadi/repository/db/EventTypeDbRepository.java
@@ -189,6 +189,10 @@ public class EventTypeDbRepository extends AbstractDbRepository implements Event
         } catch (DataAccessException e) {
             throw new InternalNakadiException("Error occurred when deleting EventType " + name, e);
         }
+    }
 
+    @Override
+    public void notifyUpdated(final String name) {
+        // Do nothing. Database is always in sync
     }
 }

--- a/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -37,6 +37,7 @@ import org.zalando.nakadi.exceptions.runtime.FeatureNotAvailableException;
 import org.zalando.nakadi.exceptions.runtime.InconsistentStateException;
 import org.zalando.nakadi.exceptions.runtime.InternalNakadiException;
 import org.zalando.nakadi.exceptions.runtime.InvalidEventTypeException;
+import org.zalando.nakadi.exceptions.runtime.NakadiBaseException;
 import org.zalando.nakadi.exceptions.runtime.NakadiRuntimeException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchEventTypeException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchPartitionStrategyException;
@@ -203,7 +204,11 @@ public class EventTypeService {
                     LOG.warn("Failed to rollback event type creation (which is highly expected)", ex2);
                 }
             }
-            throw ex;
+            if (ex instanceof NakadiBaseException) {
+                throw ex;
+            } else {
+                throw new InternalNakadiException("Failed to create event type: " + ex.getMessage(), ex);
+            }
         }
         nakadiKpiPublisher.publish(etLogEventType, () -> new JSONObject()
                 .put("event_type", eventType.getName())

--- a/src/main/java/org/zalando/nakadi/service/timeline/TimelineService.java
+++ b/src/main/java/org/zalando/nakadi/service/timeline/TimelineService.java
@@ -221,6 +221,11 @@ public class TimelineService {
         }
     }
 
+    public void rollbackTopic(final Timeline timeline) {
+        final TopicRepository repo = topicRepositoryHolder.getTopicRepository(timeline.getStorage());
+        repo.deleteTopic(timeline.getTopic());
+    }
+
     private void rollbackTopic(final TopicRepository repository, final String topic) {
         try {
             repository.deleteTopic(topic);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ jetty:
     idleTimeout: 60000
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/local_nakadi_db?preferQueryMode=simple
+    url: jdbc:postgresql://localhost:5432/local_nakadi_db
     username: nakadi
     password: nakadi
     driverClassName: org.postgresql.Driver
@@ -23,7 +23,7 @@ spring:
       test-while-idle: true
       time-between-eviction-runs-millis: 5000
       min-evictable-idle-time-millis: 60000
-      connection-properties: socketTimeout=2;connectTimeout=2;loginTimeout=2;preferQueryMode=simple
+      connection-properties: socketTimeout=2;connectTimeout=2;loginTimeout=2
 
 hystrix.command.default.execution.isolation.strategy: SEMAPHORE
 hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds: 15000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ jetty:
     idleTimeout: 60000
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/local_nakadi_db
+    url: jdbc:postgresql://localhost:5432/local_nakadi_db?preferQueryMode=simple
     username: nakadi
     password: nakadi
     driverClassName: org.postgresql.Driver
@@ -23,7 +23,7 @@ spring:
       test-while-idle: true
       time-between-eviction-runs-millis: 5000
       min-evictable-idle-time-millis: 60000
-      connection-properties: socketTimeout=2;connectTimeout=2;loginTimeout=2
+      connection-properties: socketTimeout=2;connectTimeout=2;loginTimeout=2;preferQueryMode=simple
 
 hystrix.command.default.execution.isolation.strategy: SEMAPHORE
 hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds: 15000

--- a/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
+++ b/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
@@ -684,6 +684,7 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
         final EventType et = buildDefaultEventType();
         doThrow(TopicCreationException.class).when(timelineService)
                 .createDefaultTimeline(any(), anyInt());
+        when(eventTypeRepository.saveEventType(any())).thenReturn(et);
         final Problem expectedProblem = Problem.valueOf(SERVICE_UNAVAILABLE);
 
         postEventType(et).andExpect(status().isServiceUnavailable())

--- a/src/test/java/org/zalando/nakadi/repository/db/CachingEventTypeRepositoryTest.java
+++ b/src/test/java/org/zalando/nakadi/repository/db/CachingEventTypeRepositoryTest.java
@@ -17,7 +17,7 @@ public class CachingEventTypeRepositoryTest {
     private final EventTypeRepository cachedRepo;
     private final EventType et = mock(EventType.class);
 
-    public CachingEventTypeRepositoryTest() throws Exception {
+    public CachingEventTypeRepositoryTest() {
         this.cachedRepo = new CachingEventTypeRepository(dbRepo, cache);
 
         Mockito
@@ -27,15 +27,14 @@ public class CachingEventTypeRepositoryTest {
     }
 
     @Test
-    public void whenDbPersistenceSucceedThenNotifyCache() throws Exception {
+    public void whenDbPersistenceSucceedThenNotifyCache() {
         cachedRepo.saveEventType(et);
 
         verify(dbRepo, times(1)).saveEventType(et);
-        verify(cache, times(1)).created(et.getName());
     }
 
     @Test
-    public void whenCacheFailsThenRollbackEventPersistence() throws Exception {
+    public void whenCacheFailsThenRollbackEventPersistence() {
         Mockito
                 .doThrow(Exception.class)
                 .when(cache)
@@ -49,15 +48,14 @@ public class CachingEventTypeRepositoryTest {
     }
 
     @Test
-    public void whenDbUpdateSucceedThenNotifyCache() throws Exception {
+    public void whenDbUpdateSucceedThenNotifyCache() {
         cachedRepo.update(et);
 
         verify(dbRepo, times(1)).update(et);
-        verify(cache, times(1)).updated("event-name");
     }
 
     @Test
-    public void whenUpdateCacheFailThenRollbackDbPersistence() throws Exception {
+    public void whenUpdateCacheFailThenRollbackDbPersistence() {
         Mockito
                 .doThrow(Exception.class)
                 .when(cache)
@@ -78,15 +76,14 @@ public class CachingEventTypeRepositoryTest {
     }
 
     @Test
-    public void removeFromDbSucceedNotifyCache() throws Exception {
+    public void removeFromDbSucceedNotifyCache() {
         cachedRepo.removeEventType("event-name");
 
         verify(dbRepo, times(1)).removeEventType("event-name");
-        verify(cache, times(1)).removed("event-name");
     }
 
     @Test
-    public void whenRemoveCacheEntryFailsThenRollbackDbRemoval() throws Exception {
+    public void whenRemoveCacheEntryFailsThenRollbackDbRemoval() {
         Mockito
                 .doThrow(Exception.class)
                 .when(cache)

--- a/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
+++ b/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
@@ -243,6 +243,7 @@ public class EventTypeServiceTest {
     @Test
     public void shouldRemoveEventTypeWhenTimelineCreationFails() {
         final EventType eventType = buildDefaultEventType();
+        when(eventTypeRepository.saveEventType(any())).thenReturn(eventType);
         when(timelineService.createDefaultTimeline(any(), anyInt()))
                 .thenThrow(new TopicCreationException("Failed to create topic"));
         try {


### PR DESCRIPTION
Use transactions while creating event type, notify about updates only after transaction commit, do not rely on psql getTypeInfo call for null types, as connection may be in simple mode (no prepared statements)
ARUHA-2637