### PR TITLE
ARUHA-2746 reconfigure content negotiation

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/EventTypeAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/EventTypeAT.java
@@ -359,7 +359,7 @@ public class EventTypeAT extends BaseAT {
     }
 
     @Test
-    public void whenGetEventTypeWithRegisteredExceptionThenOk() throws Exception {
+    public void whenGetEventTypeWithRegisteredExtensionThenOk() throws Exception {
         final EventType et = NakadiTestUtils.buildSimpleEventType();
         et.setName(et.getName() + ".ps");
         NakadiTestUtils.createEventTypeInNakadi(et);

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/EventTypeAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/EventTypeAT.java
@@ -359,6 +359,16 @@ public class EventTypeAT extends BaseAT {
     }
 
     @Test
+    public void whenGetEventTypeWithRegisteredExceptionThenOk() throws Exception {
+        final EventType et = NakadiTestUtils.buildSimpleEventType();
+        et.setName(et.getName() + ".ps");
+        NakadiTestUtils.createEventTypeInNakadi(et);
+        given().get(ENDPOINT + "/" + et.getName())
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
     public void whenPOSTEventTypeWithAuthorizationThenOk() throws JsonProcessingException {
         final EventType eventType = buildDefaultEventType();
 

--- a/app/src/main/java/org/zalando/nakadi/config/WebConfig.java
+++ b/app/src/main/java/org/zalando/nakadi/config/WebConfig.java
@@ -103,7 +103,7 @@ public class WebConfig extends WebMvcConfigurationSupport {
     }
 
     @Override
-    protected void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+    protected void configureContentNegotiation(final ContentNegotiationConfigurer configurer) {
         super.configureContentNegotiation(configurer);
         configurer.favorPathExtension(false);
     }

--- a/app/src/main/java/org/zalando/nakadi/config/WebConfig.java
+++ b/app/src/main/java/org/zalando/nakadi/config/WebConfig.java
@@ -16,6 +16,7 @@ import org.springframework.http.converter.xml.SourceHttpMessageConverter;
 import org.springframework.web.context.request.async.TimeoutCallableProcessingInterceptor;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
+import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 import org.zalando.nakadi.filters.TracingFilter;
@@ -56,6 +57,7 @@ public class WebConfig extends WebMvcConfigurationSupport {
     public FilterRegistrationBean flowIdRequestFilter() {
         return createFilterRegistrationBean(new FlowIdRequestFilter(), Ordered.HIGHEST_PRECEDENCE + 1);
     }
+
     @Bean
     public FilterRegistrationBean traceRequestFilter() {
         return createFilterRegistrationBean(new TracingFilter(authorizationService), Ordered.LOWEST_PRECEDENCE - 1);
@@ -98,6 +100,12 @@ public class WebConfig extends WebMvcConfigurationSupport {
         final RequestMappingHandlerMapping handlerMapping = super.requestMappingHandlerMapping();
         handlerMapping.setUseSuffixPatternMatch(false);
         return handlerMapping;
+    }
+
+    @Override
+    protected void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+        super.configureContentNegotiation(configurer);
+        configurer.favorPathExtension(false);
     }
 
     private FilterRegistrationBean createFilterRegistrationBean(final Filter filter, final int order) {


### PR DESCRIPTION
Sometimes users tend to create event types with names that have extensions like ones defined here: 
https://github.com/spring-projects/spring-framework/blob/master/spring-context-support/src/main/resources/org/springframework/mail/javamail/mime.types

This leads to 406 status code while getting event type. This fix is removing content type negotiation in this case. 