### PR TITLE
Fix handling of `null` path as StrictJsonParser uses JSONObject.NULL

### DIFF
--- a/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventOwnerExtractorFactory.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventOwnerExtractorFactory.java
@@ -44,8 +44,8 @@ public class EventOwnerExtractorFactory {
         return (batchItem) -> {
             try {
                 final JsonPathAccess jsonPath = new JsonPathAccess(batchItem);
-                final String value = jsonPath.get(selector.getValue()).toString();
-                return null == value ? null : new EventOwnerHeader(selector.getName(), value);
+                final Object value = jsonPath.get(selector.getValue());
+                return JSONObject.NULL == value ? null : new EventOwnerHeader(selector.getName(), value.toString());
             } catch (final JsonPathAccessException e) {
                 return null;
             }

--- a/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventOwnerExtractorTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventOwnerExtractorTest.java
@@ -11,8 +11,9 @@ import java.util.function.Function;
 
 public class EventOwnerExtractorTest {
     private static final JSONObject MOCK_EVENT = StrictJsonParser.parse("{" +
+            "\"other\": null, \n" +
             "\"example\": {\n" +
-            "    \"security\": {\"final\": \"test_value\"}}" +
+                "\"security\": {\"final\": \"test_value\"}}" +
             "}", false);
 
     @Test
@@ -27,9 +28,18 @@ public class EventOwnerExtractorTest {
     }
 
     @Test
-    public void testNullValueWithPathValue() {
+    public void testAbsenceOfPathValue() {
         final Function<JSONObject, EventOwnerHeader> extractor = EventOwnerExtractorFactory.createPathExtractor(
                 new EventOwnerSelector(EventOwnerSelector.Type.PATH, "retailer_id", "example.nothing.here"));
+
+        final EventOwnerHeader result = extractor.apply(MOCK_EVENT);
+        Assert.assertNull(result);
+    }
+
+    @Test
+    public void testNullWithPathValue() {
+        final Function<JSONObject, EventOwnerHeader> extractor = EventOwnerExtractorFactory.createPathExtractor(
+                new EventOwnerSelector(EventOwnerSelector.Type.PATH, "retailer_id", "other"));
 
         final EventOwnerHeader result = extractor.apply(MOCK_EVENT);
         Assert.assertNull(result);


### PR DESCRIPTION
StrictJsonParser.java returns `JSONObject.NULL` for fields where value is set as `null`. Thus, fixed the code to handle `nulls` as expected.