### PR TITLE
Validate request body on POST /settings/features

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/SettingsControllerAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/SettingsControllerAT.java
@@ -21,6 +21,7 @@ public class SettingsControllerAT extends BaseAT {
 
     private static final String BLACKLIST_URL = "/settings/blacklist";
     private static final String ADMINS_URL = "/settings/admins";
+    private static final String FEATURES_URL = "/settings/features";
     private static final CuratorFramework CURATOR = ZookeeperTestUtils.createCurator(ZOOKEEPER_URL);
 
     @Test
@@ -80,6 +81,12 @@ public class SettingsControllerAT extends BaseAT {
                 "{\"data_type\": \"service\", \"value\": \"service1\"}], " +
                 "\"writers\":[]}")
                 .contentType(ContentType.JSON).post(ADMINS_URL).then().statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+    }
+
+    @Test
+    public void testInvalidFeatureToggle() throws Exception {
+        given().body("{\"feeeeeeeature\":\"close_crutch\",\"enabled\":false}")
+                .contentType(ContentType.JSON).post(FEATURES_URL).then().statusCode(HttpStatus.SC_BAD_REQUEST);
     }
 
     public static void blacklist(final String name, final BlacklistService.Type type) throws IOException {

--- a/api-misc/src/main/java/org/zalando/nakadi/controller/SettingsController.java
+++ b/api-misc/src/main/java/org/zalando/nakadi/controller/SettingsController.java
@@ -82,7 +82,7 @@ public class SettingsController {
     }
 
     @RequestMapping(path = "/features", method = RequestMethod.POST)
-    public ResponseEntity<?> setFeature(@RequestBody final FeatureWrapper featureWrapper,
+    public ResponseEntity<?> setFeature(@Valid @RequestBody final FeatureWrapper featureWrapper,
                                         final NativeWebRequest request)
             throws ForbiddenOperationException {
         if (!adminService.isAdmin(AuthorizationService.Operation.WRITE)) {

--- a/core-common/src/main/java/org/zalando/nakadi/domain/FeatureWrapper.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/FeatureWrapper.java
@@ -1,7 +1,11 @@
 package org.zalando.nakadi.domain;
 
+import javax.validation.constraints.NotNull;
+
 public class FeatureWrapper {
+    @NotNull
     private Feature feature;
+    @NotNull
     private boolean enabled;
 
     public FeatureWrapper() {


### PR DESCRIPTION
This endpoint used to reply with 500 when the request body was
invalid.

Now it replies with 400 and some meaningful error that guides the user
towards a fix.
