### PR TITLE
ARUHA-2755 Fix problem with the fact that BEGIN is not lexicographicaly comparable

### DIFF
--- a/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/AbstractZkSubscriptionClient.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/AbstractZkSubscriptionClient.java
@@ -22,6 +22,7 @@ import org.zalando.nakadi.exceptions.runtime.UnableProcessException;
 import org.zalando.nakadi.exceptions.runtime.ZookeeperException;
 import org.zalando.nakadi.repository.zookeeper.ZooKeeperHolder;
 import org.zalando.nakadi.service.subscription.model.Session;
+import org.zalando.nakadi.view.Cursor;
 import org.zalando.nakadi.view.SubscriptionCursorWithoutToken;
 
 import java.io.Closeable;
@@ -430,8 +431,8 @@ public abstract class AbstractZkSubscriptionClient implements ZkSubscriptionClie
                             final List<Boolean> commits = Lists.newArrayList();
 
                             for (final SubscriptionCursorWithoutToken cursor : entry.getValue()) {
-                                // Offsets are lexicographically comparable
-                                if (cursor.getOffset().compareTo(newMaxOffset) > 0) {
+                                // Offsets are lexicographically comparable, except 'BEGIN'
+                                if (cursor.getOffset().compareTo(newMaxOffset) > 0 || newMaxOffset.equalsIgnoreCase(Cursor.BEFORE_OLDEST_OFFSET)) {
                                     newMaxOffset = cursor.getOffset();
                                     commits.add(true);
                                 } else {

--- a/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/AbstractZkSubscriptionClient.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/AbstractZkSubscriptionClient.java
@@ -432,7 +432,8 @@ public abstract class AbstractZkSubscriptionClient implements ZkSubscriptionClie
 
                             for (final SubscriptionCursorWithoutToken cursor : entry.getValue()) {
                                 // Offsets are lexicographically comparable, except 'BEGIN'
-                                if (cursor.getOffset().compareTo(newMaxOffset) > 0 || newMaxOffset.equalsIgnoreCase(Cursor.BEFORE_OLDEST_OFFSET)) {
+                                if (cursor.getOffset().compareTo(newMaxOffset) > 0
+                                        || newMaxOffset.equalsIgnoreCase(Cursor.BEFORE_OLDEST_OFFSET)) {
                                     newMaxOffset = cursor.getOffset();
                                     commits.add(true);
                                 } else {

--- a/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClient.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClient.java
@@ -59,8 +59,8 @@ public interface ZkSubscriptionClient extends Closeable {
     void deleteSubscription();
 
     /**
-     * Fills subscription object using partitions information provided (mapping from (topic, partition) to real offset
-     * (NOT "BEGIN").
+     * Fills subscription object using partitions information provided (mapping from (topic, partition) to offset,
+     * "BEGIN" is allowed.
      *
      * @param cursors Data to use for subscription filling.
      */


### PR DESCRIPTION
The problem was introduced as a part of refactoring eliminating the need of additional dependencies. 1 corner case was forgotten
