### PR TITLE
ARUHA-2714 Refactor Authz usage not to return 400 status code

### DIFF
--- a/app/src/main/java/org/zalando/nakadi/config/AuthenticationConfig.java
+++ b/app/src/main/java/org/zalando/nakadi/config/AuthenticationConfig.java
@@ -1,25 +1,20 @@
 package org.zalando.nakadi.config;
 
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.oauth2.common.OAuth2AccessToken;
-import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
-import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
 import org.springframework.web.client.RestTemplate;
-import org.zalando.nakadi.domain.Feature;
-import org.zalando.nakadi.metrics.MetricUtils;
 import org.zalando.nakadi.service.FeatureToggleService;
 import org.zalando.stups.oauth2.spring.authorization.DefaultUserRolesProvider;
 import org.zalando.stups.oauth2.spring.server.DefaultAuthenticationExtractor;
@@ -31,12 +26,43 @@ import org.zalando.stups.oauth2.spring.server.TokenResponseErrorHandler;
 public class AuthenticationConfig {
 
     @Bean
-    public ResourceServerTokenServices zalandoResourceTokenServices(final SecuritySettings settings,
-                                                                    final MetricRegistry metricRegistry,
-                                                                    final RestTemplate restTemplate,
-                                                                    final FeatureToggleService featureToggleService) {
-        return new MeasureAndDispatchResourceServerTokenServices(
-                metricRegistry, settings, restTemplate, featureToggleService);
+    @Qualifier("remote")
+    public TokenInfoResourceServerTokenServices remoteTokenInfo(
+            final RestTemplate restTemplate,
+            final SecuritySettings securitySettings) {
+        return new TokenInfoResourceServerTokenServices(
+                securitySettings.getTokenInfoUrl(),
+                securitySettings.getClientId(),
+                new DefaultAuthenticationExtractor(),
+                new DefaultUserRolesProvider(),
+                restTemplate
+        );
+    }
+
+    @Bean
+    @Qualifier("local")
+    public TokenInfoResourceServerTokenServices localTokenInfo(
+            final RestTemplate restTemplate,
+            final SecuritySettings securitySettings) {
+        return new TokenInfoResourceServerTokenServices(
+                securitySettings.getLocalTokenInfoUrl(),
+                securitySettings.getClientId(),
+                new DefaultAuthenticationExtractor(),
+                new DefaultUserRolesProvider(),
+                restTemplate
+        );
+    }
+
+
+    @Bean
+    @Primary
+    public ResourceServerTokenServices zalandoResourceTokenServices(
+            @Qualifier("remote") final TokenInfoResourceServerTokenServices remoteTokenInfo,
+            @Qualifier("local") final TokenInfoResourceServerTokenServices localTokenInfo,
+            final MetricRegistry metricRegistry,
+            final FeatureToggleService featureToggleService) {
+        return new NakadiResourceServerTokenServices(
+                metricRegistry, localTokenInfo, remoteTokenInfo, featureToggleService);
     }
 
     @Bean
@@ -80,61 +106,6 @@ public class AuthenticationConfig {
         final RestTemplate restTemplate = new RestTemplate(requestFactory);
         restTemplate.setErrorHandler(TokenResponseErrorHandler.getDefault());
         return restTemplate;
-    }
-
-    public static class MeasureAndDispatchResourceServerTokenServices implements ResourceServerTokenServices {
-
-        private final Timer timer;
-        private final TokenInfoResourceServerTokenServices remoteService;
-        private final TokenInfoResourceServerTokenServices localService;
-        private final FeatureToggleService featureToggleService;
-
-        public MeasureAndDispatchResourceServerTokenServices(final MetricRegistry metricRegistry,
-                                                             final SecuritySettings securitySettings,
-                                                             final RestTemplate restTemplate,
-                                                             final FeatureToggleService featureToggleService) {
-            remoteService = new TokenInfoResourceServerTokenServices(
-                    securitySettings.getTokenInfoUrl(),
-                    securitySettings.getClientId(),
-                    new DefaultAuthenticationExtractor(),
-                    new DefaultUserRolesProvider(),
-                    restTemplate);
-            localService = new TokenInfoResourceServerTokenServices(
-                    securitySettings.getLocalTokenInfoUrl(),
-                    securitySettings.getClientId(),
-                    new DefaultAuthenticationExtractor(),
-                    new DefaultUserRolesProvider(),
-                    restTemplate);
-            timer = metricRegistry.timer(MetricUtils.NAKADI_PREFIX + "general.accessTokenValidation");
-            this.featureToggleService = featureToggleService;
-        }
-
-        @Override
-        public OAuth2Authentication loadAuthentication(final String accessToken) throws AuthenticationException {
-            final Timer.Context context = timer.time();
-            try {
-                if (featureToggleService.isFeatureEnabled(Feature.REMOTE_TOKENINFO)) {
-                    return remoteService.loadAuthentication(accessToken);
-                } else {
-                    return localService.loadAuthentication(accessToken);
-                }
-            } catch (final OAuth2Exception e) {
-                throw e;
-            } catch (final RuntimeException e) {
-                throw new OAuth2Exception(e.getMessage(), e);
-            } finally {
-                context.stop();
-            }
-        }
-
-        @Override
-        public OAuth2AccessToken readAccessToken(final String accessToken) {
-            if (featureToggleService.isFeatureEnabled(Feature.REMOTE_TOKENINFO)) {
-                return remoteService.readAccessToken(accessToken);
-            } else {
-                return localService.readAccessToken(accessToken);
-            }
-        }
     }
 
 }

--- a/app/src/main/java/org/zalando/nakadi/config/NakadiResourceServerTokenServices.java
+++ b/app/src/main/java/org/zalando/nakadi/config/NakadiResourceServerTokenServices.java
@@ -1,0 +1,79 @@
+package org.zalando.nakadi.config;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
+import org.zalando.nakadi.domain.Feature;
+import org.zalando.nakadi.metrics.MetricUtils;
+import org.zalando.nakadi.service.FeatureToggleService;
+import org.zalando.stups.oauth2.spring.server.TokenInfoResourceServerTokenServices;
+
+public class NakadiResourceServerTokenServices implements ResourceServerTokenServices {
+
+    private final Timer timer;
+    private final TokenInfoResourceServerTokenServices remoteService;
+    private final TokenInfoResourceServerTokenServices localService;
+    private final FeatureToggleService featureToggleService;
+    private static final Logger LOG = LoggerFactory.getLogger(NakadiResourceServerTokenServices.class);
+
+    public NakadiResourceServerTokenServices(
+            final MetricRegistry metricRegistry,
+            final TokenInfoResourceServerTokenServices localService,
+            final TokenInfoResourceServerTokenServices remoteService,
+            final FeatureToggleService featureToggleService) {
+        this.remoteService = remoteService;
+        this.localService = localService;
+        this.timer = metricRegistry.timer(MetricUtils.NAKADI_PREFIX + "general.accessTokenValidation");
+        this.featureToggleService = featureToggleService;
+    }
+
+    @Override
+    public OAuth2Authentication loadAuthentication(final String accessToken) throws AuthenticationException {
+        final Timer.Context context = timer.time();
+        try {
+            // Try local, if exception is unexpected - try remote.
+            if (!featureToggleService.isFeatureEnabled(Feature.REMOTE_TOKENINFO)) {
+                try {
+                    return localService.loadAuthentication(accessToken);
+                } catch (final OAuth2Exception ex) {
+                    throw ex;
+                } catch (RuntimeException ex) {
+                    // This event should be pretty rare, so it is fine to log this exception.
+                    LOG.error("Failed to load local tokeninfo information", ex);
+                }
+            }
+            // local din't work, let's try remote.
+            return remoteService.loadAuthentication(accessToken);
+        } catch (final OAuth2Exception e) {
+            throw e;
+        } catch (final RuntimeException e) {
+            LOG.error("Failed to load remote tokeninfo", e); // this is the problem.
+            // The reason why we need to throw OAuth2Exception is the way how security is handled
+            throw new OAuth2Exception(e.getMessage(), e) {
+                @Override
+                public int getHttpErrorCode() {
+                    return HttpStatus.SC_SERVICE_UNAVAILABLE;
+                }
+            };
+        } finally {
+            context.stop();
+        }
+    }
+
+    // This anyway is unsupported, will not change it.
+    @Override
+    public OAuth2AccessToken readAccessToken(final String accessToken) {
+        if (featureToggleService.isFeatureEnabled(Feature.REMOTE_TOKENINFO)) {
+            return remoteService.readAccessToken(accessToken);
+        } else {
+            return localService.readAccessToken(accessToken);
+        }
+    }
+}

--- a/app/src/test/java/org/zalando/nakadi/config/NakadiResourceServerTokenServicesTest.java
+++ b/app/src/test/java/org/zalando/nakadi/config/NakadiResourceServerTokenServicesTest.java
@@ -1,0 +1,134 @@
+package org.zalando.nakadi.config;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.zalando.nakadi.domain.Feature;
+import org.zalando.nakadi.service.FeatureToggleService;
+import org.zalando.stups.oauth2.spring.server.TokenInfoResourceServerTokenServices;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NakadiResourceServerTokenServicesTest {
+    @Mock
+    private MetricRegistry metricRegistry;
+    @Mock
+    private TokenInfoResourceServerTokenServices localService;
+    @Mock
+    private TokenInfoResourceServerTokenServices remoteService;
+    @Mock
+    private FeatureToggleService featureToggleService;
+    private NakadiResourceServerTokenServices objectToTest;
+
+    @Before
+    public void prepare() {
+        final Timer timer = mock(Timer.class);
+        final Timer.Context context = mock(Timer.Context.class);
+        when(timer.time()).thenReturn(context);
+        when(metricRegistry.timer(any())).thenReturn(timer);
+
+        objectToTest = new NakadiResourceServerTokenServices(
+                metricRegistry, localService, remoteService, featureToggleService);
+    }
+
+    @Test
+    public void whenLocalIisDisabledItIsNotUsed() {
+        when(featureToggleService.isFeatureEnabled(eq(Feature.REMOTE_TOKENINFO))).thenReturn(true);
+        when(localService.loadAuthentication(any())).thenReturn(mock(OAuth2Authentication.class));
+        when(remoteService.loadAuthentication(any())).thenReturn(mock(OAuth2Authentication.class));
+
+        objectToTest.loadAuthentication("bbb");
+
+        verify(localService, times(0)).loadAuthentication(any());
+        verify(remoteService, times(1)).loadAuthentication(eq("bbb"));
+    }
+
+    @Test
+    public void whenLocalHasValidResponseRemoteIsNotCalled() {
+        when(featureToggleService.isFeatureEnabled(eq(Feature.REMOTE_TOKENINFO))).thenReturn(false);
+
+        final OAuth2Authentication expectedResponse = mock(OAuth2Authentication.class);
+        when(localService.loadAuthentication(any())).thenReturn(expectedResponse);
+        when(remoteService.loadAuthentication(any())).thenReturn(mock(OAuth2Authentication.class));
+
+        final OAuth2Authentication response = objectToTest.loadAuthentication("bbb");
+
+        assertSame(expectedResponse, response);
+    }
+
+    @Test
+    public void whenLocalHasBadResponseRemoteIsNotCalled() {
+        when(featureToggleService.isFeatureEnabled(eq(Feature.REMOTE_TOKENINFO))).thenReturn(false);
+
+        final OAuth2Exception expectedException = mock(OAuth2Exception.class);
+        when(localService.loadAuthentication(any())).thenThrow(expectedException);
+        when(remoteService.loadAuthentication(any())).thenReturn(mock(OAuth2Authentication.class));
+
+        try {
+            objectToTest.loadAuthentication("bbb");
+            fail();
+        } catch (OAuth2Exception ex) {
+            assertSame(expectedException, ex);
+        }
+    }
+
+    @Test
+    public void whenLocalBrokenRemoteValidUsed() {
+        when(featureToggleService.isFeatureEnabled(eq(Feature.REMOTE_TOKENINFO))).thenReturn(false);
+
+        when(localService.loadAuthentication(any())).thenThrow(mock(RuntimeException.class));
+        final OAuth2Authentication expectedResponse = mock(OAuth2Authentication.class);
+        when(remoteService.loadAuthentication(any())).thenReturn(expectedResponse);
+
+        final OAuth2Authentication response = objectToTest.loadAuthentication("bbb");
+        assertSame(expectedResponse, response);
+    }
+
+    @Test
+    public void whenLocalBrokenRemoteBadUsed() {
+        when(featureToggleService.isFeatureEnabled(eq(Feature.REMOTE_TOKENINFO))).thenReturn(false);
+
+        when(localService.loadAuthentication(any())).thenThrow(mock(RuntimeException.class));
+        final OAuth2Exception expectedException = mock(OAuth2Exception.class);
+        when(remoteService.loadAuthentication(any())).thenThrow(expectedException);
+
+        try{
+            objectToTest.loadAuthentication("bbb");
+            fail();
+        } catch (OAuth2Exception ex) {
+            assertSame(expectedException, ex);
+        }
+    }
+
+    @Test
+    public void whenLocalBrokenRemote500Replaced() {
+        when(featureToggleService.isFeatureEnabled(eq(Feature.REMOTE_TOKENINFO))).thenReturn(false);
+
+        when(localService.loadAuthentication(any())).thenThrow(mock(RuntimeException.class));
+        when(remoteService.loadAuthentication(any())).thenThrow(new RuntimeException("msg"));
+
+        try{
+            objectToTest.loadAuthentication("bbb");
+            fail();
+        } catch (OAuth2Exception ex) {
+            assertEquals("msg", ex.getMessage());
+            assertEquals(HttpStatus.SERVICE_UNAVAILABLE.value(), ex.getHttpErrorCode());
+        }
+    }
+}


### PR DESCRIPTION
ARUHA-2714 
The refactoring is made to be able to use several token info endpoints
one after another in case of error and the behavior was tested
intensively.
