### PR TITLE
Allow to modify partition_key_fields

### DIFF
--- a/api-metastore/src/main/java/org/zalando/nakadi/validation/schema/PartitionKeyFieldsConstraint.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/validation/schema/PartitionKeyFieldsConstraint.java
@@ -9,10 +9,7 @@ import java.util.Optional;
 public class  PartitionKeyFieldsConstraint implements SchemaEvolutionConstraint {
     @Override
     public Optional<SchemaEvolutionIncompatibility> validate(final EventType original, final EventTypeBase eventType) {
-        if (!original.getPartitionKeyFields().isEmpty()
-                && !eventType.getPartitionKeyFields().equals(original.getPartitionKeyFields())) {
-            return Optional.of(new SchemaEvolutionIncompatibility("changing partition_key_fields is not allowed"));
-        } else if (eventType.getPartitionStrategy().equals(PartitionStrategy.HASH_STRATEGY)
+        if (eventType.getPartitionStrategy().equals(PartitionStrategy.HASH_STRATEGY)
                 && eventType.getPartitionKeyFields().isEmpty()) {
             return Optional.of(new SchemaEvolutionIncompatibility("partition_key_fields is required " +
                     "when partition strategy is 'hash'"));


### PR DESCRIPTION
https://jira.zalando.net/browse/ARUHA-2648

For a long time changing partition_key_fields was an operation
performed only by admins via a database hack. This used to be case in
order to protect consumers from unexpected changes on how events are
hashed, which could lead to a number of issues on the consumer side.

But as the number of such requests grew, we decided to let the users
decided whether this field should or not be changed. We give them the
responsibility over this operation.
