### PR TITLE
Fix 500 when creating or updating event types with invalid regex in the schema

### DIFF
--- a/api-metastore/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -612,6 +612,9 @@ public class EventTypeService {
             if (eventType.getCompatibilityMode() == CompatibilityMode.COMPATIBLE) {
                 validateJsonSchemaConstraints(schemaAsJson);
             }
+        } catch (final com.google.re2j.PatternSyntaxException e) {
+            throw new InvalidEventTypeException("invalid regex pattern in the schema: "
+                    + e.getDescription() + " \"" + e.getPattern() + "\"");
         } catch (final JSONException e) {
             throw new InvalidEventTypeException("schema must be a valid json");
         } catch (final SchemaException e) {

--- a/api-metastore/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
@@ -24,6 +24,7 @@ import org.zalando.nakadi.exceptions.runtime.ConflictException;
 import org.zalando.nakadi.exceptions.runtime.EventTypeDeletionException;
 import org.zalando.nakadi.exceptions.runtime.FeatureNotAvailableException;
 import org.zalando.nakadi.exceptions.runtime.InternalNakadiException;
+import org.zalando.nakadi.exceptions.runtime.InvalidEventTypeException;
 import org.zalando.nakadi.exceptions.runtime.TopicCreationException;
 import org.zalando.nakadi.partitioning.PartitionResolver;
 import org.zalando.nakadi.repository.TopicRepository;
@@ -46,6 +47,7 @@ import java.util.Collections;
 import java.util.Optional;
 
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.doReturn;
@@ -303,6 +305,21 @@ public class EventTypeServiceTest {
                         .put("category", et.getCategory())
                         .put("authz", "disabled")
                         .put("compatibility_mode", et.getCompatibilityMode()));
+    }
+
+    @Test
+    public void throwsInvalidSchemaOnInvalidRegex() throws Exception {
+        final EventType et = TestUtils.buildDefaultEventType();
+        et.getSchema().setSchema("{\n" +
+                "      \"properties\": {\n" +
+                "        \"foo\": {\n" +
+                "          \"type\": \"string\",\n" +
+                "          \"pattern\": \"^(?!\\\\s*$).+\"\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }");
+
+        assertThrows(InvalidEventTypeException.class, () -> eventTypeService.create(et, false));
     }
 
 }


### PR DESCRIPTION
Prior to this fix, when creating a new event type with the following
schema:

```
    {
      "properties": {
        "foo": {
          "type": "string",
          "pattern": "^(?!\\s*$).+"
        }
      }
    }
```

Would result in 500 and no further explanation to the user. The user
would have to get in contact with the FlowId and we would have to dive
in the logs to find out a stack trace similar to this:

```
com.google.re2j.PatternSyntaxException: error parsing regexp: invalid or unsupported Perl syntax: `(?!`

        at com.google.re2j.Parser.parsePerlFlags(Parser.java:1139)
        at com.google.re2j.Parser.parseInternal(Parser.java:825)
        at com.google.re2j.Parser.parse(Parser.java:802)
        at com.google.re2j.RE2.compileImpl(RE2.java:183)
        at com.google.re2j.Pattern.compile(Pattern.java:136)
        at com.google.re2j.Pattern.compile(Pattern.java:96)
        at org.everit.json.schema.StringSchema.<init>(StringSchema.java:103)
        at org.everit.json.schema.StringSchema$Builder.build(StringSchema.java:34)
        at org.everit.json.schema.StringSchema$Builder.build(StringSchema.java:20)
        at org.everit.json.schema.loader.ObjectSchemaLoader.addPropertySchemaDefinition(ObjectSchemaLoader.java:68)
        at org.everit.json.schema.loader.ObjectSchemaLoader.lambda$populatePropertySchemas$9(ObjectSchemaLoader.java:62)
        at org.everit.json.schema.loader.JsonObject.iterateOnEntry(JsonObject.java:85)
        at org.everit.json.schema.loader.JsonObject.lambda$forEach$1(JsonObject.java:80)
        at java.util.HashMap$EntrySet.forEach(HashMap.java:1044)
        at org.everit.json.schema.loader.JsonObject.forEach(JsonObject.java:80)
        at org.everit.json.schema.loader.ObjectSchemaLoader.populatePropertySchemas(ObjectSchemaLoader.java:59)
        at org.everit.json.schema.loader.ObjectSchemaLoader.lambda$load$0(ObjectSchemaLoader.java:31)
        at java.util.Optional.ifPresent(Optional.java:159)
        at org.everit.json.schema.loader.ObjectSchemaLoader.load(ObjectSchemaLoader.java:31)
        at org.everit.json.schema.loader.SchemaLoader.buildObjectSchema(SchemaLoader.java:446)
        at org.everit.json.schema.loader.SchemaLoader.sniffSchemaByProps(SchemaLoader.java:471)
        at org.everit.json.schema.loader.SchemaLoader.buildSchemaWithoutExplicitType(SchemaLoader.java:336)
        at org.everit.json.schema.loader.SchemaLoader.lambda$loadSchemaObject$4(SchemaLoader.java:380)
        at java.util.Optional.orElseGet(Optional.java:267)
        at org.everit.json.schema.loader.SchemaLoader.loadSchemaObject(SchemaLoader.java:378)
        at org.everit.json.schema.loader.JsonValue$Multiplexer.requireAny(JsonValue.java:44)
        at org.everit.json.schema.loader.SchemaLoader.load(SchemaLoader.java:421)
        at org.everit.json.schema.loader.SchemaLoader.load(SchemaLoader.java:253)
        at org.everit.json.schema.loader.SchemaLoader.load(SchemaLoader.java:236)
        at org.zalando.nakadi.service.EventTypeService.validateSchema(EventTypeService.java:596)
        at org.zalando.nakadi.service.EventTypeService.create(EventTypeService.java:177)
        at
        org.zalando.nakadi.service.EventTypeServiceTest.throwsInvalidSchemaOnInvalidRegex(EventTypeServiceTest.java:320)
```

This regex library is not the default one and it was our choice to use
it in the past, given there were some security vulnerabilities with
the default regex library.

One could argue that it's weird to capture an exception from a third
library when checking for the validity of the schema and that the
everit library should probably wrap it in the already handled
`SchemaException` but since we configured this third library I would
say that it's fine as is.

Now the user will get a 422 with a nicer message: `invalid regex pattern in the schema: invalid or unsupported Perl syntax "(?!"`.