### PR TITLE
Add tracing span for fetch stats request

### DIFF
--- a/api-metastore/src/main/java/org/zalando/nakadi/controller/SubscriptionController.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/controller/SubscriptionController.java
@@ -81,7 +81,7 @@ public class SubscriptionController {
             NoSuchEventTypeException, NoSuchSubscriptionException, ServiceTemporarilyUnavailableException {
         final Span statsSpan = TracingService.extractSpan(request, "fetch_stats")
                 .setTag("subscription_id", subscriptionId)
-                .setTag("time_lag", showTimeLag);
+                .setTag("show_time_lag", showTimeLag);
         final StatsMode statsMode = showTimeLag ? StatsMode.TIMELAG : StatsMode.NORMAL;
         return subscriptionService.getSubscriptionStat(subscriptionId, statsMode, statsSpan);
     }

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/SubscriptionService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/SubscriptionService.java
@@ -2,6 +2,7 @@ package org.zalando.nakadi.service;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.opentracing.Span;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -245,7 +246,8 @@ public class SubscriptionService {
     }
 
     public ItemsWrapper<SubscriptionEventTypeStats> getSubscriptionStat(final String subscriptionId,
-                                                                        final StatsMode statsMode)
+                                                                        final StatsMode statsMode,
+                                                                        final Span span)
             throws InconsistentStateException, NoSuchEventTypeException,
             NoSuchSubscriptionException, ServiceTemporarilyUnavailableException {
         final Subscription subscription;
@@ -253,6 +255,7 @@ public class SubscriptionService {
             subscription = subscriptionRepository.getSubscription(subscriptionId);
             authorizationValidator.authorizeSubscriptionView(subscription);
         } catch (final ServiceTemporarilyUnavailableException ex) {
+            TracingService.logErrorInSpan(span, ex.getMessage());
             throw new InconsistentStateException(ex.getMessage());
         }
         final List<SubscriptionEventTypeStats> subscriptionStat = createSubscriptionStat(subscription, statsMode);

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/SubscriptionService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/SubscriptionService.java
@@ -255,7 +255,7 @@ public class SubscriptionService {
             subscription = subscriptionRepository.getSubscription(subscriptionId);
             authorizationValidator.authorizeSubscriptionView(subscription);
         } catch (final ServiceTemporarilyUnavailableException ex) {
-            TracingService.logErrorInSpan(span, ex.getMessage());
+            TracingService.logErrorInSpan(span, ex);
             throw new InconsistentStateException(ex.getMessage());
         }
         final List<SubscriptionEventTypeStats> subscriptionStat = createSubscriptionStat(subscription, statsMode);

--- a/core-common/src/main/java/org/zalando/nakadi/service/TracingService.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/TracingService.java
@@ -24,6 +24,14 @@ public class TracingService {
         }
     }
 
+    public static void logErrorInSpan(final Span span, final Exception ex) {
+        if (ex.getMessage() != null) {
+            span.log(ImmutableMap.of("error.description", ex.getMessage()));
+        } else {
+            span.log(ImmutableMap.of("error.description", ex.toString()));
+        }
+    }
+
     public static void logStreamCloseReason(final Span span, final String error) {
         if (error != null) {
             span.log(ImmutableMap.of("stream.close.reason", error));


### PR DESCRIPTION
Add span for request to fetch subscription statistics. Note that closing of the span is handled in [TracingFilter.java](https://github.com/zalando/nakadi/blob/0f8127af2272d106e1edb6fdba7f3708629097d5/core-common/src/main/java/org/zalando/nakadi/filters/TracingFilter.java#L134). Error code handling for the span is also handled [here](https://github.com/zalando/nakadi/blob/0f8127af2272d106e1edb6fdba7f3708629097d5/core-common/src/main/java/org/zalando/nakadi/filters/TracingFilter.java#L128).