### PR TITLE
reduce size of the metrics response short term

### DIFF
--- a/app/src/main/java/org/zalando/nakadi/config/MetricsConfig.java
+++ b/app/src/main/java/org/zalando/nakadi/config/MetricsConfig.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.zalando.nakadi.metrics.NakadiMetricsServlet;
 
 import java.lang.management.ManagementFactory;
 
@@ -20,7 +21,7 @@ import java.lang.management.ManagementFactory;
 public class MetricsConfig {
     @Bean
     public ServletRegistrationBean servletRegistrationBean(final MetricRegistry metricRegistry) {
-        return new ServletRegistrationBean(new MetricsServlet(metricRegistry), "/metrics/*");
+        return new ServletRegistrationBean(new NakadiMetricsServlet(metricRegistry), "/metrics/*");
     }
 
     class SubscriptionMetricsServlet extends MetricsServlet {

--- a/core-common/src/main/java/org/zalando/nakadi/metrics/NakadiMetricsModule.java
+++ b/core-common/src/main/java/org/zalando/nakadi/metrics/NakadiMetricsModule.java
@@ -30,9 +30,9 @@ public class NakadiMetricsModule extends Module {
         }
 
         @Override
-        public void serialize(Gauge gauge,
-                              JsonGenerator json,
-                              SerializerProvider provider) throws IOException {
+        public void serialize(final Gauge gauge,
+                              final JsonGenerator json,
+                              final SerializerProvider provider) throws IOException {
             json.writeStartObject();
             final Object value;
             try {
@@ -51,9 +51,9 @@ public class NakadiMetricsModule extends Module {
         }
 
         @Override
-        public void serialize(Counter counter,
-                              JsonGenerator json,
-                              SerializerProvider provider) throws IOException {
+        public void serialize(final Counter counter,
+                              final JsonGenerator json,
+                              final SerializerProvider provider) throws IOException {
             json.writeStartObject();
             json.writeNumberField("count", counter.getCount());
             json.writeEndObject();
@@ -63,15 +63,15 @@ public class NakadiMetricsModule extends Module {
     private static class HistogramSerializer extends StdSerializer<Histogram> {
         private final boolean showSamples;
 
-        private HistogramSerializer(boolean showSamples) {
+        private HistogramSerializer(final boolean showSamples) {
             super(Histogram.class);
             this.showSamples = showSamples;
         }
 
         @Override
-        public void serialize(Histogram histogram,
-                              JsonGenerator json,
-                              SerializerProvider provider) throws IOException {
+        public void serialize(final Histogram histogram,
+                              final JsonGenerator json,
+                              final SerializerProvider provider) throws IOException {
             json.writeStartObject();
             final Snapshot snapshot = histogram.getSnapshot();
             json.writeNumberField("count", histogram.getCount());
@@ -89,16 +89,16 @@ public class NakadiMetricsModule extends Module {
         private final String rateUnit;
         private final double rateFactor;
 
-        public MeterSerializer(TimeUnit rateUnit) {
+        MeterSerializer(final TimeUnit rateUnit) {
             super(Meter.class);
             this.rateFactor = rateUnit.toSeconds(1);
             this.rateUnit = calculateRateUnit(rateUnit, "events");
         }
 
         @Override
-        public void serialize(Meter meter,
-                              JsonGenerator json,
-                              SerializerProvider provider) throws IOException {
+        public void serialize(final Meter meter,
+                              final JsonGenerator json,
+                              final SerializerProvider provider) throws IOException {
             json.writeStartObject();
             json.writeNumberField("count", meter.getCount());
             json.writeNumberField("m1_rate", meter.getOneMinuteRate() * rateFactor);
@@ -114,9 +114,9 @@ public class NakadiMetricsModule extends Module {
         private final double durationFactor;
         private final boolean showSamples;
 
-        private TimerSerializer(TimeUnit rateUnit,
-                                TimeUnit durationUnit,
-                                boolean showSamples) {
+        private TimerSerializer(final TimeUnit rateUnit,
+                                final TimeUnit durationUnit,
+                                final boolean showSamples) {
             super(Timer.class);
             this.rateUnit = calculateRateUnit(rateUnit, "calls");
             this.rateFactor = rateUnit.toSeconds(1);
@@ -126,9 +126,9 @@ public class NakadiMetricsModule extends Module {
         }
 
         @Override
-        public void serialize(Timer timer,
-                              JsonGenerator json,
-                              SerializerProvider provider) throws IOException {
+        public void serialize(final Timer timer,
+                              final JsonGenerator json,
+                              final SerializerProvider provider) throws IOException {
             json.writeStartObject();
             final Snapshot snapshot = timer.getSnapshot();
             json.writeNumberField("count", timer.getCount());
@@ -154,15 +154,15 @@ public class NakadiMetricsModule extends Module {
 
         private final MetricFilter filter;
 
-        private MetricRegistrySerializer(MetricFilter filter) {
+        private MetricRegistrySerializer(final MetricFilter filter) {
             super(MetricRegistry.class);
             this.filter = filter;
         }
 
         @Override
-        public void serialize(MetricRegistry registry,
-                              JsonGenerator json,
-                              SerializerProvider provider) throws IOException {
+        public void serialize(final MetricRegistry registry,
+                              final JsonGenerator json,
+                              final SerializerProvider provider) throws IOException {
             json.writeStartObject();
             json.writeStringField("version", VERSION.toString());
             json.writeObjectField("gauges", registry.getGauges(filter));
@@ -179,11 +179,16 @@ public class NakadiMetricsModule extends Module {
     private final boolean showSamples;
     private final MetricFilter filter;
 
-    public NakadiMetricsModule(TimeUnit rateUnit, TimeUnit durationUnit, boolean showSamples) {
+    public NakadiMetricsModule(final TimeUnit rateUnit,
+                               final TimeUnit durationUnit,
+                               final boolean showSamples) {
         this(rateUnit, durationUnit, showSamples, MetricFilter.ALL);
     }
 
-    public NakadiMetricsModule(TimeUnit rateUnit, TimeUnit durationUnit, boolean showSamples, MetricFilter filter) {
+    public NakadiMetricsModule(final TimeUnit rateUnit,
+                               final TimeUnit durationUnit,
+                               final boolean showSamples,
+                               final MetricFilter filter) {
         this.rateUnit = rateUnit;
         this.durationUnit = durationUnit;
         this.showSamples = showSamples;
@@ -201,7 +206,7 @@ public class NakadiMetricsModule extends Module {
     }
 
     @Override
-    public void setupModule(SetupContext context) {
+    public void setupModule(final SetupContext context) {
         context.addSerializers(new SimpleSerializers(Arrays.<JsonSerializer<?>>asList(
                 new GaugeSerializer(),
                 new CounterSerializer(),
@@ -212,7 +217,7 @@ public class NakadiMetricsModule extends Module {
         )));
     }
 
-    private static String calculateRateUnit(TimeUnit unit, String name) {
+    private static String calculateRateUnit(final TimeUnit unit, final String name) {
         final String s = unit.toString().toLowerCase(Locale.US);
         return name + '/' + s.substring(0, s.length() - 1);
     }

--- a/core-common/src/main/java/org/zalando/nakadi/metrics/NakadiMetricsModule.java
+++ b/core-common/src/main/java/org/zalando/nakadi/metrics/NakadiMetricsModule.java
@@ -1,0 +1,219 @@
+package org.zalando.nakadi.metrics;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleSerializers;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+public class NakadiMetricsModule extends Module {
+    static final Version VERSION = new Version(3, 1, 3, "", "com.codahale.metrics", "metrics-json");
+
+    private static class GaugeSerializer extends StdSerializer<Gauge> {
+        private GaugeSerializer() {
+            super(Gauge.class);
+        }
+
+        @Override
+        public void serialize(Gauge gauge,
+                              JsonGenerator json,
+                              SerializerProvider provider) throws IOException {
+            json.writeStartObject();
+            final Object value;
+            try {
+                value = gauge.getValue();
+                json.writeObjectField("value", value);
+            } catch (RuntimeException e) {
+                json.writeObjectField("error", e.toString());
+            }
+            json.writeEndObject();
+        }
+    }
+
+    private static class CounterSerializer extends StdSerializer<Counter> {
+        private CounterSerializer() {
+            super(Counter.class);
+        }
+
+        @Override
+        public void serialize(Counter counter,
+                              JsonGenerator json,
+                              SerializerProvider provider) throws IOException {
+            json.writeStartObject();
+            json.writeNumberField("count", counter.getCount());
+            json.writeEndObject();
+        }
+    }
+
+    private static class HistogramSerializer extends StdSerializer<Histogram> {
+        private final boolean showSamples;
+
+        private HistogramSerializer(boolean showSamples) {
+            super(Histogram.class);
+            this.showSamples = showSamples;
+        }
+
+        @Override
+        public void serialize(Histogram histogram,
+                              JsonGenerator json,
+                              SerializerProvider provider) throws IOException {
+            json.writeStartObject();
+            final Snapshot snapshot = histogram.getSnapshot();
+            json.writeNumberField("count", histogram.getCount());
+            json.writeNumberField("mean", snapshot.getMean());
+
+            if (showSamples) {
+                json.writeObjectField("values", snapshot.getValues());
+            }
+
+            json.writeEndObject();
+        }
+    }
+
+    private static class MeterSerializer extends StdSerializer<Meter> {
+        private final String rateUnit;
+        private final double rateFactor;
+
+        public MeterSerializer(TimeUnit rateUnit) {
+            super(Meter.class);
+            this.rateFactor = rateUnit.toSeconds(1);
+            this.rateUnit = calculateRateUnit(rateUnit, "events");
+        }
+
+        @Override
+        public void serialize(Meter meter,
+                              JsonGenerator json,
+                              SerializerProvider provider) throws IOException {
+            json.writeStartObject();
+            json.writeNumberField("count", meter.getCount());
+            json.writeNumberField("m1_rate", meter.getOneMinuteRate() * rateFactor);
+            json.writeStringField("units", rateUnit);
+            json.writeEndObject();
+        }
+    }
+
+    private static class TimerSerializer extends StdSerializer<Timer> {
+        private final String rateUnit;
+        private final double rateFactor;
+        private final String durationUnit;
+        private final double durationFactor;
+        private final boolean showSamples;
+
+        private TimerSerializer(TimeUnit rateUnit,
+                                TimeUnit durationUnit,
+                                boolean showSamples) {
+            super(Timer.class);
+            this.rateUnit = calculateRateUnit(rateUnit, "calls");
+            this.rateFactor = rateUnit.toSeconds(1);
+            this.durationUnit = durationUnit.toString().toLowerCase(Locale.US);
+            this.durationFactor = 1.0 / durationUnit.toNanos(1);
+            this.showSamples = showSamples;
+        }
+
+        @Override
+        public void serialize(Timer timer,
+                              JsonGenerator json,
+                              SerializerProvider provider) throws IOException {
+            json.writeStartObject();
+            final Snapshot snapshot = timer.getSnapshot();
+            json.writeNumberField("count", timer.getCount());
+            json.writeNumberField("mean", snapshot.getMean() * durationFactor);
+
+            if (showSamples) {
+                final long[] values = snapshot.getValues();
+                final double[] scaledValues = new double[values.length];
+                for (int i = 0; i < values.length; i++) {
+                    scaledValues[i] = values[i] * durationFactor;
+                }
+                json.writeObjectField("values", scaledValues);
+            }
+
+            json.writeNumberField("m1_rate", timer.getOneMinuteRate() * rateFactor);
+            json.writeStringField("duration_units", durationUnit);
+            json.writeStringField("rate_units", rateUnit);
+            json.writeEndObject();
+        }
+    }
+
+    private static class MetricRegistrySerializer extends StdSerializer<MetricRegistry> {
+
+        private final MetricFilter filter;
+
+        private MetricRegistrySerializer(MetricFilter filter) {
+            super(MetricRegistry.class);
+            this.filter = filter;
+        }
+
+        @Override
+        public void serialize(MetricRegistry registry,
+                              JsonGenerator json,
+                              SerializerProvider provider) throws IOException {
+            json.writeStartObject();
+            json.writeStringField("version", VERSION.toString());
+            json.writeObjectField("gauges", registry.getGauges(filter));
+            json.writeObjectField("counters", registry.getCounters(filter));
+            json.writeObjectField("histograms", registry.getHistograms(filter));
+            json.writeObjectField("meters", registry.getMeters(filter));
+            json.writeObjectField("timers", registry.getTimers(filter));
+            json.writeEndObject();
+        }
+    }
+
+    private final TimeUnit rateUnit;
+    private final TimeUnit durationUnit;
+    private final boolean showSamples;
+    private final MetricFilter filter;
+
+    public NakadiMetricsModule(TimeUnit rateUnit, TimeUnit durationUnit, boolean showSamples) {
+        this(rateUnit, durationUnit, showSamples, MetricFilter.ALL);
+    }
+
+    public NakadiMetricsModule(TimeUnit rateUnit, TimeUnit durationUnit, boolean showSamples, MetricFilter filter) {
+        this.rateUnit = rateUnit;
+        this.durationUnit = durationUnit;
+        this.showSamples = showSamples;
+        this.filter = filter;
+    }
+
+    @Override
+    public String getModuleName() {
+        return "metrics";
+    }
+
+    @Override
+    public Version version() {
+        return VERSION;
+    }
+
+    @Override
+    public void setupModule(SetupContext context) {
+        context.addSerializers(new SimpleSerializers(Arrays.<JsonSerializer<?>>asList(
+                new GaugeSerializer(),
+                new CounterSerializer(),
+                new HistogramSerializer(showSamples),
+                new MeterSerializer(rateUnit),
+                new TimerSerializer(rateUnit, durationUnit, showSamples),
+                new MetricRegistrySerializer(filter)
+        )));
+    }
+
+    private static String calculateRateUnit(TimeUnit unit, String name) {
+        final String s = unit.toString().toLowerCase(Locale.US);
+        return name + '/' + s.substring(0, s.length() - 1);
+    }
+}

--- a/core-common/src/main/java/org/zalando/nakadi/metrics/NakadiMetricsServlet.java
+++ b/core-common/src/main/java/org/zalando/nakadi/metrics/NakadiMetricsServlet.java
@@ -1,0 +1,193 @@
+package org.zalando.nakadi.metrics;
+
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.util.JSONPObject;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+public class NakadiMetricsServlet extends HttpServlet {
+    /**
+     * An abstract {@link ServletContextListener} which allows you to programmatically inject the
+     * {@link MetricRegistry}, rate and duration units, and allowed origin for
+     * {@link com.codahale.metrics.servlets.MetricsServlet}.
+     */
+    public static abstract class ContextListener implements ServletContextListener {
+        /**
+         * @return the {@link MetricRegistry} to inject into the servlet context.
+         */
+        protected abstract MetricRegistry getMetricRegistry();
+
+        /**
+         * @return the {@link TimeUnit} to which rates should be converted, or {@code null} if the
+         * default should be used.
+         */
+        protected TimeUnit getRateUnit() {
+            // use the default
+            return null;
+        }
+
+        /**
+         * @return the {@link TimeUnit} to which durations should be converted, or {@code null} if
+         * the default should be used.
+         */
+        protected TimeUnit getDurationUnit() {
+            // use the default
+            return null;
+        }
+
+        /**
+         * @return the {@code Access-Control-Allow-Origin} header value, if any.
+         */
+        protected String getAllowedOrigin() {
+            // use the default
+            return null;
+        }
+
+        /**
+         * Returns the name of the parameter used to specify the jsonp callback, if any.
+         */
+        protected String getJsonpCallbackParameter() {
+            return null;
+        }
+
+        /**
+         * Returns the {@link MetricFilter} that shall be used to filter metrics, or {@link MetricFilter#ALL} if
+         * the default should be used.
+         */
+        protected MetricFilter getMetricFilter() {
+            // use the default
+            return MetricFilter.ALL;
+        }
+
+        @Override
+        public void contextInitialized(ServletContextEvent event) {
+            final ServletContext context = event.getServletContext();
+            context.setAttribute(METRICS_REGISTRY, getMetricRegistry());
+            context.setAttribute(METRIC_FILTER, getMetricFilter());
+            if (getDurationUnit() != null) {
+                context.setInitParameter(com.codahale.metrics.servlets.MetricsServlet.DURATION_UNIT, getDurationUnit().toString());
+            }
+            if (getRateUnit() != null) {
+                context.setInitParameter(com.codahale.metrics.servlets.MetricsServlet.RATE_UNIT, getRateUnit().toString());
+            }
+            if (getAllowedOrigin() != null) {
+                context.setInitParameter(com.codahale.metrics.servlets.MetricsServlet.ALLOWED_ORIGIN, getAllowedOrigin());
+            }
+            if (getJsonpCallbackParameter() != null) {
+                context.setAttribute(CALLBACK_PARAM, getJsonpCallbackParameter());
+            }
+        }
+
+        @Override
+        public void contextDestroyed(ServletContextEvent event) {
+            // no-op
+        }
+    }
+
+    public static final String RATE_UNIT = com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".rateUnit";
+    public static final String DURATION_UNIT = com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".durationUnit";
+    public static final String SHOW_SAMPLES = com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".showSamples";
+    public static final String METRICS_REGISTRY = com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".registry";
+    public static final String ALLOWED_ORIGIN = com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".allowedOrigin";
+    public static final String METRIC_FILTER = com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".metricFilter";
+    public static final String CALLBACK_PARAM = com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".jsonpCallback";
+
+    private static final long serialVersionUID = 1049773947734939602L;
+    private static final String CONTENT_TYPE = "application/json";
+
+    private String allowedOrigin;
+    private String jsonpParamName;
+    private transient MetricRegistry registry;
+    private transient ObjectMapper mapper;
+
+    public NakadiMetricsServlet() {
+    }
+
+    public NakadiMetricsServlet(MetricRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        super.init(config);
+
+        final ServletContext context = config.getServletContext();
+        if (null == registry) {
+            final Object registryAttr = context.getAttribute(METRICS_REGISTRY);
+            if (registryAttr instanceof MetricRegistry) {
+                this.registry = (MetricRegistry) registryAttr;
+            } else {
+                throw new ServletException("Couldn't find a MetricRegistry instance.");
+            }
+        }
+
+        final TimeUnit rateUnit = parseTimeUnit(context.getInitParameter(RATE_UNIT),
+                TimeUnit.SECONDS);
+        final TimeUnit durationUnit = parseTimeUnit(context.getInitParameter(DURATION_UNIT),
+                TimeUnit.SECONDS);
+        final boolean showSamples = Boolean.parseBoolean(context.getInitParameter(SHOW_SAMPLES));
+        MetricFilter filter = (MetricFilter) context.getAttribute(METRIC_FILTER);
+        if (filter == null) {
+            filter = MetricFilter.ALL;
+        }
+        this.mapper = new ObjectMapper().registerModule(new NakadiMetricsModule(rateUnit,
+                durationUnit,
+                showSamples,
+                filter));
+
+        this.allowedOrigin = context.getInitParameter(ALLOWED_ORIGIN);
+        this.jsonpParamName = context.getInitParameter(CALLBACK_PARAM);
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req,
+                         HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType(CONTENT_TYPE);
+        if (allowedOrigin != null) {
+            resp.setHeader("Access-Control-Allow-Origin", allowedOrigin);
+        }
+        resp.setHeader("Cache-Control", "must-revalidate,no-cache,no-store");
+        resp.setStatus(HttpServletResponse.SC_OK);
+
+        final OutputStream output = resp.getOutputStream();
+        try {
+            if (jsonpParamName != null && req.getParameter(jsonpParamName) != null) {
+                getWriter(req).writeValue(output, new JSONPObject(req.getParameter(jsonpParamName), registry));
+            } else {
+                getWriter(req).writeValue(output, registry);
+            }
+        } finally {
+            output.close();
+        }
+    }
+
+    private ObjectWriter getWriter(HttpServletRequest request) {
+        final boolean prettyPrint = Boolean.parseBoolean(request.getParameter("pretty"));
+        if (prettyPrint) {
+            return mapper.writerWithDefaultPrettyPrinter();
+        }
+        return mapper.writer();
+    }
+
+    private TimeUnit parseTimeUnit(String value, TimeUnit defaultValue) {
+        try {
+            return TimeUnit.valueOf(String.valueOf(value).toUpperCase(Locale.US));
+        } catch (IllegalArgumentException e) {
+            return defaultValue;
+        }
+    }
+}

--- a/core-common/src/main/java/org/zalando/nakadi/metrics/NakadiMetricsServlet.java
+++ b/core-common/src/main/java/org/zalando/nakadi/metrics/NakadiMetricsServlet.java
@@ -25,7 +25,7 @@ public class NakadiMetricsServlet extends HttpServlet {
      * {@link MetricRegistry}, rate and duration units, and allowed origin for
      * {@link com.codahale.metrics.servlets.MetricsServlet}.
      */
-    public static abstract class ContextListener implements ServletContextListener {
+    public abstract static class ContextListener implements ServletContextListener {
         /**
          * @return the {@link MetricRegistry} to inject into the servlet context.
          */
@@ -74,18 +74,21 @@ public class NakadiMetricsServlet extends HttpServlet {
         }
 
         @Override
-        public void contextInitialized(ServletContextEvent event) {
+        public void contextInitialized(final ServletContextEvent event) {
             final ServletContext context = event.getServletContext();
             context.setAttribute(METRICS_REGISTRY, getMetricRegistry());
             context.setAttribute(METRIC_FILTER, getMetricFilter());
             if (getDurationUnit() != null) {
-                context.setInitParameter(com.codahale.metrics.servlets.MetricsServlet.DURATION_UNIT, getDurationUnit().toString());
+                context.setInitParameter(com.codahale.metrics.servlets.MetricsServlet.DURATION_UNIT,
+                        getDurationUnit().toString());
             }
             if (getRateUnit() != null) {
-                context.setInitParameter(com.codahale.metrics.servlets.MetricsServlet.RATE_UNIT, getRateUnit().toString());
+                context.setInitParameter(com.codahale.metrics.servlets.MetricsServlet.RATE_UNIT,
+                        getRateUnit().toString());
             }
             if (getAllowedOrigin() != null) {
-                context.setInitParameter(com.codahale.metrics.servlets.MetricsServlet.ALLOWED_ORIGIN, getAllowedOrigin());
+                context.setInitParameter(com.codahale.metrics.servlets.MetricsServlet.ALLOWED_ORIGIN,
+                        getAllowedOrigin());
             }
             if (getJsonpCallbackParameter() != null) {
                 context.setAttribute(CALLBACK_PARAM, getJsonpCallbackParameter());
@@ -93,20 +96,27 @@ public class NakadiMetricsServlet extends HttpServlet {
         }
 
         @Override
-        public void contextDestroyed(ServletContextEvent event) {
+        public void contextDestroyed(final ServletContextEvent event) {
             // no-op
         }
     }
 
-    public static final String RATE_UNIT = com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".rateUnit";
-    public static final String DURATION_UNIT = com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".durationUnit";
-    public static final String SHOW_SAMPLES = com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".showSamples";
-    public static final String METRICS_REGISTRY = com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".registry";
-    public static final String ALLOWED_ORIGIN = com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".allowedOrigin";
-    public static final String METRIC_FILTER = com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".metricFilter";
-    public static final String CALLBACK_PARAM = com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".jsonpCallback";
+    public static final String RATE_UNIT =
+            com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".rateUnit";
+    public static final String DURATION_UNIT =
+            com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".durationUnit";
+    public static final String SHOW_SAMPLES =
+            com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".showSamples";
+    public static final String METRICS_REGISTRY =
+            com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".registry";
+    public static final String ALLOWED_ORIGIN =
+            com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".allowedOrigin";
+    public static final String METRIC_FILTER =
+            com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".metricFilter";
+    public static final String CALLBACK_PARAM =
+            com.codahale.metrics.servlets.MetricsServlet.class.getCanonicalName() + ".jsonpCallback";
 
-    private static final long serialVersionUID = 1049773947734939602L;
+    private static final long serialVersionUID = 1049773947734559602L;
     private static final String CONTENT_TYPE = "application/json";
 
     private String allowedOrigin;
@@ -114,15 +124,12 @@ public class NakadiMetricsServlet extends HttpServlet {
     private transient MetricRegistry registry;
     private transient ObjectMapper mapper;
 
-    public NakadiMetricsServlet() {
-    }
-
-    public NakadiMetricsServlet(MetricRegistry registry) {
+    public NakadiMetricsServlet(final MetricRegistry registry) {
         this.registry = registry;
     }
 
     @Override
-    public void init(ServletConfig config) throws ServletException {
+    public void init(final ServletConfig config) throws ServletException {
         super.init(config);
 
         final ServletContext context = config.getServletContext();
@@ -154,8 +161,8 @@ public class NakadiMetricsServlet extends HttpServlet {
     }
 
     @Override
-    protected void doGet(HttpServletRequest req,
-                         HttpServletResponse resp) throws ServletException, IOException {
+    protected void doGet(final HttpServletRequest req,
+                         final HttpServletResponse resp) throws IOException {
         resp.setContentType(CONTENT_TYPE);
         if (allowedOrigin != null) {
             resp.setHeader("Access-Control-Allow-Origin", allowedOrigin);
@@ -175,7 +182,7 @@ public class NakadiMetricsServlet extends HttpServlet {
         }
     }
 
-    private ObjectWriter getWriter(HttpServletRequest request) {
+    private ObjectWriter getWriter(final HttpServletRequest request) {
         final boolean prettyPrint = Boolean.parseBoolean(request.getParameter("pretty"));
         if (prettyPrint) {
             return mapper.writerWithDefaultPrettyPrinter();
@@ -183,7 +190,7 @@ public class NakadiMetricsServlet extends HttpServlet {
         return mapper.writer();
     }
 
-    private TimeUnit parseTimeUnit(String value, TimeUnit defaultValue) {
+    private TimeUnit parseTimeUnit(final String value, final TimeUnit defaultValue) {
         try {
             return TimeUnit.valueOf(String.valueOf(value).toUpperCase(Locale.US));
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
# One-line summary
Reduce size of the metrics response short term

Example of the metric
```
    "nakadi.eventtypes.xxx.publishing.averageEventSizeInBytes": {
      "count": 24,
      "max": 186,
      "mean": 185.99941606885423,
      "min": 174,
      "p50": 186,
      "p75": 186,
      "p95": 186,
      "p98": 186,
      "p99": 186,
      "p999": 186,
      "stddev": 0.08370682632688281
}
```

what is actually used
```
m1_rate
count
mean
```