### PR TITLE
Change retention time in documentation, remove obsolete answer

### DIFF
--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -2866,7 +2866,7 @@ definitions:
       retention_time:
         type: integer
         format: int64
-        default: 345600000 # 4 days
+        default: 172800000 # 4 days
         description: |
           Number of milliseconds that Nakadi stores events published to this event type.
 

--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -2866,7 +2866,7 @@ definitions:
       retention_time:
         type: integer
         format: int64
-        default: 172800000 # 4 days
+        default: 172800000 # 2 days
         description: |
           Number of milliseconds that Nakadi stores events published to this event type.
 

--- a/docs/_documentation/faq.md
+++ b/docs/_documentation/faq.md
@@ -8,7 +8,6 @@ position: 14
 ## Table of Contents
 
 - [How long will events be persisted for?](#how-long-will-events-be-persisted-for-)
-- [How do I define how long will events be persisted for?](#how-do-i-define-how-long-will-events-be-persisted-for-)
 - [How many partitions will an event type be given?](#how-many-partitions-will-an-event-type-be-given-)
 - [How do I configure the number of partitions?](#how-do-i-configure-the-number-of-partitions-)
 - [Which partitioning strategy should I use?](#which-partitioning-strategy-should-i-use-)
@@ -32,12 +31,6 @@ position: 14
 The default retention time in the project is set by the `retentionMs` value in `application.yml`, which is currently 2 days. 
 
 The service installation you're working with may have a different operational setting, and you should get in touch with the team operating that internal Nakadi service. 
-
-#### How do I define how long will events be persisted for?
-
-At the moment, retention can't be defined via the API per event type. It may be added as an option in the future. The best option for now would be to configure the underlying Kafka topic directly.
-
-If you want to change the default for a server installation, you can set the `retentionMs` value in `application.yml` to a new value.
 
 #### How many partitions will an event type be given?
 


### PR DESCRIPTION
The default value is 2 days for quite a while, but it was'n reflected everywhere in the documentation. 
This PR removes some obsolete answers and fixes default value in api specification. 
Fixes #1190 