### PR TITLE
Log 5xx even when access log is disabled

### DIFF
--- a/app/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
+++ b/app/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
@@ -81,7 +81,10 @@ public class LoggingFilter extends OncePerRequestFilter {
             this.response = response;
             this.flowId = flowId;
             this.requestLogInfo = new RequestLogInfo(request, startTime);
-            logToAccessLog(this.requestLogInfo, HttpStatus.PROCESSING.value(), 0L);
+
+            if (featureToggleService.isFeatureEnabled(Feature.ACCESS_LOG_ENABLED)) {
+                logToAccessLog(this.requestLogInfo, HttpStatus.PROCESSING.value(), 0L);
+            }
         }
 
         private void logOnEvent() {
@@ -153,18 +156,16 @@ public class LoggingFilter extends OncePerRequestFilter {
     }
 
     private void logToAccessLog(final RequestLogInfo requestLogInfo, final int statusCode, final Long timeSpentMs) {
-        if (featureToggleService.isFeatureEnabled(Feature.ACCESS_LOG_ENABLED)) {
-            ACCESS_LOGGER.info("{} \"{}{}\" \"{}\" \"{}\" {} {}ms \"{}\" \"{}\" {}B",
-                    requestLogInfo.method,
-                    requestLogInfo.path,
-                    requestLogInfo.query,
-                    requestLogInfo.userAgent,
-                    requestLogInfo.user,
-                    statusCode,
-                    timeSpentMs,
-                    requestLogInfo.contentEncoding,
-                    requestLogInfo.acceptEncoding,
-                    requestLogInfo.contentLength);
-        }
+        ACCESS_LOGGER.info("{} \"{}{}\" \"{}\" \"{}\" {} {}ms \"{}\" \"{}\" {}B",
+                requestLogInfo.method,
+                requestLogInfo.path,
+                requestLogInfo.query,
+                requestLogInfo.userAgent,
+                requestLogInfo.user,
+                statusCode,
+                timeSpentMs,
+                requestLogInfo.contentEncoding,
+                requestLogInfo.acceptEncoding,
+                requestLogInfo.contentLength);
     }
 }

--- a/app/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
+++ b/app/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
@@ -134,9 +134,10 @@ public class LoggingFilter extends OncePerRequestFilter {
     private void logRequest(final RequestLogInfo requestLogInfo, final int statusCode) {
         final Long timeSpentMs = System.currentTimeMillis() - requestLogInfo.requestTime;
 
-        if (!isSuccessPublishingRequest(requestLogInfo, statusCode)) {
+        if (statusCode >= 500 || featureToggleService.isFeatureEnabled(Feature.ACCESS_LOG_ENABLED)) {
             logToAccessLog(requestLogInfo, statusCode, timeSpentMs);
         }
+
         logToKpiPublisher(requestLogInfo, statusCode, timeSpentMs);
     }
 
@@ -165,16 +166,5 @@ public class LoggingFilter extends OncePerRequestFilter {
                     requestLogInfo.acceptEncoding,
                     requestLogInfo.contentLength);
         }
-    }
-
-
-    private boolean isSuccessPublishingRequest(final RequestLogInfo requestLogInfo, final int statusCode) {
-        return isPublishingRequest(requestLogInfo) && statusCode == 200;
-    }
-
-    private boolean isPublishingRequest(final RequestLogInfo requestLogInfo) {
-        return requestLogInfo.path != null && "POST".equals(requestLogInfo.method) &&
-                requestLogInfo.path.startsWith("/event-types/") &&
-                (requestLogInfo.path.endsWith("/events") || requestLogInfo.path.endsWith("/events/"));
     }
 }

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -172,6 +172,7 @@ nakadi:
     AUDIT_LOG_COLLECTION: true
     REPARTITIONING: true
     EVENT_OWNER_SELECTOR_AUTHZ: false
+    ACCESS_LOG_ENABLED: true
 kpi:
   config:
     stream-data-collection-frequency-ms: 100
@@ -197,3 +198,4 @@ nakadi.features.defaultFeatures:
   FORCE_SUBSCRIPTION_AUTHZ: false
   REPARTITIONING: true
   EVENT_OWNER_SELECTOR_AUTHZ: false
+  ACCESS_LOG_ENABLED: true


### PR DESCRIPTION
Not logging 5xx would make it difficult to catch bugs as the stack
trace would be lost.

This change also makes successful publishing request to be logged, so turning access log on should be done with care and only when needed, otherwise the log volume could be even bigger.

Do you think I should add another condition on top of these so that successful publishing requests are never logged?