### PR TITLE
Log full message instead of unusable one for event validation

### DIFF
--- a/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventPublisher.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventPublisher.java
@@ -142,7 +142,8 @@ public class EventPublisher {
             return ok(batch);
         } catch (final EventValidationException e) {
             LOG.info(
-                    "Event validation error: {}",
+                    "Event type {} validation error: {}",
+                    eventTypeName,
                     Optional.ofNullable(e.getMessage()).map(s -> s.replaceAll("\n", "; ")).orElse(null)
             );
             return aborted(EventPublishingStep.VALIDATING, batch);


### PR DESCRIPTION
Log full message instead of unusable one for event validation