### PR TITLE
Avoid sending empty batches in case there are no events in the upcoming window

### DIFF
--- a/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java
@@ -113,11 +113,14 @@ class PartitionData {
     }
 
     private List<ConsumedEvent> extractTimespan(final long batchWindowEndTimestamp) {
-        batchWindowStartTimestamp = batchWindowEndTimestamp;
-
         // extract at least one. This condition is necessary in case the event that triggers the extract is outside
         // the window but it's the only event to be streamed.
-        return extract((taken) -> nakadiEvents.get(0).getTimestamp() < batchWindowEndTimestamp || taken == 0);
+        final List<ConsumedEvent> events = extract((taken) -> nakadiEvents.get(0).getTimestamp() < batchWindowEndTimestamp || taken == 0);
+
+        // needed to fast forward the window start in case there are no events for an extended period of time
+        batchWindowStartTimestamp = Math.max(batchWindowEndTimestamp, events.get(events.size()-1).getTimestamp());
+
+        return events;
     }
 
     NakadiCursor getSentOffset() {
@@ -146,9 +149,6 @@ class PartitionData {
             final ConsumedEvent event = nakadiEvents.remove(0);
             bytesInMemory -= event.getEvent().length;
             result.add(event);
-
-            // needed to fast forward the window start in case there are no events for an extended period of time
-            batchWindowStartTimestamp = Math.max(batchWindowStartTimestamp, event.getTimestamp());
         }
         if (!result.isEmpty()) {
             this.sentOffset = result.get(result.size() - 1).getPosition();

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java
@@ -115,7 +115,9 @@ class PartitionData {
     private List<ConsumedEvent> extractTimespan(final long batchWindowEndTimestamp) {
         // extract at least one. This condition is necessary in case the event that triggers the extract is outside
         // the window but it's the only event to be streamed.
-        final List<ConsumedEvent> events = extract((taken) -> nakadiEvents.get(0).getTimestamp() < batchWindowEndTimestamp || taken == 0);
+        final List<ConsumedEvent> events = extract((taken) -> {
+            return nakadiEvents.get(0).getTimestamp() < batchWindowEndTimestamp || taken == 0;
+        });
 
         // needed to fast forward the window start in case there are no events for an extended period of time
         if (!events.isEmpty()) {

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java
@@ -118,7 +118,9 @@ class PartitionData {
         final List<ConsumedEvent> events = extract((taken) -> nakadiEvents.get(0).getTimestamp() < batchWindowEndTimestamp || taken == 0);
 
         // needed to fast forward the window start in case there are no events for an extended period of time
-        batchWindowStartTimestamp = Math.max(batchWindowEndTimestamp, events.get(events.size()-1).getTimestamp());
+        if (!events.isEmpty()) {
+            batchWindowStartTimestamp = Math.max(batchWindowEndTimestamp, events.get(events.size()-1).getTimestamp());
+        }
 
         return events;
     }


### PR DESCRIPTION
In case there are no events in the time window, but there a single
event outside the time window, this event would trigger extraction but
then no events would be sent, as the window is empty.

As no events would be sent, the value of the window would not be
updated.

This could cause low frequency streams to get stuck.