### PR TITLE
Check if node exists before attempt to delete

### DIFF
--- a/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -76,7 +76,6 @@ public class StreamingContext implements SubscriptionStreamer {
     private State currentState = new DummyState();
     private ZkSubscription<List<String>> sessionListSubscription;
     private Closeable authorizationCheckSubscription;
-    private boolean sessionRegistered;
 
     private final Logger log;
 
@@ -236,7 +235,6 @@ public class StreamingContext implements SubscriptionStreamer {
     public void registerSession() throws NakadiRuntimeException {
         log.info("Registering session {}", session);
         zkClient.registerSession(session);
-        sessionRegistered = true;
     }
 
     public void subscribeToSessionListChangeAndRebalance() throws NakadiRuntimeException {
@@ -248,16 +246,13 @@ public class StreamingContext implements SubscriptionStreamer {
 
     public void unregisterSession() {
         log.info("Unregistering session {}", session);
-        if (sessionRegistered) {
-            try {
-                if (sessionListSubscription != null) {
-                    sessionListSubscription.close();
-                }
-            } finally {
-                this.sessionListSubscription = null;
-                zkClient.unregisterSession(session);
-                sessionRegistered = false;
+        try {
+            if (sessionListSubscription != null) {
+                sessionListSubscription.close();
             }
+        } finally {
+            this.sessionListSubscription = null;
+            zkClient.unregisterSession(session);
         }
     }
 

--- a/src/main/java/org/zalando/nakadi/service/subscription/zk/AbstractZkSubscriptionClient.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/zk/AbstractZkSubscriptionClient.java
@@ -196,7 +196,9 @@ public abstract class AbstractZkSubscriptionClient implements ZkSubscriptionClie
     @Override
     public final void unregisterSession(final Session session) {
         try {
-            getCurator().delete().guaranteed().forPath(getSubscriptionPath("/sessions/" + session.getId()));
+            if (isActiveSession(session.getId())) {
+                getCurator().delete().guaranteed().forPath(getSubscriptionPath("/sessions/" + session.getId()));
+            }
         } catch (final Exception e) {
             throw new NakadiRuntimeException(e);
         }

--- a/src/test/java/org/zalando/nakadi/service/subscription/StreamingContextTest.java
+++ b/src/test/java/org/zalando/nakadi/service/subscription/StreamingContextTest.java
@@ -23,6 +23,7 @@ import java.util.function.Consumer;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class StreamingContextTest {
     private static StreamingContext createTestContext(final Consumer<Exception> onException) throws IOException {
@@ -176,6 +177,7 @@ public class StreamingContextTest {
     public void testSessionAlwaysCleanedIfRegistered() throws Exception {
 
         final ZkSubscriptionClient zkMock = mock(ZkSubscriptionClient.class);
+        when(zkMock.isActiveSession(any())).thenReturn(true);
 
         final StreamingContext context = new StreamingContext.Builder()
                 .setSession(Session.generate(1, ImmutableList.of()))


### PR DESCRIPTION
Initially, I did set the flag (`sessionRegistered` back to false only after successfully un-registering a node. If an exception occurred after deletion of the node, it is happening that the variable is not unset and we loop through `CleanupState.onEntry()` logging too much

Added check if the node exists (it should not increase much over-head on zookeeper, since this is not a very frequent operation) before deletion as I don't want to set `sessionRegistered=false` if un-registering fails, which would cause the zombie session issue
