### PR TITLE
instance termination plugin support

### DIFF
--- a/src/main/java/org/zalando/nakadi/config/PluginsConfig.java
+++ b/src/main/java/org/zalando/nakadi/config/PluginsConfig.java
@@ -54,4 +54,19 @@ public class PluginsConfig {
             throw new BeanCreationException("Can't create AuthorizationService " + factoryName, e);
         }
     }
+
+    @Bean
+    public TerminationService authorizationService(@Value("${nakadi.plugins.termination.factory}") final String factoryName,
+                                                   final SystemProperties systemProperties,
+                                                   final DefaultResourceLoader loader) {
+        try {
+            LOGGER.info("Initialize per-resource termination service factory: " + factoryName);
+            final Class<TerminationServiceFactory> factoryClass =
+                    (Class<TerminationServiceFactory>) loader.getClassLoader().loadClass(factoryName);
+            final TerminationServiceFactory factory = factoryClass.newInstance();
+            return factory.init(systemProperties);
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+            throw new BeanCreationException("Can't create TerminationService " + factoryName, e);
+        }
+    }
 }

--- a/src/main/java/org/zalando/nakadi/plugin/DefaultTerminationService.java
+++ b/src/main/java/org/zalando/nakadi/plugin/DefaultTerminationService.java
@@ -1,0 +1,12 @@
+package org.zalando.nakadi.plugin;
+
+public class DefaultTerminationService implements TerminationService {
+
+    public void register(final String listenerName, final TerminationListener terminationRunnable) {
+        // skip implementation for the local setup
+    }
+
+    public void deregister(final String listenerName) {
+        // skip implementation for the local setup
+    }
+}

--- a/src/main/java/org/zalando/nakadi/plugin/DefaultTerminationServiceFactory.java
+++ b/src/main/java/org/zalando/nakadi/plugin/DefaultTerminationServiceFactory.java
@@ -1,0 +1,10 @@
+package org.zalando.nakadi.plugin;
+
+import org.zalando.nakadi.plugin.api.SystemProperties;
+
+public class DefaultTerminationServiceFactory {
+
+    public DefaultTerminationService init(final SystemProperties systemProperties) {
+        return new DefaultTerminationService();
+    }
+}

--- a/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -11,6 +11,7 @@ import org.zalando.nakadi.domain.NakadiCursor;
 import org.zalando.nakadi.domain.Subscription;
 import org.zalando.nakadi.exceptions.runtime.AccessDeniedException;
 import org.zalando.nakadi.exceptions.runtime.NakadiRuntimeException;
+import org.zalando.nakadi.plugin.api.exceptions.PluginException;
 import org.zalando.nakadi.service.AuthorizationValidator;
 import org.zalando.nakadi.service.BlacklistService;
 import org.zalando.nakadi.service.CursorConverter;
@@ -68,6 +69,7 @@ public class StreamingContext implements SubscriptionStreamer {
     private final NakadiKpiPublisher kpiPublisher;
     private final Span currentSpan;
     private final String kpiDataStreamedEventType;
+    private final TerminationService terminationService;
 
     private final long kpiCollectionFrequencyMs;
 
@@ -105,6 +107,7 @@ public class StreamingContext implements SubscriptionStreamer {
         this.kpiCollectionFrequencyMs = builder.kpiCollectionFrequencyMs;
         this.streamMemoryLimitBytes = builder.streamMemoryLimitBytes;
         this.currentSpan = builder.currentSpan;
+        this.terminationService = builder.terminationService;
     }
 
     public Span getCurrentSpan() {
@@ -163,16 +166,28 @@ public class StreamingContext implements SubscriptionStreamer {
         return kpiCollectionFrequencyMs;
     }
 
+    public TerminationService getTerminationService() {
+        return terminationService;
+    }
+
     @Override
     public void stream() throws InterruptedException {
         try (Closeable ignore = ShutdownHooks.addHook(this::onNodeShutdown)) { // bugfix ARUHA-485
+            terminationService.register(getSessionId(), this::onInstanceTermination);
             streamInternal(new StartingState());
+        } catch (final PluginException pe) {
+            log.error("Failed to register instance termination callback for subscription {}", getSubscription(), pe);
         } catch (final IOException ex) {
             log.error(
                     "Failed to delete shutdown hook for subscription {}. This method should not throw any exception",
                     getSubscription(),
                     ex);
         }
+    }
+
+    void onInstanceTermination() {
+        log.info("Instance is about to be terminated. Trying to terminate subscription gracefully");
+        switchState(new CleanupState(null));
     }
 
     void onNodeShutdown() {
@@ -372,6 +387,7 @@ public class StreamingContext implements SubscriptionStreamer {
         private long kpiCollectionFrequencyMs;
         private long streamMemoryLimitBytes;
         private Span currentSpan;
+        private TerminationService terminationService;
 
         public Builder setCurrentSpan(final Span span) {
             this.currentSpan = span;
@@ -492,6 +508,12 @@ public class StreamingContext implements SubscriptionStreamer {
             this.kpiCollectionFrequencyMs = kpiCollectionFrequencyMs;
             return this;
         }
+
+        public Builder setTerminationService(final TerminationService terminationService) {
+            this.terminationService = terminationService;
+            return this;
+        }
+
 
         public StreamingContext build() {
             return new StreamingContext(this);

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/CleanupState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/CleanupState.java
@@ -29,8 +29,8 @@ public class CleanupState extends State {
             }
         } finally {
             try {
+                getContext().getTerminationService().deregister(getSessionId());
                 getContext().unregisterSession();
-
             } finally {
                 switchState(StreamingContext.DEAD_STATE);
             }

--- a/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -656,7 +656,7 @@ class StreamingState extends State {
                 LoggerFactory.getLogger(LogPathBuilder.build(
                         getContext().getSubscription().getId(), getSessionId(), String.valueOf(partition.getKey()))),
                 System.currentTimeMillis(), this.getContext().getParameters().batchTimespan
-                );
+        );
 
         offsets.put(partition.getKey(), pd);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -98,6 +98,8 @@ nakadi:
       factory: org.zalando.nakadi.plugin.auth.DefaultApplicationServiceFactory
     authz:
       factory: org.zalando.nakadi.plugin.auth.DefaultAuthorizationServiceFactory
+    termination:
+      factory: org.zalando.nakadi.plugin.DefaultTerminationServiceFactory
   event.max.bytes: 999000
   timeline.wait.timeoutMs: 40000
   subscription:


### PR DESCRIPTION
# One-line summary
it should be possible to notify nakadi about coming instance termination, that it can release used resources and prepare itself for termination. A good example would be subscription connection termination in clean way, that consumer will not wait commit timeout

PR is not compilable due to plugin api change, which is expected here https://github.com/zalando-nakadi/nakadi-plugin-api/pull/10