### PR TITLE
Fixing validation in api-cursors

### DIFF
--- a/api-cursors/build.gradle
+++ b/api-cursors/build.gradle
@@ -44,6 +44,9 @@ dependencies {
         exclude module: 'spring-boot-starter-tomcat'
     }
 
+    // validation
+    compile("org.springframework.boot:spring-boot-starter-validation")
+
     // oauth
     compile('org.springframework.security.oauth:spring-security-oauth2:2.3.5.RELEASE') {
         exclude module: 'spring-webmvc'

--- a/api-cursors/src/test/java/org/zalando/nakadi/controller/CursorsControllerTest.java
+++ b/api-cursors/src/test/java/org/zalando/nakadi/controller/CursorsControllerTest.java
@@ -188,7 +188,7 @@ public class CursorsControllerTest {
     public void whenCommitCursorWithoutEventTypeThenUnprocessableEntity() throws Exception {
         checkForProblem(
                 postCursorsString("{\"items\":[{\"offset\":\"0\",\"partition\":\"0\",\"cursor_token\":\"x\"}]}"),
-                TestUtils.invalidProblem("items[0].event_type", "may not be null"));
+                TestUtils.invalidProblem("items[0].event_type", "must not be null"));
     }
 
     @Test

--- a/api-metastore/build.gradle
+++ b/api-metastore/build.gradle
@@ -28,6 +28,9 @@ dependencies {
 
     compile 'org.json:json:20180130'
 
+    // validation
+    compile("org.springframework.boot:spring-boot-starter-validation")
+
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile('org.junit.jupiter:junit-jupiter-api:5.5.2') {
         exclude module: "hamcrest-core"

--- a/api-metastore/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
@@ -202,7 +202,7 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
         final EventType invalidEventType = TestUtils.buildDefaultEventType();
         invalidEventType.setSchema(null);
 
-        final Problem expectedProblem = TestUtils.invalidProblem("schema", "may not be null");
+        final Problem expectedProblem = TestUtils.invalidProblem("schema", "must not be null");
         postETAndExpect422WithProblem(invalidEventType, expectedProblem);
     }
 
@@ -211,7 +211,7 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
         final EventType invalidEventType = TestUtils.buildDefaultEventType();
         invalidEventType.setName(null);
 
-        final Problem expectedProblem = TestUtils.invalidProblem("name", "may not be null");
+        final Problem expectedProblem = TestUtils.invalidProblem("name", "must not be null");
         postETAndExpect422WithProblem(invalidEventType, expectedProblem);
     }
 
@@ -222,13 +222,13 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
 
         jsonObject.remove("category");
 
-        final Problem expectedProblem = TestUtils.invalidProblem("category", "may not be null");
+        final Problem expectedProblem = TestUtils.invalidProblem("category", "must not be null");
         postETAndExpect422WithProblem(jsonObject.toString(), expectedProblem);
     }
 
     @Test
     public void whenPostWithNoSchemaSchemaThenReturn422() throws Exception {
-        final Problem expectedProblem = TestUtils.invalidProblem("schema.schema", "may not be null");
+        final Problem expectedProblem = TestUtils.invalidProblem("schema.schema", "must not be null");
 
         final String eventType = "{\"category\": \"data\", \"owning_application\": \"blah-app\", "
                 + "\"name\": \"blah-event-type\", \"schema\": { \"type\": \"JSON_SCHEMA\" }}";
@@ -448,11 +448,11 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
                 .andExpect(status().isUnprocessableEntity())
                 .andExpect(content().contentType("application/problem+json"))
                 .andExpect(content().string(
-                        containsString("Field \\\"authorization.admins\\\" may not be null")))
+                        containsString("Field \\\"authorization.admins\\\" must not be null")))
                 .andExpect(content().string(
-                        containsString("Field \\\"authorization.readers\\\" may not be null")))
+                        containsString("Field \\\"authorization.readers\\\" must not be null")))
                 .andExpect(content().string(
-                        containsString("Field \\\"authorization.writers\\\" may not be null")));
+                        containsString("Field \\\"authorization.writers\\\" must not be null")));
     }
 
     @Test
@@ -482,9 +482,9 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
                 .andExpect(status().isUnprocessableEntity())
                 .andExpect(content().contentType("application/problem+json"))
                 .andExpect(content().string(
-                        containsString("Field \\\"authorization.readers[0].data_type\\\" may not be null")))
+                        containsString("Field \\\"authorization.readers[0].data_type\\\" must not be null")))
                 .andExpect(content().string(
-                        containsString("Field \\\"authorization.writers[0].value\\\" may not be null")));
+                        containsString("Field \\\"authorization.writers[0].value\\\" must not be null")));
     }
 
     @Test
@@ -665,7 +665,7 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
     public void whenPersistencyErrorThen500() throws Exception {
         final Problem expectedProblem = Problem.valueOf(INTERNAL_SERVER_ERROR);
 
-        doThrow(InternalNakadiException.class).when(eventTypeRepository).saveEventType(any(EventType.class));
+        doThrow(InternalNakadiException.class).when(eventTypeRepository).saveEventType(any(EventTypeBase.class));
 
         postEventType(TestUtils.buildDefaultEventType()).andExpect(status().isInternalServerError())
                 .andExpect(content().contentType("application/problem+json")).andExpect(
@@ -681,7 +681,7 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
 
         postEventType(et).andExpect(status().isCreated()).andExpect(content().string(""));
 
-        verify(eventTypeRepository, times(1)).saveEventType(any(EventType.class));
+        verify(eventTypeRepository, times(1)).saveEventType(any(EventTypeBase.class));
         verify(timelineService, times(1)).createDefaultTimeline(any(), anyInt());
     }
 
@@ -698,7 +698,7 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
                 .andExpect(content().contentType("application/problem+json")).andExpect(content().string(
                 matchesProblem(expectedProblem)));
 
-        verify(eventTypeRepository, times(1)).saveEventType(any(EventType.class));
+        verify(eventTypeRepository, times(1)).saveEventType(any(EventTypeBase.class));
         verify(timelineService, times(1)).createDefaultTimeline(any(), anyInt());
         verify(eventTypeRepository, times(1)).removeEventType(et.getName());
     }
@@ -710,7 +710,7 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
 
         jsonObject.remove("category");
 
-        final Problem expectedProblem = TestUtils.invalidProblem("category", "may not be null");
+        final Problem expectedProblem = TestUtils.invalidProblem("category", "must not be null");
 
         putEventType(jsonObject.toString(), invalidEventType.getName()).andExpect(status().isUnprocessableEntity())
                 .andExpect(content().contentType(

--- a/api-metastore/src/test/java/org/zalando/nakadi/controller/PostSubscriptionControllerTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/controller/PostSubscriptionControllerTest.java
@@ -144,7 +144,7 @@ public class PostSubscriptionControllerTest {
         final SubscriptionBase subscriptionBase = RandomSubscriptionBuilder.builder()
                 .withOwningApplication(null)
                 .buildSubscriptionBase();
-        final Problem expectedProblem = TestUtils.invalidProblem("owning_application", "may not be null");
+        final Problem expectedProblem = TestUtils.invalidProblem("owning_application", "must not be null");
         checkForProblem(postSubscription(subscriptionBase), expectedProblem);
     }
 
@@ -170,7 +170,7 @@ public class PostSubscriptionControllerTest {
     @Test
     public void whenEventTypesIsNullThenUnprocessableEntity() throws Exception {
         final String subscription = "{\"owning_application\":\"app\",\"consumer_group\":\"myGroup\"}";
-        final Problem expectedProblem = TestUtils.invalidProblem("event_types", "may not be null");
+        final Problem expectedProblem = TestUtils.invalidProblem("event_types", "must not be null");
         checkForProblem(postSubscriptionAsJson(subscription), expectedProblem);
     }
 

--- a/app/src/main/java/org/zalando/nakadi/config/WebConfig.java
+++ b/app/src/main/java/org/zalando/nakadi/config/WebConfig.java
@@ -18,7 +18,6 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 import org.zalando.nakadi.filters.TracingFilter;
 import org.zalando.nakadi.plugin.api.authz.AuthorizationService;
 import org.zalando.nakadi.security.ClientResolver;


### PR DESCRIPTION
With Spring boot 2.3, we need to explicity add
spring-boot-starter-validation for @Valid to work properly