### PR TITLE
Block external references in schemas

### DIFF
--- a/api-metastore/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/service/EventTypeServiceTest.java
@@ -24,6 +24,7 @@ import org.zalando.nakadi.exceptions.runtime.ConflictException;
 import org.zalando.nakadi.exceptions.runtime.EventTypeDeletionException;
 import org.zalando.nakadi.exceptions.runtime.FeatureNotAvailableException;
 import org.zalando.nakadi.exceptions.runtime.InternalNakadiException;
+import org.zalando.nakadi.exceptions.runtime.InvalidEventTypeException;
 import org.zalando.nakadi.exceptions.runtime.TopicCreationException;
 import org.zalando.nakadi.partitioning.PartitionResolver;
 import org.zalando.nakadi.repository.TopicRepository;
@@ -46,6 +47,7 @@ import java.util.Collections;
 import java.util.Optional;
 
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.doReturn;
@@ -243,6 +245,20 @@ public class EventTypeServiceTest {
                 .thenReturn(true);
 
         eventTypeService.create(eventType, true);
+    }
+
+    @Test
+    public void doNotSupportSchemaWithExternalRef() {
+        final EventType eventType = TestUtils.buildDefaultEventType();
+        eventType.getSchema().setSchema("{\n" +
+                "    \"properties\": {\n" +
+                "      \"foo\": {\n" +
+                "        \"$ref\": \"/invalid/url\"\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }");
+
+        assertThrows(InvalidEventTypeException.class, () -> eventTypeService.create(eventType, true));
     }
 
     @Test


### PR DESCRIPTION
Prior to this fix it would be possible to refer an external schema in
a schema definition. If the URL would be valid, it would fetch it over
the network. All sorts of problems could happen here:

- invalid URL
- timeout due to server being unresponsive
- other network issues

Besides, loading a schema from an external source could mean that
schema evolution rules could be worked around, by externalizing the
chunk of the schema that would change without any rules, as we do not
verify external schemas.

On top of all this problems, external schemas were never meant to be
supported and this feature made its way in the project since version 0
of Nakadi without the maintainers being aware of it.

After this fix, using external urls will result in 422 with a message
like:

`external url reference is not supported: /invalid/url`
