### PR TITLE
recreate watcher on brokers change list

### DIFF
--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -64,8 +64,10 @@ public class KafkaLocationManager {
             if (createWatcher) {
                 LOG.info("Creating watcher on brokers change");
                 childrenBuilder.usingWatcher((Watcher) event -> {
+                    if (event.getType() != Watcher.Event.EventType.NodeChildrenChanged) {
+                        return;
+                    }
                     this.scheduledExecutor.schedule(() -> updateBootstrapServersSafe(true), 0, TimeUnit.MILLISECONDS);
-                    LOG.info("Watcher event on brokers change received: {}", event.toString());
                 });
             }
             for (final String brokerId : childrenBuilder.forPath(BROKERS_IDS_PATH)) {


### PR DESCRIPTION
# One-line summary
the fix narrows down the triggering on brokers change watcher only for the case when list of broker id nodes changed

replicates the broken branch :) https://github.com/zalando/nakadi/pull/1119
```
Currently, broker list changed watcher is recreated on disconnects, which means a lot of watchers created for no reason and later on triggered for the same reason creating even more watchers and so on.
Although, it is clearly seen from the logs, this is hypothesis and the testing is required.
```