### PR TITLE
Allow Nakadi admins to change compatibility mode in unsafe ways

### DIFF
--- a/api-metastore/src/main/java/org/zalando/nakadi/config/SchemaValidatorConfig.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/config/SchemaValidatorConfig.java
@@ -6,9 +6,11 @@ import com.google.common.io.Resources;
 import org.everit.json.schema.Schema;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.zalando.nakadi.domain.SchemaChange;
+import org.zalando.nakadi.service.AdminService;
 import org.zalando.nakadi.service.SchemaEvolutionService;
 import org.zalando.nakadi.validation.schema.CategoryChangeConstraint;
 import org.zalando.nakadi.validation.schema.CompatibilityModeChangeConstraint;
@@ -43,6 +45,13 @@ import static org.zalando.nakadi.domain.SchemaChange.Type.TYPE_CHANGED;
 @Configuration
 public class SchemaValidatorConfig {
 
+    private final AdminService adminService;
+
+    @Autowired
+    public SchemaValidatorConfig(final AdminService adminService) {
+        this.adminService = adminService;
+    }
+
     @Bean
     public SchemaEvolutionService schemaEvolutionService() throws IOException {
         final JSONObject metaSchemaJson = new JSONObject(Resources.toString(Resources.getResource("schema.json"),
@@ -51,7 +60,7 @@ public class SchemaValidatorConfig {
 
         final List<SchemaEvolutionConstraint> schemaEvolutionConstraints = Lists.newArrayList(
                 new CategoryChangeConstraint(),
-                new CompatibilityModeChangeConstraint(),
+                new CompatibilityModeChangeConstraint(adminService),
                 new PartitionKeyFieldsConstraint(),
                 new PartitionStrategyConstraint(),
                 new EnrichmentStrategyConstraint()

--- a/api-metastore/src/main/java/org/zalando/nakadi/validation/schema/CompatibilityModeChangeConstraint.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/validation/schema/CompatibilityModeChangeConstraint.java
@@ -5,6 +5,8 @@ import com.google.common.collect.Lists;
 import org.zalando.nakadi.domain.CompatibilityMode;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeBase;
+import org.zalando.nakadi.plugin.api.authz.AuthorizationService;
+import org.zalando.nakadi.service.AdminService;
 
 import java.util.List;
 import java.util.Map;
@@ -17,9 +19,18 @@ public class CompatibilityModeChangeConstraint implements SchemaEvolutionConstra
             CompatibilityMode.NONE, Lists.newArrayList(CompatibilityMode.NONE, CompatibilityMode.FORWARD)
     );
 
+    private final AdminService adminService;
+
+    public CompatibilityModeChangeConstraint(final AdminService adminService) {
+        this.adminService = adminService;
+    }
+
     @Override
     public Optional<SchemaEvolutionIncompatibility> validate(final EventType original, final EventTypeBase eventType) {
-        if (!allowedChanges.get(original.getCompatibilityMode()).contains(eventType.getCompatibilityMode())) {
+        final boolean isNakadiAdmin = adminService.isAdmin(AuthorizationService.Operation.WRITE);
+        final boolean isChangeValid = allowedChanges.get(original.getCompatibilityMode())
+                .contains(eventType.getCompatibilityMode());
+        if (!isNakadiAdmin && !isChangeValid) {
             return Optional.of(new SchemaEvolutionIncompatibility("changing compatibility_mode is not allowed"));
         } else {
             return Optional.empty();

--- a/api-metastore/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
@@ -86,10 +86,10 @@ public class EventTypeControllerTestCase {
     protected final TimelineService timelineService = mock(TimelineService.class);
     protected final TimelineSync timelineSync = mock(TimelineSync.class);
     protected final TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
-    protected final SchemaEvolutionService schemaEvolutionService = new SchemaValidatorConfig()
+    protected final AdminService adminService = mock(AdminService.class);
+    protected final SchemaEvolutionService schemaEvolutionService = new SchemaValidatorConfig(adminService)
             .schemaEvolutionService();
     protected final AuthorizationValidator authorizationValidator = mock(AuthorizationValidator.class);
-    protected final AdminService adminService = mock(AdminService.class);
     protected final NakadiKpiPublisher nakadiKpiPublisher = mock(NakadiKpiPublisher.class);
     protected final AuthorizationService authorizationService = mock(AuthorizationService.class);
     protected final NakadiAuditLogPublisher nakadiAuditLogPublisher = mock(NakadiAuditLogPublisher.class);
@@ -115,6 +115,7 @@ public class EventTypeControllerTestCase {
             final TransactionCallback callback = (TransactionCallback) invocation.getArguments()[0];
             return callback.doInTransaction(null);
         });
+        when(adminService.isAdmin(AuthorizationService.Operation.WRITE)).thenReturn(false);
 
         final EventTypeOptionsValidator eventTypeOptionsValidator =
                 new EventTypeOptionsValidator(TOPIC_RETENTION_MIN_MS, TOPIC_RETENTION_MAX_MS);


### PR DESCRIPTION
https://jira.zalando.net/browse/ARUHA-2804

Users often make mistakes when editing their schemas. Sometimes it's a
typo on a properties name, others it's something more serious that causes events to be
rejected. The rules often do not allowed for such changes to be
undone, as that would mean breaking the compatibility mode (at least
in theory).

But this has led our team to make manual changes to the database
several times as a way to rescue users from dead ends.

Since hacking the database is less than ideal, we are making it
possible for admins (Nakadi admins, not event type admins) to downgrade the compatibility mode, so that users
can fix their schemas and then set the compatibility mode back to what
it was, which they can do on their own.

This is only made available for Nakadi admins, as it's a potentialy
harmful operation if users execute this without properly reflecting on
the downstream consequences of performing incompatible changes to schemas.
