### PR TITLE
Change schema created at time only if new schema

### DIFF
--- a/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaEvolutionService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaEvolutionService.java
@@ -13,6 +13,7 @@ import org.zalando.nakadi.domain.EnrichmentStrategyDescriptor;
 import org.zalando.nakadi.domain.EventCategory;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeBase;
+import org.zalando.nakadi.domain.EventTypeSchema;
 import org.zalando.nakadi.domain.SchemaChange;
 import org.zalando.nakadi.domain.Version;
 import org.zalando.nakadi.exceptions.runtime.InvalidEventTypeException;
@@ -217,6 +218,8 @@ public class SchemaEvolutionService {
         final DateTime now = new DateTime(DateTimeZone.UTC);
         final String newVersion = original.getSchema().getVersion().bump(changeLevel).toString();
 
-        return new EventType(eventType, newVersion, original.getCreatedAt(), now);
+        final EventTypeSchema schema = changeLevel == NO_CHANGES ? original.getSchema():
+                new EventTypeSchema(eventType.getSchema(), newVersion, now);
+        return new EventType(eventType, original.getCreatedAt(), now, schema);
     }
 }

--- a/api-metastore/src/test/java/org/zalando/nakadi/validation/SchemaEvolutionServiceTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/validation/SchemaEvolutionServiceTest.java
@@ -122,6 +122,17 @@ public class SchemaEvolutionServiceTest {
     }
 
     @Test
+    public void whenNoSchemaChangeThenSchemaCreatedAtUnchanged() {
+        final EventTypeTestBuilder builder = EventTypeTestBuilder.builder();
+        final EventType oldEventType = builder.build();
+        final EventType newEventType = builder.build();
+
+        Mockito.doReturn(Optional.empty()).when(evolutionConstraint).validate(oldEventType, newEventType);
+        final EventType eventType = service.evolve(oldEventType, newEventType);
+        Assert.assertEquals(eventType.getSchema().getCreatedAt(), oldEventType.getSchema().getCreatedAt());
+    }
+
+    @Test
     public void whenPatchChangesBumpVersion() {
         final EventTypeTestBuilder builder = EventTypeTestBuilder.builder();
         final EventType oldEventType = builder.build();

--- a/core-common/src/main/java/org/zalando/nakadi/domain/EventType.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/EventType.java
@@ -18,6 +18,14 @@ public class EventType extends EventTypeBase {
         this.setSchema(new EventTypeSchema(eventType.getSchema(), version, updatedAt));
     }
 
+    public EventType(final EventTypeBase eventType, final DateTime createdAt, final DateTime updatedAt,
+                     final EventTypeSchema eventTypeSchema) {
+        super(eventType);
+        this.updatedAt = updatedAt;
+        this.createdAt = createdAt;
+        this.setSchema(eventTypeSchema);
+    }
+
     public EventType() {
         super();
     }


### PR DESCRIPTION
Don't change schema created at time if nothing changes for schema when event type is updated.
> Zalando ticket : ARUHA-2837 (only if appropriate)

Even without no changes to the schema, event type updates would change the schema `created_at` time without version upgrade.