### PR TITLE
Reduce logging by conditionally disabling ACCESS_LOG

### DIFF
--- a/core-common/src/main/java/org/zalando/nakadi/domain/Feature.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/Feature.java
@@ -16,7 +16,8 @@ public enum Feature {
     FORCE_EVENT_TYPE_AUTHZ("force_event_type_authz"),
     FORCE_SUBSCRIPTION_AUTHZ("force_subscription_authz"),
     REPARTITIONING("repartitioning"),
-    EVENT_OWNER_SELECTOR_AUTHZ("event_owner_selector_authz");
+    EVENT_OWNER_SELECTOR_AUTHZ("event_owner_selector_authz"),
+    ACCESS_LOG_ENABLED("access_log_enabled");
 
     private final String id;
 


### PR DESCRIPTION
ACCESS_LOG lines represent 33% of all the logs from Nakadi. This
information is already available via internal event type
`nakadi.access.log` archived in the  datalake and many other important
operations are instrumented via open tracing, making this log line
redundant.

Since there might be a need to switch access logs back, we are adding
a feature toggle to enable access log. This toggle is turned off by
default meaning that new deployments will have access log turned off
by default.

The feature toggle is checked inside the method and not on the caller code because this method is used in multiple places.