### PR TITLE
Register new schema independently from changing other properties

### DIFF
--- a/api-metastore/src/main/java/org/zalando/nakadi/controller/SchemaController.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/controller/SchemaController.java
@@ -25,7 +25,6 @@ import org.zalando.nakadi.service.EventTypeService;
 import org.zalando.nakadi.service.SchemaService;
 
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 
 import static org.springframework.http.ResponseEntity.status;
 
@@ -43,7 +42,7 @@ public class SchemaController {
 
     @RequestMapping(value = "/event-types/{name}/schemas", method = RequestMethod.POST)
     public ResponseEntity<?> create(@PathVariable("name") final String name,
-                                    @Valid @RequestBody @NotNull final EventTypeSchemaBase schema,
+                                    @Valid @RequestBody final EventTypeSchemaBase schema,
                                     final Errors errors) {
         if (errors.hasErrors()) {
             throw new ValidationException(errors);

--- a/api-metastore/src/main/java/org/zalando/nakadi/controller/SchemaController.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/controller/SchemaController.java
@@ -3,21 +3,31 @@ package org.zalando.nakadi.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeSchema;
+import org.zalando.nakadi.domain.EventTypeSchemaBase;
 import org.zalando.nakadi.domain.PaginationWrapper;
 import org.zalando.nakadi.exceptions.runtime.InternalNakadiException;
 import org.zalando.nakadi.exceptions.runtime.InvalidLimitException;
 import org.zalando.nakadi.exceptions.runtime.InvalidVersionNumberException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchEventTypeException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchSchemaException;
+import org.zalando.nakadi.exceptions.runtime.ValidationException;
 import org.zalando.nakadi.service.EventTypeService;
 import org.zalando.nakadi.service.SchemaService;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import static org.springframework.http.ResponseEntity.status;
 
 @RestController
 public class SchemaController {
@@ -31,7 +41,21 @@ public class SchemaController {
         this.eventTypeService = eventTypeService;
     }
 
-    @RequestMapping("/event-types/{name}/schemas")
+    @RequestMapping(value = "/event-types/{name}/schemas", method = RequestMethod.POST)
+    public ResponseEntity<?> create(@PathVariable("name") final String name,
+                                    @Valid @RequestBody @NotNull final EventTypeSchemaBase schema,
+                                    final Errors errors) {
+        if (errors.hasErrors()) {
+            throw new ValidationException(errors);
+        }
+
+        final EventType eventType = eventTypeService.get(name);
+        schemaService.addSchema(eventType, schema);
+
+        return status(HttpStatus.OK).build();
+    }
+
+    @RequestMapping(value = "/event-types/{name}/schemas", method = RequestMethod.GET)
     public ResponseEntity<?> getSchemas(
             @PathVariable("name") final String name,
             @RequestParam(value = "offset", required = false, defaultValue = "0") final int offset,

--- a/api-metastore/src/main/java/org/zalando/nakadi/controller/SchemaController.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/controller/SchemaController.java
@@ -48,8 +48,7 @@ public class SchemaController {
             throw new ValidationException(errors);
         }
 
-        final EventType eventType = eventTypeService.get(name);
-        schemaService.addSchema(eventType, schema);
+        schemaService.addSchema(name, schema);
 
         return status(HttpStatus.OK).build();
     }

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -2,10 +2,6 @@ package org.zalando.nakadi.service;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
-import org.everit.json.schema.Schema;
-import org.everit.json.schema.SchemaException;
-import org.everit.json.schema.loader.SchemaLoader;
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,7 +13,6 @@ import org.springframework.transaction.support.TransactionTemplate;
 import org.zalando.nakadi.cache.EventTypeCache;
 import org.zalando.nakadi.config.NakadiSettings;
 import org.zalando.nakadi.domain.CleanupPolicy;
-import org.zalando.nakadi.domain.CompatibilityMode;
 import org.zalando.nakadi.domain.EventCategory;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeBase;
@@ -62,20 +57,15 @@ import org.zalando.nakadi.service.publishing.NakadiKpiPublisher;
 import org.zalando.nakadi.service.timeline.TimelineService;
 import org.zalando.nakadi.service.timeline.TimelineSync;
 import org.zalando.nakadi.service.validation.EventTypeOptionsValidator;
-import org.zalando.nakadi.util.JsonUtils;
-import org.zalando.nakadi.validation.JsonSchemaEnrichment;
-import org.zalando.nakadi.validation.SchemaIncompatibility;
 import org.zalando.nakadi.view.EventOwnerSelector;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 import static org.zalando.nakadi.domain.Feature.DELETE_EVENT_TYPE_WITH_SUBSCRIPTIONS;
 import static org.zalando.nakadi.domain.Feature.FORCE_EVENT_TYPE_AUTHZ;
@@ -103,8 +93,9 @@ public class EventTypeService {
     private final EventTypeOptionsValidator eventTypeOptionsValidator;
     private final AdminService adminService;
     private final RepartitioningService repartitioningService;
-    private final JsonSchemaEnrichment jsonSchemaEnrichment;
+
     private final EventTypeCache eventTypeCache;
+    private final SchemaService schemaService;
 
     @Autowired
     public EventTypeService(
@@ -127,7 +118,7 @@ public class EventTypeService {
             final AdminService adminService,
             final RepartitioningService repartitioningService,
             final EventTypeCache eventTypeCache,
-            final JsonSchemaEnrichment jsonSchemaEnrichment) {
+            final SchemaService schemaService) {
         this.eventTypeRepository = eventTypeRepository;
         this.timelineService = timelineService;
         this.partitionResolver = partitionResolver;
@@ -147,7 +138,7 @@ public class EventTypeService {
         this.adminService = adminService;
         this.repartitioningService = repartitioningService;
         this.eventTypeCache = eventTypeCache;
-        this.jsonSchemaEnrichment = jsonSchemaEnrichment;
+        this.schemaService = schemaService;
     }
 
     public List<EventType> list() {
@@ -174,7 +165,7 @@ public class EventTypeService {
         }
         eventTypeOptionsValidator.checkRetentionTime(eventType.getOptions());
         setDefaultEventTypeOptions(eventType);
-        validateSchema(eventType);
+        schemaService.validateSchema(eventType);
         validateCompaction(eventType);
         enrichment.validate(eventType);
         partitionResolver.validate(eventType);
@@ -435,7 +426,7 @@ public class EventTypeService {
             authorizationValidator.validateAuthorization(original.asResource(), eventTypeBase.asBaseResource());
             validateName(eventTypeName, eventTypeBase);
             validateCompactionUpdate(original, eventTypeBase);
-            validateSchema(eventTypeBase);
+            schemaService.validateSchema(eventTypeBase);
             validateAudience(original, eventTypeBase);
             partitionResolver.validate(eventTypeBase);
             eventType = schemaEvolutionService.evolve(original, eventTypeBase);
@@ -579,67 +570,5 @@ public class EventTypeService {
         } else if (updatedEventOwnerSelector == null && originalEventOwnerSelector != null) {
             throw new InvalidEventTypeException("event_owner_selector can't be set back to null");
         }
-    }
-
-    private void validateSchema(final EventTypeBase eventType) throws InvalidEventTypeException {
-        try {
-            final String eventTypeSchema = eventType.getSchema().getSchema();
-
-            JsonUtils.checkEventTypeSchemaValid(eventTypeSchema);
-
-            final JSONObject schemaAsJson = new JSONObject(eventTypeSchema);
-
-            if (schemaAsJson.has("type") && !Objects.equals("object", schemaAsJson.getString("type"))) {
-                throw new InvalidEventTypeException("\"type\" of root element in schema can only be \"object\"");
-            }
-
-            final Schema schema = SchemaLoader.load(schemaAsJson);
-            if (eventType.getCategory() == EventCategory.BUSINESS && schema.definesProperty("#/metadata")) {
-                throw new InvalidEventTypeException("\"metadata\" property is reserved");
-            }
-
-            final List<String> orderingInstanceIds = eventType.getOrderingInstanceIds();
-            final List<String> orderingKeyFields = eventType.getOrderingKeyFields();
-            if (!orderingInstanceIds.isEmpty() && orderingKeyFields.isEmpty()) {
-                throw new InvalidEventTypeException(
-                        "`ordering_instance_ids` field can not be defined without defining `ordering_key_fields`");
-            }
-            final JSONObject effectiveSchemaAsJson = jsonSchemaEnrichment.effectiveSchema(eventType);
-            final Schema effectiveSchema = SchemaLoader.load(effectiveSchemaAsJson);
-            validateFieldsInSchema("ordering_key_fields", orderingKeyFields, effectiveSchema);
-            validateFieldsInSchema("ordering_instance_ids", orderingInstanceIds, effectiveSchema);
-
-            if (eventType.getCompatibilityMode() == CompatibilityMode.COMPATIBLE) {
-                validateJsonSchemaConstraints(schemaAsJson);
-            }
-        } catch (final JSONException e) {
-            throw new InvalidEventTypeException("schema must be a valid json");
-        } catch (final SchemaException e) {
-            throw new InvalidEventTypeException("schema must be a valid json-schema");
-        }
-    }
-
-    private void validateJsonSchemaConstraints(final JSONObject schema) throws InvalidEventTypeException {
-        final List<SchemaIncompatibility> incompatibilities = schemaEvolutionService.collectIncompatibilities(schema);
-
-        if (!incompatibilities.isEmpty()) {
-            final String errorMessage = incompatibilities.stream().map(Object::toString)
-                    .collect(Collectors.joining(", "));
-            throw new InvalidEventTypeException("Invalid schema: " + errorMessage);
-        }
-    }
-
-    private void validateFieldsInSchema(final String fieldName, final List<String> fields, final Schema schema) {
-        final List<String> absentFields = fields.stream()
-                .filter(field -> !schema.definesProperty(convertToJSONPointer(field)))
-                .collect(Collectors.toList());
-        if (!absentFields.isEmpty()) {
-            throw new InvalidEventTypeException(fieldName + " " + absentFields + " absent in schema");
-        }
-    }
-
-
-    private String convertToJSONPointer(final String value) {
-        return value.replaceAll("\\.", "/");
     }
 }

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaService.java
@@ -1,33 +1,84 @@
 package org.zalando.nakadi.service;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.everit.json.schema.Schema;
+import org.everit.json.schema.SchemaException;
+import org.everit.json.schema.loader.SchemaLoader;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.zalando.nakadi.cache.EventTypeCache;
+import org.zalando.nakadi.domain.CompatibilityMode;
+import org.zalando.nakadi.domain.EventCategory;
+import org.zalando.nakadi.domain.EventType;
+import org.zalando.nakadi.domain.EventTypeBase;
 import org.zalando.nakadi.domain.EventTypeSchema;
+import org.zalando.nakadi.domain.EventTypeSchemaBase;
 import org.zalando.nakadi.domain.PaginationWrapper;
+import org.zalando.nakadi.exceptions.runtime.InvalidEventTypeException;
 import org.zalando.nakadi.exceptions.runtime.InvalidLimitException;
 import org.zalando.nakadi.exceptions.runtime.InvalidVersionNumberException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchSchemaException;
+import org.zalando.nakadi.plugin.api.authz.AuthorizationService;
+import org.zalando.nakadi.repository.db.EventTypeRepository;
 import org.zalando.nakadi.repository.db.SchemaRepository;
+import org.zalando.nakadi.util.JsonUtils;
+import org.zalando.nakadi.validation.JsonSchemaEnrichment;
+import org.zalando.nakadi.validation.SchemaIncompatibility;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Component
 public class SchemaService {
 
     private static final Pattern VERSION_PATTERN = Pattern.compile("\\d+\\.\\d+\\.\\d+");
-    private static final Logger LOG = LoggerFactory.getLogger(SchemaService.class);
 
     private final SchemaRepository schemaRepository;
     private final PaginationService paginationService;
+    private final JsonSchemaEnrichment jsonSchemaEnrichment;
+    private final SchemaEvolutionService schemaEvolutionService;
+    private final EventTypeRepository eventTypeRepository;
+    private final AdminService adminService;
+    private final AuthorizationValidator authorizationValidator;
+    private final EventTypeCache eventTypeCache;
 
     @Autowired
     public SchemaService(final SchemaRepository schemaRepository,
-                         final PaginationService paginationService) {
+                         final PaginationService paginationService,
+                         final JsonSchemaEnrichment jsonSchemaEnrichment,
+                         final SchemaEvolutionService schemaEvolutionService,
+                         final EventTypeRepository eventTypeRepository,
+                         final AdminService adminService,
+                         final AuthorizationValidator authorizationValidator,
+                         final EventTypeCache eventTypeCache) {
         this.schemaRepository = schemaRepository;
         this.paginationService = paginationService;
+        this.jsonSchemaEnrichment = jsonSchemaEnrichment;
+        this.schemaEvolutionService = schemaEvolutionService;
+        this.eventTypeRepository = eventTypeRepository;
+        this.adminService = adminService;
+        this.authorizationValidator = authorizationValidator;
+        this.eventTypeCache = eventTypeCache;
+    }
+
+    public void addSchema(final EventType originalEventType, final EventTypeSchemaBase newSchema) {
+        if (!adminService.isAdmin(AuthorizationService.Operation.WRITE)) {
+            authorizationValidator.authorizeEventTypeAdmin(originalEventType);
+        }
+
+        final EventTypeBase updatedEventType = new EventTypeBase(originalEventType);
+        updatedEventType.setSchema(newSchema);
+        validateSchema(updatedEventType);
+
+        final EventType eventType = schemaEvolutionService.evolve(originalEventType, updatedEventType);
+
+        eventTypeRepository.update(eventType);
+
+        eventTypeCache.invalidate(eventType.getName());
     }
 
     public PaginationWrapper getSchemas(final String name, final int offset, final int limit)
@@ -54,5 +105,66 @@ public class SchemaService {
         }
         final EventTypeSchema schema = schemaRepository.getSchemaVersion(name, version);
         return schema;
+    }
+
+    public void validateSchema(final EventTypeBase eventType) throws InvalidEventTypeException {
+        try {
+            final String eventTypeSchema = eventType.getSchema().getSchema();
+
+            JsonUtils.checkEventTypeSchemaValid(eventTypeSchema);
+
+            final JSONObject schemaAsJson = new JSONObject(eventTypeSchema);
+
+            if (schemaAsJson.has("type") && !Objects.equals("object", schemaAsJson.getString("type"))) {
+                throw new InvalidEventTypeException("\"type\" of root element in schema can only be \"object\"");
+            }
+
+            final Schema schema = SchemaLoader.load(schemaAsJson);
+            if (eventType.getCategory() == EventCategory.BUSINESS && schema.definesProperty("#/metadata")) {
+                throw new InvalidEventTypeException("\"metadata\" property is reserved");
+            }
+
+            final List<String> orderingInstanceIds = eventType.getOrderingInstanceIds();
+            final List<String> orderingKeyFields = eventType.getOrderingKeyFields();
+            if (!orderingInstanceIds.isEmpty() && orderingKeyFields.isEmpty()) {
+                throw new InvalidEventTypeException(
+                        "`ordering_instance_ids` field can not be defined without defining `ordering_key_fields`");
+            }
+            final JSONObject effectiveSchemaAsJson = jsonSchemaEnrichment.effectiveSchema(eventType);
+            final Schema effectiveSchema = SchemaLoader.load(effectiveSchemaAsJson);
+            validateFieldsInSchema("ordering_key_fields", orderingKeyFields, effectiveSchema);
+            validateFieldsInSchema("ordering_instance_ids", orderingInstanceIds, effectiveSchema);
+
+            if (eventType.getCompatibilityMode() == CompatibilityMode.COMPATIBLE) {
+                validateJsonSchemaConstraints(schemaAsJson);
+            }
+        } catch (final JSONException e) {
+            throw new InvalidEventTypeException("schema must be a valid json");
+        } catch (final SchemaException e) {
+            throw new InvalidEventTypeException("schema must be a valid json-schema");
+        }
+    }
+
+    private void validateJsonSchemaConstraints(final JSONObject schema) throws InvalidEventTypeException {
+        final List<SchemaIncompatibility> incompatibilities = schemaEvolutionService.collectIncompatibilities(schema);
+
+        if (!incompatibilities.isEmpty()) {
+            final String errorMessage = incompatibilities.stream().map(Object::toString)
+                    .collect(Collectors.joining(", "));
+            throw new InvalidEventTypeException("Invalid schema: " + errorMessage);
+        }
+    }
+
+    private void validateFieldsInSchema(final String fieldName, final List<String> fields, final Schema schema) {
+        final List<String> absentFields = fields.stream()
+                .filter(field -> !schema.definesProperty(convertToJSONPointer(field)))
+                .collect(Collectors.toList());
+        if (!absentFields.isEmpty()) {
+            throw new InvalidEventTypeException(fieldName + " " + absentFields + " absent in schema");
+        }
+    }
+
+    private String convertToJSONPointer(final String value) {
+        return value.replaceAll("\\.", "/");
     }
 }

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaService.java
@@ -8,6 +8,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.zalando.nakadi.cache.EventTypeCache;
 import org.zalando.nakadi.domain.CompatibilityMode;
 import org.zalando.nakadi.domain.EventCategory;
@@ -67,7 +68,10 @@ public class SchemaService {
         this.eventTypeCache = eventTypeCache;
     }
 
-    public void addSchema(final EventType originalEventType, final EventTypeSchemaBase newSchema) {
+    @Transactional
+    public void addSchema(final String eventTypeName, final EventTypeSchemaBase newSchema) {
+        final EventType originalEventType = eventTypeRepository.findByName(eventTypeName);
+
         if (!adminService.isAdmin(AuthorizationService.Operation.WRITE)) {
             authorizationValidator.authorizeEventTypeAdmin(originalEventType);
         }

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaService.java
@@ -8,7 +8,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 import org.zalando.nakadi.cache.EventTypeCache;
 import org.zalando.nakadi.domain.CompatibilityMode;
 import org.zalando.nakadi.domain.EventCategory;
@@ -68,7 +67,6 @@ public class SchemaService {
         this.eventTypeCache = eventTypeCache;
     }
 
-    @Transactional
     public void addSchema(final String eventTypeName, final EventTypeSchemaBase newSchema) {
         final EventType originalEventType = eventTypeRepository.findByName(eventTypeName);
 

--- a/api-metastore/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
@@ -2,7 +2,6 @@ package org.zalando.nakadi.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.Before;
-import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -34,6 +33,7 @@ import org.zalando.nakadi.service.EventTypeService;
 import org.zalando.nakadi.service.FeatureToggleService;
 import org.zalando.nakadi.service.RepartitioningService;
 import org.zalando.nakadi.service.SchemaEvolutionService;
+import org.zalando.nakadi.service.SchemaService;
 import org.zalando.nakadi.service.TracingService;
 import org.zalando.nakadi.service.publishing.NakadiAuditLogPublisher;
 import org.zalando.nakadi.service.publishing.NakadiKpiPublisher;
@@ -42,7 +42,6 @@ import org.zalando.nakadi.service.timeline.TimelineSync;
 import org.zalando.nakadi.service.validation.EventTypeOptionsValidator;
 import org.zalando.nakadi.util.UUIDGenerator;
 import org.zalando.nakadi.utils.TestUtils;
-import org.zalando.nakadi.validation.JsonSchemaEnrichment;
 import org.zalando.problem.Problem;
 import uk.co.datumedge.hamcrest.json.SameJSONAs;
 
@@ -94,6 +93,7 @@ public class EventTypeControllerTestCase {
     protected final AuthorizationService authorizationService = mock(AuthorizationService.class);
     protected final NakadiAuditLogPublisher nakadiAuditLogPublisher = mock(NakadiAuditLogPublisher.class);
     protected final TracingService tracingService = mock(TracingService.class);
+    private final SchemaService schemaService = mock(SchemaService.class);
     protected MockMvc mockMvc;
 
     public EventTypeControllerTestCase() throws IOException {
@@ -124,7 +124,8 @@ public class EventTypeControllerTestCase {
                 featureToggleService, authorizationValidator, timelineSync, transactionTemplate, nakadiSettings,
                 nakadiKpiPublisher, "et-log-event-type", nakadiAuditLogPublisher,
                 eventTypeOptionsValidator, adminService, mock(RepartitioningService.class), eventTypeCache,
-                new JsonSchemaEnrichment(new DefaultResourceLoader(), "classpath:schema_metadata.json"));
+                schemaService);
+
         final EventTypeController controller = new EventTypeController(eventTypeService, featureToggleService,
                 adminService, nakadiSettings);
         doReturn(randomUUID).when(uuid).randomUUID();

--- a/api-metastore/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
@@ -8,7 +8,6 @@ import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
-import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.zalando.nakadi.cache.EventTypeCache;
@@ -38,7 +37,6 @@ import org.zalando.nakadi.service.validation.EventTypeOptionsValidator;
 import org.zalando.nakadi.utils.EventTypeTestBuilder;
 import org.zalando.nakadi.utils.RandomSubscriptionBuilder;
 import org.zalando.nakadi.utils.TestUtils;
-import org.zalando.nakadi.validation.JsonSchemaEnrichment;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -79,6 +77,7 @@ public class EventTypeServiceTest {
     private final NakadiKpiPublisher nakadiKpiPublisher = mock(NakadiKpiPublisher.class);
     private final NakadiAuditLogPublisher nakadiAuditLogPublisher = mock(NakadiAuditLogPublisher.class);
     private final AdminService adminService = mock(AdminService.class);
+    private final SchemaService schemaService = mock(SchemaService.class);
     private EventTypeService eventTypeService;
 
     @Before
@@ -89,8 +88,7 @@ public class EventTypeServiceTest {
                 subscriptionDbRepository, schemaEvolutionService, partitionsCalculator, featureToggleService,
                 authorizationValidator, timelineSync, transactionTemplate, nakadiSettings, nakadiKpiPublisher,
                 KPI_ET_LOG_EVENT_TYPE, nakadiAuditLogPublisher, eventTypeOptionsValidator,
-                adminService, mock(RepartitioningService.class), eventTypeCache,
-                new JsonSchemaEnrichment(new DefaultResourceLoader(), "classpath:schema_metadata.json"));
+                adminService, mock(RepartitioningService.class), eventTypeCache, schemaService);
         when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
             final TransactionCallback callback = (TransactionCallback) invocation.getArguments()[0];
             return callback.doInTransaction(null);

--- a/api-metastore/src/test/java/org/zalando/nakadi/service/SchemaServiceTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/service/SchemaServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.zalando.nakadi.cache.EventTypeCache;
+import org.zalando.nakadi.config.NakadiSettings;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeSchema;
 import org.zalando.nakadi.domain.PaginationWrapper;
@@ -17,6 +18,7 @@ import org.zalando.nakadi.exceptions.runtime.InvalidLimitException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchSchemaException;
 import org.zalando.nakadi.repository.db.EventTypeRepository;
 import org.zalando.nakadi.repository.db.SchemaRepository;
+import org.zalando.nakadi.service.timeline.TimelineSync;
 import org.zalando.nakadi.utils.TestUtils;
 import org.zalando.nakadi.validation.JsonSchemaEnrichment;
 
@@ -38,6 +40,8 @@ public class SchemaServiceTest {
     private AuthorizationValidator authorizationValidator;
     private EventTypeCache eventTypeCache;
     private EventType eventType;
+    private TimelineSync timelineSync;
+    private NakadiSettings nakadiSettings;
 
     @Before
     public void setUp() throws IOException {
@@ -51,9 +55,12 @@ public class SchemaServiceTest {
         eventTypeCache = Mockito.mock(EventTypeCache.class);
         eventType = TestUtils.buildDefaultEventType();
         Mockito.when(eventTypeRepository.findByName(any())).thenReturn(eventType);
+        timelineSync = Mockito.mock(TimelineSync.class);
+        nakadiSettings = Mockito.mock(NakadiSettings.class);
         schemaService = new SchemaService(schemaRepository, paginationService,
                 new JsonSchemaEnrichment(new DefaultResourceLoader(), "classpath:schema_metadata.json"),
-                schemaEvolutionService, eventTypeRepository, adminService, authorizationValidator, eventTypeCache);
+                schemaEvolutionService, eventTypeRepository, adminService, authorizationValidator, eventTypeCache,
+                timelineSync, nakadiSettings);
     }
 
     @Test(expected = InvalidLimitException.class)

--- a/api-metastore/src/test/java/org/zalando/nakadi/service/SchemaServiceTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/service/SchemaServiceTest.java
@@ -1,17 +1,30 @@
 package org.zalando.nakadi.service;
 
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.zalando.nakadi.cache.EventTypeCache;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeSchema;
 import org.zalando.nakadi.domain.PaginationWrapper;
 import org.zalando.nakadi.domain.Version;
+import org.zalando.nakadi.exceptions.runtime.InvalidEventTypeException;
 import org.zalando.nakadi.exceptions.runtime.InvalidLimitException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchSchemaException;
+import org.zalando.nakadi.repository.db.EventTypeRepository;
 import org.zalando.nakadi.repository.db.SchemaRepository;
+import org.zalando.nakadi.utils.TestUtils;
+import org.zalando.nakadi.validation.JsonSchemaEnrichment;
 
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Matchers.any;
+import static org.zalando.nakadi.domain.EventCategory.BUSINESS;
 import static org.zalando.nakadi.utils.TestUtils.buildDefaultEventType;
 
 public class SchemaServiceTest {
@@ -19,12 +32,26 @@ public class SchemaServiceTest {
     private SchemaRepository schemaRepository;
     private PaginationService paginationService;
     private SchemaService schemaService;
+    private JsonSchemaEnrichment jsonSchemaEnrichment;
+    private SchemaEvolutionService schemaEvolutionService;
+    private EventTypeRepository eventTypeRepository;
+    private AdminService adminService;
+    private AuthorizationValidator authorizationValidator;
+    private EventTypeCache eventTypeCache;
 
     @Before
-    public void setUp() {
+    public void setUp() throws IOException {
         schemaRepository = Mockito.mock(SchemaRepository.class);
         paginationService = Mockito.mock(PaginationService.class);
-        schemaService = new SchemaService(schemaRepository, paginationService);
+        jsonSchemaEnrichment = Mockito.mock(JsonSchemaEnrichment.class);
+        schemaEvolutionService = Mockito.mock(SchemaEvolutionService.class);
+        eventTypeRepository = Mockito.mock(EventTypeRepository.class);
+        adminService = Mockito.mock(AdminService.class);
+        authorizationValidator = Mockito.mock(AuthorizationValidator.class);
+        eventTypeCache = Mockito.mock(EventTypeCache.class);
+        schemaService = new SchemaService(schemaRepository, paginationService,
+                new JsonSchemaEnrichment(new DefaultResourceLoader(), "classpath:schema_metadata.json"),
+                schemaEvolutionService, eventTypeRepository, adminService, authorizationValidator, eventTypeCache);
     }
 
     @Test(expected = InvalidLimitException.class)
@@ -79,4 +106,52 @@ public class SchemaServiceTest {
         Assert.assertTrue(true);
     }
 
+    @Test
+    public void invalidEventTypeSchemaJsonSchemaThenThrows() throws Exception {
+        final EventType eventType = TestUtils.buildDefaultEventType();
+
+        final String jsonSchemaString = Resources.toString(
+                Resources.getResource("sample-invalid-json-schema.json"),
+                Charsets.UTF_8);
+        eventType.getSchema().setSchema(jsonSchemaString);
+
+        assertThrows(InvalidEventTypeException.class, () -> schemaService.validateSchema(eventType));
+    }
+
+    @Test
+    public void whenPOSTBusinessEventTypeMetadataThenThrows() throws Exception {
+        final EventType eventType = TestUtils.buildDefaultEventType();
+        eventType.getSchema().setSchema(
+                "{\"type\": \"object\", \"properties\": {\"metadata\": {\"type\": \"object\"} }}");
+        eventType.setCategory(BUSINESS);
+
+        assertThrows(InvalidEventTypeException.class, () -> schemaService.validateSchema(eventType));
+    }
+
+    @Test
+    public void whenEventTypeSchemaJsonIsMalformedThenThrows() throws Exception {
+        final EventType eventType = TestUtils.buildDefaultEventType();
+        eventType.getSchema().setSchema("invalid-json");
+
+        assertThrows(InvalidEventTypeException.class, () -> schemaService.validateSchema(eventType));
+    }
+
+    @Test
+    public void whenSchemaHasIncompatibilitiesThenThrows() throws Exception {
+        final EventType eventType = TestUtils.buildDefaultEventType();
+        
+        Mockito.doThrow(InvalidEventTypeException.class).when(schemaEvolutionService).collectIncompatibilities(any());
+
+        assertThrows(InvalidEventTypeException.class, () -> schemaService.validateSchema(eventType));
+    }
+
+    @Test
+    public void whenPostWithRootElementOfTypeArrayThenThrows() throws Exception {
+        final EventType eventType = TestUtils.buildDefaultEventType();
+        eventType.getSchema().setSchema(
+                "{\\\"type\\\":\\\"array\\\" }");
+        eventType.setCategory(BUSINESS);
+
+        assertThrows(InvalidEventTypeException.class, () -> schemaService.validateSchema(eventType));
+    }
 }

--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -530,6 +530,46 @@ paths:
             $ref: '#/definitions/Problem'
 
   '/event-types/{name}/schemas':
+    post:
+      tags:
+        - schema-registry-api
+      description: |
+        Adds a new schema for this event type. New schemas are automatically used for validation of events. The rules
+        for adding a new schema are described in details in the
+        [event types](https://zalando.github.io/nakadi/manual.html#using_event-types) section of the documentation.
+
+        For API backward compatibility, adding a new schema can also be done by updating the entire event type via PUT.
+    parameters:
+      - name: name
+        in: path
+        description: EventType name
+        type: string
+        required: true
+      - name:
+        description: |
+          New version of the event type's schema to be used for validating published events.
+        schema:
+          $ref: '#/definitions/EventTypeSchema'
+        required: true
+    responses:
+      '201':
+        description: |
+          New schema registered with success.
+      '401':
+        description: Not authenticated
+        schema:
+          $ref: '#/definitions/Problem'
+      '422':
+        description: |
+          Unprocessable entity. For understanding the rules on what can be changed in a schema, please refer to
+          the [schema evolution documentation](https://zalando.github.io/nakadi/manual.html#using_event-types).
+        schema:
+          $ref: '#/definitions/Problem'
+      '403':
+        description: Access is forbidden for the client or event type
+        schema:
+          $ref: '#/definitions/Problem'
+
     get:
       tags:
         - schema-registry-api


### PR DESCRIPTION
The only way to update a schema so far has been to call `PUT
/event-types/{name}` with the complete definition of the event type in
the body (including the modified schema).

This way of changing schemas has proven to be problematic, as users
could accidentally modify other properties of the event type when
their intention would be to only change the schema.

One example in particular has been causing a lot of problems:
automated schema evolution performed by Nakadi SQL.

Nakadi SQL listens to schema changes made to input event types of
queries and automatically reflects those changes in the schema of the
output event type. It then calls `PUT /event-types/{name}` with the
new schema in order to register it. But this call fails due to
something unrelated to the schema change: the authorization section.

Every time an event type update is performed, all the properties are
validated, including authorization. But when users leave the company,
their identifiers are no longer valid, meaning that updating updating
event types fail if they are not removed from the event type
definition.

We consider that removing users from the authorization section is
responsibility of the team owning the event type and not job of an
automated task related with schema updating. So we are decoupling both
changes in order to solve the problem of automated schema change
independently from maintaining an up-to-date authorization section.

## Rejected alternative

Automatically removing invalid users from authorization section has been considered a potentially harmful operation, as it could result in empty authorization sections where it's no longer possible to keep track of who were the original maintainers of the event type.