### PR TITLE
update scope info required for accessing API

### DIFF
--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -90,10 +90,8 @@ securityDefinitions:
         Grants access for changing Nakadi configuration.
       nakadi.event_type.write: |
         Grants access for applications to define and update EventTypes.
-      nakadi.event_stream.write: |
-        Grants access for applications to submit Events.
-      nakadi.event_stream.read: |
-        Grants access for consuming Event streams.
+      uid: |
+        Grants access for applications to submit or consume Events.
 
 paths:
   /metrics:


### PR DESCRIPTION
## Description
For consuming or submtting events, uid scope is enough, we don't need `nakadi.event_stream.write` and `nakadi.event_stream.read`.

I have removed other parts from the PR template as they were not relevant to the changes I made.

Please review and let me know if more info is required.