### PR TITLE
Create system event-types only if they are missing

### DIFF
--- a/api-metastore/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -224,6 +224,24 @@ public class EventTypeService {
                 eventType.getName());
     }
 
+    public void createIfMissing(final EventTypeBase eventType, final boolean checkAuth)
+            throws AuthorizationSectionException,
+            TopicCreationException,
+            InternalNakadiException,
+            NoSuchPartitionStrategyException,
+            DuplicatedEventTypeNameException,
+            InvalidEventTypeException,
+            DbWriteOperationsBlockedException,
+            EventTypeOptionsValidationException {
+        try {
+            eventTypeRepository.findByName(eventType.getName());
+            LOG.info("Event-type {} already exist", eventType.getName());
+        } catch (final NoSuchEventTypeException noSuchEventTypeException) {
+            LOG.info("Creating event-type {} as it is missing", eventType.getName());
+            create(eventType, checkAuth);
+        }
+    }
+
     private void validateCompaction(final EventTypeBase eventType) throws
             InvalidEventTypeException {
         if (eventType.getCategory() == EventCategory.UNDEFINED &&

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -235,7 +235,7 @@ public class EventTypeService {
             EventTypeOptionsValidationException {
         try {
             eventTypeRepository.findByName(eventType.getName());
-            LOG.info("Event-type {} already exist", eventType.getName());
+            LOG.info("Event-type {} already exists", eventType.getName());
         } catch (final NoSuchEventTypeException noSuchEventTypeException) {
             LOG.info("Creating event-type {} as it is missing", eventType.getName());
             create(eventType, checkAuth);

--- a/app/src/main/java/org/zalando/nakadi/service/SystemEventTypeInitializer.java
+++ b/app/src/main/java/org/zalando/nakadi/service/SystemEventTypeInitializer.java
@@ -19,7 +19,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @Component
-public class  SystemEventTypeInitializer {
+public class SystemEventTypeInitializer {
     private final ObjectMapper objectMapper;
     private final EventTypeService eventTypeService;
     private static final Logger LOG = LoggerFactory.getLogger(SystemEventTypeInitializer.class);
@@ -49,7 +49,7 @@ public class  SystemEventTypeInitializer {
 
         eventTypes.forEach(et -> {
             try {
-                eventTypeService.create(et, false);
+                eventTypeService.createIfMissing(et, false);
             } catch (final DuplicatedEventTypeNameException e) {
                 LOG.debug("Event type {} from {} already exists", et.getName(), resourceName);
             } catch (final NakadiBaseException e) {


### PR DESCRIPTION
Signed-off-by: Thomas Abraham <thomas.abraham@zalando.de>

# Create system event-types only if they are missing

> Zalando ticket : ARUHA-2704

## Description
When Nakadi starts up, it tries to create a few system event types.
When the event type creation fails, because they already exist, it logs the an error with complete stack trace. This PR introduces a `createIfMissing` function, which will check if the event exists first. 
