### PR TITLE
Don't check event authorization if the owner is not set

### DIFF
--- a/core-services/src/main/java/org/zalando/nakadi/service/AuthorizationValidator.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/AuthorizationValidator.java
@@ -122,6 +122,9 @@ public class AuthorizationValidator {
 
     public void authorizeEventWrite(final BatchItem batchItem)
             throws AccessDeniedException, ServiceTemporarilyUnavailableException {
+        if (batchItem.getOwner() == null) {
+            return;
+        }
         try {
             final boolean authorized = authorizationService.isAuthorized(
                     AuthorizationService.Operation.WRITE, batchItem);

--- a/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventPublisher.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventPublisher.java
@@ -118,7 +118,8 @@ public class EventPublisher {
                                        final Span parentSpan,
                                        final boolean delete)
             throws NoSuchEventTypeException, InternalNakadiException, EventTypeTimeoutException,
-            AccessDeniedException, ServiceTemporarilyUnavailableException, EnrichmentException, PartitioningException {
+            AccessDeniedException, ServiceTemporarilyUnavailableException, PublishEventOwnershipException,
+            EnrichmentException, PartitioningException {
 
         Closeable publishingCloser = null;
         final List<BatchItem> batch = BatchFactory.from(events);


### PR DESCRIPTION
# One-line summary
Don't check `authorization` per event if owner is not set. 
