### PR TITLE
create meter to track number of short circuiting per broker

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -1,5 +1,6 @@
 package org.zalando.nakadi.repository.kafka;
 
+import com.codahale.metrics.MetricRegistry;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.PartitionInfo;
@@ -242,7 +243,7 @@ public class KafkaRepositoryAT extends BaseAT {
         for (int i = 0; i < 10; i++) {
             assertThat(items.get(i).getResponse().getPublishingStatus(), equalTo(EventPublishingStatus.SUBMITTED));
         }
-}
+    }
 
     private Map<String, List<PartitionInfo>> getAllTopics() {
         final KafkaConsumer<String, String> kafkaConsumer = kafkaHelper.createConsumer();
@@ -264,12 +265,16 @@ public class KafkaRepositoryAT extends BaseAT {
                 .when(factory)
                 .takeProducer();
 
-        return new KafkaTopicRepository(kafkaZookeeper,
-                factory,
-                nakadiSettings,
-                kafkaSettings,
-                zookeeperSettings,
-                kafkaTopicConfigFactory, kafkaLocationManager);
+        return new KafkaTopicRepository.Builder()
+                .setKafkaZookeeper(kafkaZookeeper)
+                .setKafkaFactory(factory)
+                .setNakadiSettings(nakadiSettings)
+                .setKafkaSettings(kafkaSettings)
+                .setZookeeperSettings(zookeeperSettings)
+                .setKafkaTopicConfigFactory(kafkaTopicConfigFactory)
+                .setKafkaLocationManager(kafkaLocationManager)
+                .setMetricRegistry(new MetricRegistry())
+                .build();
     }
 
 }

--- a/core-common/src/main/java/org/zalando/nakadi/repository/KafkaRepositoryCreator.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/KafkaRepositoryCreator.java
@@ -6,9 +6,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.zalando.nakadi.config.NakadiSettings;
 import org.zalando.nakadi.domain.NakadiCursor;
+import org.zalando.nakadi.domain.Timeline;
 import org.zalando.nakadi.domain.storage.KafkaConfiguration;
 import org.zalando.nakadi.domain.storage.Storage;
-import org.zalando.nakadi.domain.Timeline;
 import org.zalando.nakadi.exceptions.runtime.NakadiRuntimeException;
 import org.zalando.nakadi.exceptions.runtime.TopicRepositoryException;
 import org.zalando.nakadi.repository.kafka.KafkaFactory;
@@ -63,9 +63,17 @@ public class KafkaRepositoryCreator implements TopicRepositoryCreator {
             final KafkaFactory kafkaFactory =
                     new KafkaFactory(new KafkaLocationManager(zooKeeperHolder, kafkaSettings), metricRegistry);
             final KafkaZookeeper zk = new KafkaZookeeper(zooKeeperHolder, objectMapper);
-            final KafkaTopicRepository kafkaTopicRepository = new KafkaTopicRepository(zk,
-                    kafkaFactory, nakadiSettings, kafkaSettings, zookeeperSettings, kafkaTopicConfigFactory,
-                    kafkaLocationManager);
+            final KafkaTopicRepository kafkaTopicRepository =
+                    new KafkaTopicRepository.Builder()
+                            .setKafkaZookeeper(zk)
+                            .setKafkaFactory(kafkaFactory)
+                            .setNakadiSettings(nakadiSettings)
+                            .setKafkaSettings(kafkaSettings)
+                            .setZookeeperSettings(zookeeperSettings)
+                            .setKafkaTopicConfigFactory(kafkaTopicConfigFactory)
+                            .setKafkaLocationManager(kafkaLocationManager)
+                            .setMetricRegistry(metricRegistry)
+                            .build();
             // check that it does work
             kafkaTopicRepository.listTopics();
             return kafkaTopicRepository;

--- a/core-services/src/test/java/org/zalando/nakadi/service/CursorOperationsServiceTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/CursorOperationsServiceTest.java
@@ -1,5 +1,6 @@
 package org.zalando.nakadi.service;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Lists;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
@@ -310,14 +311,17 @@ public class CursorOperationsServiceTest {
         }
         Mockito.when(timeline.isActive()).thenReturn(null == latestOffset);
 
-        final TopicRepository repository = new KafkaTopicRepository(
-                Mockito.mock(KafkaZookeeper.class),
-                Mockito.mock(KafkaFactory.class),
-                Mockito.mock(NakadiSettings.class),
-                Mockito.mock(KafkaSettings.class),
-                Mockito.mock(ZookeeperSettings.class),
-                Mockito.mock(KafkaTopicConfigFactory.class),
-                Mockito.mock(KafkaLocationManager.class));
+        final TopicRepository repository = new KafkaTopicRepository.Builder()
+                .setKafkaZookeeper(Mockito.mock(KafkaZookeeper.class))
+                .setKafkaFactory(Mockito.mock(KafkaFactory.class))
+                .setNakadiSettings(Mockito.mock(NakadiSettings.class))
+                .setKafkaSettings(Mockito.mock(KafkaSettings.class))
+                .setZookeeperSettings(Mockito.mock(ZookeeperSettings.class))
+                .setKafkaTopicConfigFactory(Mockito.mock(KafkaTopicConfigFactory.class))
+                .setKafkaLocationManager(Mockito.mock(KafkaLocationManager.class))
+                .setMetricRegistry(new MetricRegistry())
+                .build();
+
         Mockito.when(timelineService.getTopicRepository(timeline)).thenReturn(repository);
         return timeline;
     }


### PR DESCRIPTION
# One-line summary
create meter to track number of short circuiting per broker

example look of the metric
```
"meters": {
    "hystrix.short.circuit.{BROKER_ID}_{BROKER_IP}": {
      "count": 16,
      "m1_rate": 0.38728607837966667,
      "units": "events/second"
    }
  }
```