### PR TITLE
Do unregister session as before

### DIFF
--- a/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -76,6 +76,7 @@ public class StreamingContext implements SubscriptionStreamer {
     private State currentState = new DummyState();
     private ZkSubscription<List<String>> sessionListSubscription;
     private Closeable authorizationCheckSubscription;
+    private boolean sessionRegistered;
 
     private final Logger log;
 
@@ -235,6 +236,7 @@ public class StreamingContext implements SubscriptionStreamer {
     public void registerSession() throws NakadiRuntimeException {
         log.info("Registering session {}", session);
         zkClient.registerSession(session);
+        sessionRegistered = true;
     }
 
     public void subscribeToSessionListChangeAndRebalance() throws NakadiRuntimeException {
@@ -252,7 +254,10 @@ public class StreamingContext implements SubscriptionStreamer {
             }
         } finally {
             this.sessionListSubscription = null;
-            zkClient.unregisterSession(session);
+            if (sessionRegistered) {
+                sessionRegistered = false;
+                zkClient.unregisterSession(session);
+            }
         }
     }
 

--- a/src/main/java/org/zalando/nakadi/service/subscription/zk/AbstractZkSubscriptionClient.java
+++ b/src/main/java/org/zalando/nakadi/service/subscription/zk/AbstractZkSubscriptionClient.java
@@ -196,9 +196,7 @@ public abstract class AbstractZkSubscriptionClient implements ZkSubscriptionClie
     @Override
     public final void unregisterSession(final Session session) {
         try {
-            if (isActiveSession(session.getId())) {
-                getCurator().delete().guaranteed().forPath(getSubscriptionPath("/sessions/" + session.getId()));
-            }
+            getCurator().delete().guaranteed().forPath(getSubscriptionPath("/sessions/" + session.getId()));
         } catch (final Exception e) {
             throw new NakadiRuntimeException(e);
         }


### PR DESCRIPTION
Do unregister based on a flag as before. Right now, disk is still filling up if it fails with the `isActiveSession` call.