### PR TITLE
Log 207's and small refactoring

### DIFF
--- a/app/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
+++ b/app/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
@@ -137,13 +137,17 @@ public class LoggingFilter extends OncePerRequestFilter {
     private void logRequest(final RequestLogInfo requestLogInfo, final int statusCode) {
         final Long timeSpentMs = System.currentTimeMillis() - requestLogInfo.requestTime;
 
-        final boolean isAccessLogEnabled = featureToggleService.isFeatureEnabled(Feature.ACCESS_LOG_ENABLED);
+        boolean isServerSideError = statusCode >= 500 || statusCode == 207;
 
-        if (statusCode >= 500 || (isAccessLogEnabled && !isSuccessPublishingRequest(requestLogInfo, statusCode))) {
+        if (isServerSideError || (isAccessLogEnabled() && !isPublishingRequest(requestLogInfo))) {
             logToAccessLog(requestLogInfo, statusCode, timeSpentMs);
         }
 
         logToKpiPublisher(requestLogInfo, statusCode, timeSpentMs);
+    }
+
+    private boolean isAccessLogEnabled() {
+        return featureToggleService.isFeatureEnabled(Feature.ACCESS_LOG_ENABLED);
     }
 
     private void logToKpiPublisher(final RequestLogInfo requestLogInfo, final int statusCode, final Long timeSpentMs) {
@@ -169,10 +173,6 @@ public class LoggingFilter extends OncePerRequestFilter {
                 requestLogInfo.contentEncoding,
                 requestLogInfo.acceptEncoding,
                 requestLogInfo.contentLength);
-    }
-
-    private boolean isSuccessPublishingRequest(final RequestLogInfo requestLogInfo, final int statusCode) {
-        return isPublishingRequest(requestLogInfo) && statusCode == 200;
     }
 
     private boolean isPublishingRequest(final RequestLogInfo requestLogInfo) {

--- a/app/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
+++ b/app/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
@@ -137,7 +137,7 @@ public class LoggingFilter extends OncePerRequestFilter {
     private void logRequest(final RequestLogInfo requestLogInfo, final int statusCode) {
         final Long timeSpentMs = System.currentTimeMillis() - requestLogInfo.requestTime;
 
-        boolean isServerSideError = statusCode >= 500 || statusCode == 207;
+        final boolean isServerSideError = statusCode >= 500 || statusCode == 207;
 
         if (isServerSideError || (isAccessLogEnabled() && !isPublishingRequest(requestLogInfo))) {
             logToAccessLog(requestLogInfo, statusCode, timeSpentMs);


### PR DESCRIPTION
This commit logs 207's which is considered a server side error and
one of the biggest mistakes in the API design, from my point of
view, given how many clients interpreted it as success in the last 4
years of operating Nakadi. It's such a mistake that even ourselves overlooked
it yesterday when we planned to only log server side errors.

The only type of publishing request that we would like to log are
those where the error is on the server side. Client side errors can be
checked through lightstep and explained in the FAQ.
