### PR TITLE
Session not cleaned if error before making zookeeper session change subscription

### DIFF
--- a/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -75,6 +75,7 @@ public class StreamingContext implements SubscriptionStreamer {
 
     private State currentState = new DummyState();
     private ZkSubscription<List<String>> sessionListSubscription;
+    private boolean sessionRegistered;
     private Closeable authorizationCheckSubscription;
 
     private final Logger log;
@@ -235,6 +236,7 @@ public class StreamingContext implements SubscriptionStreamer {
     public void registerSession() throws NakadiRuntimeException {
         log.info("Registering session {}", session);
         zkClient.registerSession(session);
+        sessionRegistered = true;
     }
 
     public void subscribeToSessionListChangeAndRebalance() throws NakadiRuntimeException {
@@ -246,9 +248,11 @@ public class StreamingContext implements SubscriptionStreamer {
 
     public void unregisterSession() {
         log.info("Unregistering session {}", session);
-        if (null != sessionListSubscription) {
+        if (sessionRegistered) {
             try {
-                sessionListSubscription.close();
+                if (sessionListSubscription != null) {
+                    sessionListSubscription.close();
+                }
             } finally {
                 this.sessionListSubscription = null;
                 zkClient.unregisterSession(session);

--- a/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -75,7 +75,6 @@ public class StreamingContext implements SubscriptionStreamer {
 
     private State currentState = new DummyState();
     private ZkSubscription<List<String>> sessionListSubscription;
-    private boolean sessionRegistered;
     private Closeable authorizationCheckSubscription;
 
     private final Logger log;
@@ -236,7 +235,6 @@ public class StreamingContext implements SubscriptionStreamer {
     public void registerSession() throws NakadiRuntimeException {
         log.info("Registering session {}", session);
         zkClient.registerSession(session);
-        sessionRegistered = true;
     }
 
     public void subscribeToSessionListChangeAndRebalance() throws NakadiRuntimeException {
@@ -248,15 +246,13 @@ public class StreamingContext implements SubscriptionStreamer {
 
     public void unregisterSession() {
         log.info("Unregistering session {}", session);
-        if (sessionRegistered) {
-            try {
-                if (sessionListSubscription != null) {
-                    sessionListSubscription.close();
-                }
-            } finally {
-                this.sessionListSubscription = null;
-                zkClient.unregisterSession(session);
+        try {
+            if (sessionListSubscription != null) {
+                sessionListSubscription.close();
             }
+        } finally {
+            this.sessionListSubscription = null;
+            zkClient.unregisterSession(session);
         }
     }
 

--- a/src/test/java/org/zalando/nakadi/service/subscription/StreamingContextTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/StreamingContextTest.java
@@ -175,7 +175,7 @@ public class StreamingContextTest {
     @Test
     public void testSessionAlwaysCleanedIfRegistered() throws Exception {
 
-        ZkSubscriptionClient zkMock = mock(ZkSubscriptionClient.class);
+        final ZkSubscriptionClient zkMock = mock(ZkSubscriptionClient.class);
 
         final StreamingContext context = new StreamingContext.Builder()
                 .setSession(Session.generate(1, ImmutableList.of()))

--- a/src/test/java/org/zalando/nakadi/service/subscription/StreamingContextTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/StreamingContextTest.java
@@ -186,7 +186,7 @@ public class StreamingContextTest {
                 .build();
 
         context.registerSession();
-        // CleanupState calls context.unregisterSession() in finally
+        // CleanupState calls context.unregisterSession() in finally block
         context.unregisterSession();
 
         Mockito.verify(zkMock, Mockito.times(1)).registerSession(any());

--- a/src/test/java/org/zalando/nakadi/service/subscription/StreamingContextTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/StreamingContextTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 
@@ -169,5 +170,26 @@ public class StreamingContextTest {
         Mockito.verify(ctxSpy).switchState(Mockito.isA(CleanupState.class));
         Mockito.verify(ctxSpy).unregisterSession();
         Mockito.verify(ctxSpy).switchState(Mockito.isA(DummyState.class));
+    }
+
+    @Test
+    public void testSessionAlwaysCleanedIfRegistered() throws Exception {
+
+        ZkSubscriptionClient zkMock = mock(ZkSubscriptionClient.class);
+
+        final StreamingContext context = new StreamingContext.Builder()
+                .setSession(Session.generate(1, ImmutableList.of()))
+                .setSubscription(new Subscription())
+                .setZkClient(zkMock)
+                .setKafkaPollTimeout(0)
+                .setConnectionReady(new AtomicBoolean(true))
+                .build();
+
+        context.registerSession();
+        // CleanupState calls context.unregisterSession() in finally
+        context.unregisterSession();
+
+        Mockito.verify(zkMock, Mockito.times(1)).registerSession(any());
+        Mockito.verify(zkMock, Mockito.times(1)).unregisterSession(any());
     }
 }


### PR DESCRIPTION
In case of exception before creation of subscription for zookeeper changes to sessions list, the corresponding session registered in Zookeeper is not cleaned up, leading to a zombie state, where a stream is present, but not in `StreamingState`.

The bug that the consumption instance wouldn't clean up the session was because the session timed out while releasing the lock during registration of session (i.e before [switching](https://gist.github.com/ferbncode/5f97ee428d9124c869c51ccf0139ef42#file-exception-L66) to streaming state)

See exception here: https://gist.github.com/ferbncode/5f97ee428d9124c869c51ccf0139ef42

This can then only be fixed by terminating the instance where the exception occurred.