### PR TITLE
ARUHA-2882: PartitionData generated a lot short lived objects

### DIFF
--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -72,6 +72,7 @@ public class StreamingContext implements SubscriptionStreamer {
     private final AutocommitSupport autocommitSupport;
     private final Span currentSpan;
     private final String kpiDataStreamedEventType;
+    private final CursorOperationsService cursorOperationsService;
 
     private final long kpiCollectionFrequencyMs;
 
@@ -111,6 +112,7 @@ public class StreamingContext implements SubscriptionStreamer {
         this.kpiCollectionFrequencyMs = builder.kpiCollectionFrequencyMs;
         this.streamMemoryLimitBytes = builder.streamMemoryLimitBytes;
         this.currentSpan = builder.currentSpan;
+        this.cursorOperationsService = builder.cursorOperationsService;
     }
 
     public Span getCurrentSpan() {
@@ -167,6 +169,10 @@ public class StreamingContext implements SubscriptionStreamer {
 
     public long getKpiCollectionFrequencyMs() {
         return kpiCollectionFrequencyMs;
+    }
+
+    public CursorOperationsService getCursorOperationsService() {
+        return cursorOperationsService;
     }
 
     @Override

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -670,7 +670,9 @@ class StreamingState extends State {
                 cursor,
                 LoggerFactory.getLogger(LogPathBuilder.build(
                         getContext().getSubscription().getId(), getSessionId(), String.valueOf(partition.getKey()))),
-                System.currentTimeMillis(), this.getContext().getParameters().batchTimespan
+                System.currentTimeMillis(),
+                this.getContext().getParameters().batchTimespan,
+                getContext().getCursorOperationsService()
         );
 
         offsets.put(partition.getKey(), pd);

--- a/api-consumption/src/test/java/org/zalando/nakadi/service/subscription/state/StreamingStateTest.java
+++ b/api-consumption/src/test/java/org/zalando/nakadi/service/subscription/state/StreamingStateTest.java
@@ -23,6 +23,7 @@ import org.zalando.nakadi.repository.EventConsumer;
 import org.zalando.nakadi.repository.TopicRepository;
 import org.zalando.nakadi.security.Client;
 import org.zalando.nakadi.service.CursorConverter;
+import org.zalando.nakadi.service.CursorOperationsService;
 import org.zalando.nakadi.service.subscription.StreamParameters;
 import org.zalando.nakadi.service.subscription.StreamParametersTest;
 import org.zalando.nakadi.service.subscription.StreamingContext;
@@ -91,6 +92,8 @@ public class StreamingStateTest {
         when(contextMock.getZkClient()).thenReturn(zkMock);
         when(contextMock.getCursorConverter()).thenReturn(cursorConverter);
         when(contextMock.isConnectionReady()).thenReturn(true);
+        when(contextMock.getCursorOperationsService())
+                .thenReturn(Mockito.mock(CursorOperationsService.class));
 
         final Client client = mock(Client.class);
         when(client.getClientId()).thenReturn("consumingAppId");


### PR DESCRIPTION
After having a look at heap dump, it is clear where the problem is:
![VisualVM 1 4 4 2020-05-11 16-02-50](https://user-images.githubusercontent.com/4863810/82043665-4981b500-96ac-11ea-83b3-55120c01c725.png)
![Eclipse Memory Analyzer 2020-05-11 16-39-19](https://user-images.githubusercontent.com/4863810/82043671-4b4b7880-96ac-11ea-879b-90e38cb94a93.png)

Nakadi consumption uses TreeSet (PartitionData.allCursorsOrdered) to calculate the distance between cursors. Every time cursors are committed or a decision is made to send more data to the client a new subset is created, and once decision is made objects are thrown away, which happens all the time during streaming.

https://github.com/zalando/nakadi/blob/abbabfb0b5598352294bf488a4c852987e51a664/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java#L218

https://github.com/zalando/nakadi/blob/abbabfb0b5598352294bf488a4c852987e51a664/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java#L252

Changing a way to calculate distance will bring performance improvement in reduction of 30%-40% CPU usage on consumption stack as experiments showed.

**I would like first check the correctness, and then execute a performance test**
