### PR TITLE
Allow for type narrowing under forward compatibility mode

### DIFF
--- a/api-metastore/src/main/java/org/zalando/nakadi/validation/schema/diff/SchemaDiff.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/validation/schema/diff/SchemaDiff.java
@@ -99,7 +99,7 @@ public class SchemaDiff {
         });
     }
 
-    private static boolean typeNarrowed(Schema originalIn, Schema updateIn) {
+    private static boolean typeNarrowed(final Schema originalIn, final Schema updateIn) {
         return originalIn instanceof EmptySchema && !(updateIn instanceof EmptySchema);
     }
 

--- a/api-metastore/src/main/java/org/zalando/nakadi/validation/schema/diff/SchemaDiff.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/validation/schema/diff/SchemaDiff.java
@@ -19,6 +19,7 @@ import static org.zalando.nakadi.domain.SchemaChange.Type.ID_CHANGED;
 import static org.zalando.nakadi.domain.SchemaChange.Type.SCHEMA_REMOVED;
 import static org.zalando.nakadi.domain.SchemaChange.Type.TITLE_CHANGED;
 import static org.zalando.nakadi.domain.SchemaChange.Type.TYPE_CHANGED;
+import static org.zalando.nakadi.domain.SchemaChange.Type.TYPE_NARROWED;
 
 public class SchemaDiff {
     public List<SchemaChange> collectChanges(final Schema original, final Schema update) {
@@ -55,6 +56,9 @@ public class SchemaDiff {
             if (originalIn instanceof EmptySchema && updateIn instanceof ObjectSchema) {
                 original = replaceWithEmptyObjectSchema(originalIn);
                 update = updateIn;
+            } else if (typeNarrowed(originalIn, updateIn)) {
+                state.addChange(TYPE_NARROWED);
+                return;
             } else {
                 state.addChange(TYPE_CHANGED);
                 return;
@@ -93,6 +97,10 @@ public class SchemaDiff {
                 ReferenceSchemaDiff.recursiveCheck((ReferenceSchema) original, (ReferenceSchema) update, state);
             }
         });
+    }
+
+    private static boolean typeNarrowed(Schema originalIn, Schema updateIn) {
+        return originalIn instanceof EmptySchema && !(updateIn instanceof EmptySchema);
     }
 
     private static Schema replaceWithEmptyObjectSchema(final Schema in) {

--- a/api-metastore/src/test/resources/invalid-schema-evolution-examples.json
+++ b/api-metastore/src/test/resources/invalid-schema-evolution-examples.json
@@ -40,6 +40,15 @@
     "errors": ["TYPE_CHANGED #/"]
   },
   {
+    "description": "Narrowing type definition",
+    "original_schema": {
+    },
+    "update_schema": {
+      "type": "string"
+    },
+    "errors": ["TYPE_NARROWED #/"]
+  },
+  {
     "description": "Do not allow changes to minLength string schema",
     "original_schema": {
       "type": "string",

--- a/core-common/src/main/java/org/zalando/nakadi/domain/SchemaChange.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/SchemaChange.java
@@ -8,6 +8,7 @@ public class SchemaChange {
         PROPERTIES_ADDED(Version.Level.MINOR),
         SCHEMA_REMOVED(Version.Level.MAJOR),
         TYPE_CHANGED(Version.Level.MAJOR),
+        TYPE_NARROWED(Version.Level.MINOR, Version.Level.MAJOR),
         NUMBER_OF_ITEMS_CHANGED(Version.Level.MAJOR),
         PROPERTY_REMOVED(Version.Level.MAJOR),
         DEPENDENCY_ARRAY_CHANGED(Version.Level.MAJOR),

--- a/docs/_documentation/using_event-types.md
+++ b/docs/_documentation/using_event-types.md
@@ -117,6 +117,7 @@ Supported changes:
 2. addition of new attributes, both optional and required.
 3. marking attributes as required.
 4. change additionalProperties from true to object.
+5. narrow schema type definition from empty to specific 
 
 Under this mode event validation accepts events with fields not
 declared in the schema. In other words, it's not necessary to specify


### PR DESCRIPTION
Changing a schema from empty `{}` to something that is not empty
`{type: string}` should be seen as a type narrowing operation that
doesn't break consumers of forward compatible event types, given the set of events accepted by the
narrowed definition is a subset of the original events. That means
that such a change should be allowed in this direction.

It could be argued that other changes are also type narrowing, as for example `{type:[string,null]}` to `{type:[string]}`, but detecting all possible "type narrowing" changes is a complex problem as it could be posed in a more formal way as "the new schema accepts only a subset of events from the previous schema" which is a computationally difficult problem ( I found some papers years ago). So this is an approximation that handles a specific case that is of significant value for us and fixes a bug in Nakadi SQL automatic schema evolution.

For fully compatible mode that is still not allowed as it means that
consumers developed based on the latest schema would not be able to
read events published under the oldest schema, contradicting the
definition of fully compatible.
