### PR TITLE
Update Kafka Clients to 2.4.0

### DIFF
--- a/acceptance-test/build.gradle
+++ b/acceptance-test/build.gradle
@@ -35,7 +35,7 @@ configurations {
 dependencies {
     ext {
         dropwizardVersion = '3.1.3'
-        jacksonVersion = '2.8.8'
+        jacksonVersion = '2.9.8'
         springFrameworkVersion = '4.3.23.RELEASE'
     }
     // Override spring-boot BOM versions
@@ -81,6 +81,7 @@ dependencies {
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-joda:$jacksonVersion"
     compile "com.fasterxml.jackson.module:jackson-module-afterburner:$jacksonVersion"
+    compile "com.fasterxml.jackson.module:jackson-module-scala_2.12:$jacksonVersion"
     compile 'org.zalando:jackson-datatype-problem:0.22.0'
     compile 'org.zalando:problem:0.22.0'
     compile 'org.json:json:20180130'

--- a/acceptance-test/build.gradle
+++ b/acceptance-test/build.gradle
@@ -35,7 +35,7 @@ configurations {
 dependencies {
     ext {
         dropwizardVersion = '3.1.3'
-        jacksonVersion = '2.9.8'
+        jacksonVersion = '2.8.8'
         springFrameworkVersion = '4.3.23.RELEASE'
     }
     // Override spring-boot BOM versions

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -46,6 +46,7 @@ public class KafkaRepositoryAT extends BaseAT {
     private static final int DEFAULT_COMMIT_TIMEOUT = 60;
     private static final int ZK_SESSION_TIMEOUT = 30000;
     private static final int ZK_CONNECTION_TIMEOUT = 10000;
+    private static final int ZK_MAX_IN_FLIGHT_REQUESTS = 1000;
     private static final int NAKADI_SEND_TIMEOUT = 10000;
     private static final int NAKADI_POLL_TIMEOUT = 10000;
     private static final Long DEFAULT_RETENTION_TIME = 100L;
@@ -101,7 +102,7 @@ public class KafkaRepositoryAT extends BaseAT {
         kafkaSettings = new KafkaSettings(KAFKA_REQUEST_TIMEOUT, KAFKA_BATCH_SIZE, KAFKA_BUFFER_MEMORY,
                 KAFKA_LINGER_MS, KAFKA_ENABLE_AUTO_COMMIT, KAFKA_MAX_REQUEST_SIZE,
                 KAFKA_DELIVERY_TIMEOUT, KAFKA_MAX_BLOCK_TIMEOUT);
-        zookeeperSettings = new ZookeeperSettings(ZK_SESSION_TIMEOUT, ZK_CONNECTION_TIMEOUT);
+        zookeeperSettings = new ZookeeperSettings(ZK_SESSION_TIMEOUT, ZK_CONNECTION_TIMEOUT, ZK_MAX_IN_FLIGHT_REQUESTS);
         kafkaHelper = new KafkaTestHelper(KAFKA_URL);
         defaultTopicConfig = new NakadiTopicConfig(DEFAULT_PARTITION_COUNT, DEFAULT_CLEANUP_POLICY,
                 Optional.of(DEFAULT_RETENTION_TIME));

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaTestHelper.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaTestHelper.java
@@ -100,22 +100,15 @@ public class KafkaTestHelper {
     }
 
     public void createTopic(final String topic, final String zkUrl) {
-        KafkaZkClient zkClient = null;
-        try {
-            zkClient = getZkClient(zkUrl);
+        try (KafkaZkClient zkClient = createZkClient(zkUrl)) {
             final AdminZkClient adminZkClient = new AdminZkClient(zkClient);
             adminZkClient.createTopic(topic, 1, 1,
                     new Properties(), RackAwareMode.Safe$.MODULE$);
-        } finally {
-            if (zkClient != null) {
-                zkClient.close();
-            }
         }
     }
 
-    private static KafkaZkClient getZkClient(final String zkUrl) {
-        KafkaZkClient zkClient = null;
-        zkClient = new KafkaZkClient(
+    private static KafkaZkClient createZkClient(final String zkUrl) {
+        return new KafkaZkClient(
                 new ZooKeeperClient(
                         zkUrl,
                         30000,
@@ -128,7 +121,6 @@ public class KafkaTestHelper {
                 false,
                 Time.SYSTEM
         );
-        return zkClient;
     }
 
     public static Long getTopicRetentionTime(final String topic, final String zkPath) {
@@ -140,16 +132,10 @@ public class KafkaTestHelper {
     }
 
     public static String getTopicProperty(final String topic, final String zkPath, final String propertyName) {
-        KafkaZkClient zkClient = null;
-        try {
-            zkClient = getZkClient(zkPath);
+        try (KafkaZkClient zkClient = createZkClient(zkPath)) {
             final AdminZkClient adminZkClient = new AdminZkClient(zkClient);
             final Properties topicConfig = adminZkClient.fetchEntityConfig(ConfigType.Topic(), topic);
             return topicConfig.getProperty(propertyName);
-        } finally {
-            if (zkClient != null) {
-                zkClient.close();
-            }
         }
     }
 }

--- a/api-consumption/build.gradle
+++ b/api-consumption/build.gradle
@@ -79,8 +79,8 @@ dependencies {
     compile 'io.opentracing:opentracing-api:0.31.0'
     compile 'io.opentracing:opentracing-util:0.31.0'
 
-    compile 'org.apache.kafka:kafka-clients:2.1.0'
-    compile('org.apache.kafka:kafka_2.12:2.1.0') {
+    compile 'org.apache.kafka:kafka-clients:2.4.0'
+    compile('org.apache.kafka:kafka_2.12:2.4.0') {
         exclude module: "zookeeper"
     }
 

--- a/api-consumption/build.gradle
+++ b/api-consumption/build.gradle
@@ -69,6 +69,7 @@ dependencies {
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-joda:$jacksonVersion"
     compile "com.fasterxml.jackson.module:jackson-module-afterburner:$jacksonVersion"
+    compile "com.fasterxml.jackson.module:jackson-module-scala_2.12:$jacksonVersion"
     compile 'org.zalando:jackson-datatype-problem:0.22.0'
     compile 'org.zalando:problem:0.22.0'
     compile 'org.json:json:20180130'

--- a/api-consumption/build.gradle
+++ b/api-consumption/build.gradle
@@ -80,8 +80,8 @@ dependencies {
     compile 'io.opentracing:opentracing-api:0.31.0'
     compile 'io.opentracing:opentracing-util:0.31.0'
 
-    compile 'org.apache.kafka:kafka-clients:2.4.0'
-    compile('org.apache.kafka:kafka_2.12:2.4.0') {
+    compile "org.apache.kafka:kafka-clients:$kafkaClientVersion"
+    compile("org.apache.kafka:kafka_2.12:$kafkaClientVersion") {
         exclude module: "zookeeper"
     }
 

--- a/api-cursors/build.gradle
+++ b/api-cursors/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-joda:$jacksonVersion"
     compile "com.fasterxml.jackson.module:jackson-module-afterburner:$jacksonVersion"
+    compile "com.fasterxml.jackson.module:jackson-module-scala_2.12:$jacksonVersion"
     compile 'org.zalando:jackson-datatype-problem:0.22.0'
     compile 'org.zalando:problem:0.22.0'
     compile 'org.json:json:20180130'

--- a/api-misc/build.gradle
+++ b/api-misc/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-joda:$jacksonVersion"
     compile "com.fasterxml.jackson.module:jackson-module-afterburner:$jacksonVersion"
+    compile "com.fasterxml.jackson.module:jackson-module-scala_2.12:$jacksonVersion"
     compile 'org.zalando:jackson-datatype-problem:0.22.0'
     compile 'org.zalando:problem:0.22.0'
     compile 'org.json:json:20180130'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -102,8 +102,8 @@ dependencies {
     compile 'org.echocat.jomon:runtime:1.6.3'
 
     // kafka & zookeeper
-    compile 'org.apache.kafka:kafka-clients:2.1.0'
-    compile('org.apache.kafka:kafka_2.12:2.1.0') {
+    compile 'org.apache.kafka:kafka-clients:2.4.0'
+    compile('org.apache.kafka:kafka_2.12:2.4.0') {
         exclude module: "zookeeper"
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,6 +121,7 @@ dependencies {
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-joda:$jacksonVersion"
     compile "com.fasterxml.jackson.module:jackson-module-afterburner:$jacksonVersion"
+    compile "com.fasterxml.jackson.module:jackson-module-scala_2.12:$jacksonVersion"
     compile 'org.zalando:twintip-spring-web:1.1.0'
     compile 'org.json:json:20180130'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,12 +101,6 @@ dependencies {
     compile 'org.zalando:nakadi-plugin-api:3.2.1'
     compile 'org.echocat.jomon:runtime:1.6.3'
 
-    // kafka & zookeeper
-    compile 'org.apache.kafka:kafka-clients:2.4.0'
-    compile('org.apache.kafka:kafka_2.12:2.4.0') {
-        exclude module: "zookeeper"
-    }
-
     // json
     compile('com.github.everit-org.json-schema:org.everit.json.schema:1.8.0') {
         exclude module: "json"

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -80,6 +80,8 @@ nakadi:
     connectionString: zookeeper://zookeeper:2181
     sessionTimeoutMs: 10000
     connectionTimeoutMs: 3000
+    maxInFlightRequests: 1000
+
   oauth2:
     mode: BASIC
     adminClientId: adminClientId

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ subprojects {
         ext {
             curatorVersion = '4.2.0'
             zookeeperVersion = '3.5.6'
+            kafkaClientVersion = '2.4.0'
         }
     }
 }

--- a/core-common/build.gradle
+++ b/core-common/build.gradle
@@ -75,8 +75,8 @@ dependencies {
     compile 'io.opentracing:opentracing-api:0.31.0'
     compile 'io.opentracing:opentracing-util:0.31.0'
 
-    compile 'org.apache.kafka:kafka-clients:2.1.0'
-    compile('org.apache.kafka:kafka_2.12:2.1.0') {
+    compile 'org.apache.kafka:kafka-clients:2.4.0'
+    compile('org.apache.kafka:kafka_2.12:2.4.0') {
         exclude module: "zookeeper"
     }
     compile("org.apache.curator:curator-recipes:$curatorVersion") {

--- a/core-common/build.gradle
+++ b/core-common/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-joda:$jacksonVersion"
     compile "com.fasterxml.jackson.module:jackson-module-afterburner:$jacksonVersion"
+    compile "com.fasterxml.jackson.module:jackson-module-scala_2.12:$jacksonVersion"
     compile 'org.zalando:jackson-datatype-problem:0.22.0'
     compile 'org.zalando:problem:0.22.0'
     compile 'org.json:json:20180130'

--- a/core-common/build.gradle
+++ b/core-common/build.gradle
@@ -76,10 +76,11 @@ dependencies {
     compile 'io.opentracing:opentracing-api:0.31.0'
     compile 'io.opentracing:opentracing-util:0.31.0'
 
-    compile 'org.apache.kafka:kafka-clients:2.4.0'
-    compile('org.apache.kafka:kafka_2.12:2.4.0') {
+    compile "org.apache.kafka:kafka-clients:$kafkaClientVersion"
+    compile("org.apache.kafka:kafka_2.12:$kafkaClientVersion") {
         exclude module: "zookeeper"
     }
+
     compile("org.apache.curator:curator-recipes:$curatorVersion") {
         exclude module: "zookeeper"
     }

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -3,9 +3,10 @@ package org.zalando.nakadi.repository.kafka;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import kafka.admin.AdminUtils;
 import kafka.server.ConfigType;
-import kafka.utils.ZkUtils;
+import kafka.zk.AdminZkClient;
+import kafka.zk.KafkaZkClient;
+import kafka.zookeeper.ZooKeeperClient;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewPartitions;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -19,6 +20,7 @@ import org.apache.kafka.common.errors.NotLeaderForPartitionException;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.utils.Time;
 import org.echocat.jomon.runtime.concurrent.RetryForSpecifiedCountStrategy;
 import org.echocat.jomon.runtime.concurrent.RetryForSpecifiedTimeStrategy;
 import org.echocat.jomon.runtime.concurrent.Retryer;
@@ -208,15 +210,15 @@ public class KafkaTopicRepository implements TopicRepository {
     public String createTopic(final NakadiTopicConfig nakadiTopicConfig) throws TopicCreationException {
 
         final KafkaTopicConfig kafkaTopicConfig = kafkaTopicConfigFactory.createKafkaTopicConfig(nakadiTopicConfig);
-        try {
-            doWithZkUtils(zkUtils -> {
-                AdminUtils.createTopic(zkUtils,
-                        kafkaTopicConfig.getTopicName(),
-                        kafkaTopicConfig.getPartitionCount(),
-                        kafkaTopicConfig.getReplicaFactor(),
-                        kafkaTopicConfigFactory.createKafkaTopicLevelProperties(kafkaTopicConfig),
-                        kafkaTopicConfig.getRackAwareMode());
-            });
+        try (KafkaZkClient client = getZkClient()) {
+            final AdminZkClient adminZkClient = new AdminZkClient(client);
+            adminZkClient.createTopic(
+                    kafkaTopicConfig.getTopicName(),
+                    kafkaTopicConfig.getPartitionCount(),
+                    kafkaTopicConfig.getReplicaFactor(),
+                    kafkaTopicConfigFactory.createKafkaTopicLevelProperties(kafkaTopicConfig),
+                    kafkaTopicConfig.getRackAwareMode()
+            );
         } catch (final TopicExistsException e) {
             throw new TopicCreationException("Topic with name " + kafkaTopicConfig.getTopicName() +
                     " already exists (or wasn't completely removed yet)", e);
@@ -244,9 +246,10 @@ public class KafkaTopicRepository implements TopicRepository {
 
     @Override
     public void deleteTopic(final String topic) throws TopicDeletionException {
-        try {
+        try (KafkaZkClient zkClient = getZkClient()) {
             // this will only trigger topic deletion, but the actual deletion is asynchronous
-            doWithZkUtils(zkUtils -> AdminUtils.deleteTopic(zkUtils, topic));
+            final AdminZkClient adminZkClient = new AdminZkClient(zkClient);
+            adminZkClient.deleteTopic(topic);
         } catch (final Exception e) {
             throw new TopicDeletionException("Unable to delete topic " + topic, e);
         }
@@ -616,12 +619,11 @@ public class KafkaTopicRepository implements TopicRepository {
 
     @Override
     public void setRetentionTime(final String topic, final Long retentionMs) throws TopicConfigException {
-        try {
-            doWithZkUtils(zkUtils -> {
-                final Properties topicProps = AdminUtils.fetchEntityConfig(zkUtils, ConfigType.Topic(), topic);
-                topicProps.setProperty("retention.ms", Long.toString(retentionMs));
-                AdminUtils.changeTopicConfig(zkUtils, topic, topicProps);
-            });
+        try (KafkaZkClient zkClient = getZkClient()) {
+            final AdminZkClient adminZkClient = new AdminZkClient(zkClient);
+            final Properties topicProps = adminZkClient.fetchEntityConfig(ConfigType.Topic(), topic);
+            topicProps.setProperty("retention.ms", Long.toString(retentionMs));
+            adminZkClient.changeTopicConfig(topic, topicProps);
         } catch (final Exception e) {
             throw new TopicConfigException("Unable to update retention time for topic " + topic, e);
         }
@@ -636,24 +638,20 @@ public class KafkaTopicRepository implements TopicRepository {
         }
     }
 
-    private void doWithZkUtils(final ZkUtilsAction action) throws Exception {
-        ZkUtils zkUtils = null;
-        try {
-            zkUtils = ZkUtils.apply(
-                    kafkaZookeeper.getZookeeperConnectionString(),
-                    zookeeperSettings.getZkSessionTimeoutMs(),
-                    zookeeperSettings.getZkConnectionTimeoutMs(),
-                    false);
-            action.execute(zkUtils);
-        } finally {
-            if (zkUtils != null) {
-                zkUtils.close();
-            }
-        }
-    }
-
-    @FunctionalInterface
-    private interface ZkUtilsAction {
-        void execute(ZkUtils zkUtils) throws Exception;
+    private KafkaZkClient getZkClient() {
+        // The calling method should make sure to close connection
+        return new KafkaZkClient(
+                    new ZooKeeperClient(
+                            kafkaZookeeper.getZookeeperConnectionString(),
+                            zookeeperSettings.getZkSessionTimeoutMs(),
+                            zookeeperSettings.getZkConnectionTimeoutMs(),
+                            zookeeperSettings.getMaxInFlightRequests(),
+                            Time.SYSTEM,
+                            ZookeeperSettings.METRIC_GROUP,
+                            ZookeeperSettings.METRIC_TYPE
+                    ),
+                    false,
+                    Time.SYSTEM
+        );
     }
 }

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -210,7 +210,7 @@ public class KafkaTopicRepository implements TopicRepository {
     public String createTopic(final NakadiTopicConfig nakadiTopicConfig) throws TopicCreationException {
 
         final KafkaTopicConfig kafkaTopicConfig = kafkaTopicConfigFactory.createKafkaTopicConfig(nakadiTopicConfig);
-        try (KafkaZkClient client = getZkClient()) {
+        try (KafkaZkClient client = createZkClient()) {
             final AdminZkClient adminZkClient = new AdminZkClient(client);
             adminZkClient.createTopic(
                     kafkaTopicConfig.getTopicName(),
@@ -246,7 +246,7 @@ public class KafkaTopicRepository implements TopicRepository {
 
     @Override
     public void deleteTopic(final String topic) throws TopicDeletionException {
-        try (KafkaZkClient zkClient = getZkClient()) {
+        try (KafkaZkClient zkClient = createZkClient()) {
             // this will only trigger topic deletion, but the actual deletion is asynchronous
             final AdminZkClient adminZkClient = new AdminZkClient(zkClient);
             adminZkClient.deleteTopic(topic);
@@ -619,7 +619,7 @@ public class KafkaTopicRepository implements TopicRepository {
 
     @Override
     public void setRetentionTime(final String topic, final Long retentionMs) throws TopicConfigException {
-        try (KafkaZkClient zkClient = getZkClient()) {
+        try (KafkaZkClient zkClient = createZkClient()) {
             final AdminZkClient adminZkClient = new AdminZkClient(zkClient);
             final Properties topicProps = adminZkClient.fetchEntityConfig(ConfigType.Topic(), topic);
             topicProps.setProperty("retention.ms", Long.toString(retentionMs));
@@ -638,7 +638,7 @@ public class KafkaTopicRepository implements TopicRepository {
         }
     }
 
-    private KafkaZkClient getZkClient() {
+    private KafkaZkClient createZkClient() {
         // The calling method should make sure to close connection
         return new KafkaZkClient(
                     new ZooKeeperClient(

--- a/core-common/src/main/java/org/zalando/nakadi/repository/zookeeper/ZookeeperSettings.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/zookeeper/ZookeeperSettings.java
@@ -9,12 +9,18 @@ public class ZookeeperSettings {
 
     private final int zkSessionTimeoutMs;
     private final int zkConnectionTimeoutMs;
+    private final int maxInFlightRequests;
+    public static final String METRIC_GROUP = "kafka.server";
+    public static final String METRIC_TYPE = "kakfaZookeeper";
+
 
     @Autowired
     public ZookeeperSettings(@Value("${nakadi.zookeeper.sessionTimeoutMs}") final int zkSessionTimeoutMs,
-                             @Value("${nakadi.zookeeper.connectionTimeoutMs}")final int zkConnectionTimeoutMs) {
+                             @Value("${nakadi.zookeeper.connectionTimeoutMs}")final int zkConnectionTimeoutMs,
+                             @Value("${nakadi.zookeeper.maxInFlightRequests}") final int maxInFlightRequests) {
         this.zkSessionTimeoutMs = zkSessionTimeoutMs;
         this.zkConnectionTimeoutMs = zkConnectionTimeoutMs;
+        this.maxInFlightRequests = maxInFlightRequests;
     }
 
     public int getZkSessionTimeoutMs() {
@@ -23,5 +29,9 @@ public class ZookeeperSettings {
 
     public int getZkConnectionTimeoutMs() {
         return zkConnectionTimeoutMs;
+    }
+
+    public int getMaxInFlightRequests() {
+        return maxInFlightRequests;
     }
 }

--- a/core-metastore/build.gradle
+++ b/core-metastore/build.gradle
@@ -77,8 +77,8 @@ dependencies {
     compile 'io.opentracing:opentracing-api:0.31.0'
     compile 'io.opentracing:opentracing-util:0.31.0'
 
-    compile 'org.apache.kafka:kafka-clients:2.1.0'
-    compile('org.apache.kafka:kafka_2.12:2.1.0') {
+    compile 'org.apache.kafka:kafka-clients:2.4.0'
+    compile('org.apache.kafka:kafka_2.12:2.4.0') {
         exclude module: "zookeeper"
     }
 

--- a/core-metastore/build.gradle
+++ b/core-metastore/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-joda:$jacksonVersion"
     compile "com.fasterxml.jackson.module:jackson-module-afterburner:$jacksonVersion"
+    compile "com.fasterxml.jackson.module:jackson-module-scala_2.12:$jacksonVersion"
     compile 'org.zalando:jackson-datatype-problem:0.22.0'
     compile 'org.zalando:problem:0.22.0'
     compile 'org.json:json:20180130'

--- a/core-metastore/build.gradle
+++ b/core-metastore/build.gradle
@@ -78,8 +78,8 @@ dependencies {
     compile 'io.opentracing:opentracing-api:0.31.0'
     compile 'io.opentracing:opentracing-util:0.31.0'
 
-    compile 'org.apache.kafka:kafka-clients:2.4.0'
-    compile('org.apache.kafka:kafka_2.12:2.4.0') {
+    compile "org.apache.kafka:kafka-clients:$kafkaClientVersion"
+    compile("org.apache.kafka:kafka_2.12:$kafkaClientVersion") {
         exclude module: "zookeeper"
     }
 

--- a/core-services/build.gradle
+++ b/core-services/build.gradle
@@ -78,8 +78,8 @@ dependencies {
     compile 'io.opentracing:opentracing-api:0.31.0'
     compile 'io.opentracing:opentracing-util:0.31.0'
 
-    compile 'org.apache.kafka:kafka-clients:2.1.0'
-    compile('org.apache.kafka:kafka_2.12:2.1.0') {
+    compile 'org.apache.kafka:kafka-clients:2.4.0'
+    compile('org.apache.kafka:kafka_2.12:2.4.0') {
         exclude module: "zookeeper"
     }
 

--- a/core-services/build.gradle
+++ b/core-services/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-joda:$jacksonVersion"
     compile "com.fasterxml.jackson.module:jackson-module-afterburner:$jacksonVersion"
+    compile "com.fasterxml.jackson.module:jackson-module-scala_2.12:$jacksonVersion"
     compile 'org.zalando:jackson-datatype-problem:0.22.0'
     compile 'org.zalando:problem:0.22.0'
     compile 'org.json:json:20180130'

--- a/core-services/build.gradle
+++ b/core-services/build.gradle
@@ -79,8 +79,8 @@ dependencies {
     compile 'io.opentracing:opentracing-api:0.31.0'
     compile 'io.opentracing:opentracing-util:0.31.0'
 
-    compile 'org.apache.kafka:kafka-clients:2.4.0'
-    compile('org.apache.kafka:kafka_2.12:2.4.0') {
+    compile "org.apache.kafka:kafka-clients:$kafkaClientVersion"
+    compile("org.apache.kafka:kafka_2.12:$kafkaClientVersion") {
         exclude module: "zookeeper"
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:2.11-1.1.1
+    image: wurstmeister/kafka:2.12-2.4.0
     ports:
       - "29092:29092"
       - "9092:9092"


### PR DESCRIPTION
Kafka Client removed `zkUtils` and `adminUtils` from client libraries. Implemented their functions from `KafkaZkClient` and `AdminZkClient`.

For creating a `ZookeeperClient` instance, the following new parameters: https://jaceklaskowski.gitbooks.io/apache-kafka/kafka-ZooKeeperClient.html

I kept the max-in-flight requests parameter to `1000`(not too high), for we'd be using this zookeeper connection/client for only creation/update and deletion of topics.

We used the `zkUtils` and `adminUtils` libraries only for creating topics/updating retention time and deleting topics