### PR TITLE
ARUHA-2915: scripted out nakadi build and start

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import java.util.concurrent.TimeUnit
-
 subprojects {
     buildscript {
         ext {
@@ -56,68 +54,24 @@ subprojects {
     }
 }
 
-task testInitNakadi(type: Exec) {
-    environment "SPRING_PROFILES_ACTIVE", "acceptanceTest"
-    commandLine "bash", "-c", "docker-compose up -d --build"
-    doLast {
-        println "Waiting for Nakadi to start up"
-        long start = System.currentTimeMillis()
-        waitForNakadi()
-        println "Nakadi is fully started in " + (System.currentTimeMillis() - start) + " ms"
-    }
+task startNakadi(type: Exec) {
+    commandLine "bash", "-c", "./nakadi.sh start-nakadi"
 }
 
-task initNakadi(type: Exec) {
-    environment "SPRING_PROFILES_ACTIVE", "local"
-    commandLine "bash", "-c", "docker-compose up -d --build"
-    doLast {
-        println "Waiting for Nakadi to start up"
-        long start = System.currentTimeMillis()
-        waitForNakadi()
-        println "Nakadi is fully started in " + (System.currentTimeMillis() - start) + " ms"
-    }
-}
-
-task startNakadi(type: GradleBuild) {
-    tasks = ['clean', 'app:bootJar', 'initNakadi']
-}
-
-task startNakadiForTests(type: GradleBuild) {
-    tasks = ['clean', 'app:bootJar', 'testInitNakadi']
-}
-
-
-task fullAcceptanceTest(type: GradleBuild) {
-    tasks = ['startNakadiForTests', ':acceptance-test:acceptanceTest', 'stopNakadi']
+task fullAcceptanceTest(type: Exec) {
+    commandLine "bash", "-c", "./nakadi.sh acceptance-tests"
 }
 
 task stopNakadi(type: Exec) {
-    commandLine "bash", "-c", "docker-compose down"
-}
-
-def waitForNakadi() {
-    // wait till application is up (health check is successful)
-    int result = 1
-    while (result != 0) {
-        result = execAndWait('curl http://localhost:8080/health')
-        sleep(1000L)
-    }
-}
-
-def execAndWait(command, timeoutInSeconds = 15) {
-    println "Running command: " + command
-    ProcessBuilder pb = new ProcessBuilder(["bash", "-c", command]).inheritIO()
-    Process proc = pb.start()
-    proc.waitFor(timeoutInSeconds, TimeUnit.SECONDS)
-    return proc.exitValue()
+    commandLine "bash", "-c", "./nakadi.sh stop-nakadi"
 }
 
 task startStorages(type: Exec) {
-    commandLine "bash", "-c", "docker-compose up -d postgres zookeeper kafka"
+    commandLine "bash", "-c", "./nakadi.sh start-storages"
 }
 
 task stopStorages(type: Exec) {
-    commandLine "bash", "-c", "docker-compose down"
+    commandLine "bash", "-c", "./nakadi.sh stop-storages"
 }
 
 task checkstyle {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Jul 06 11:38:21 CEST 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/nakadi.sh
+++ b/nakadi.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+function waitForNakadi() {
+  echo "Waiting for Nakadi to start up"
+  while True; do
+    res=$(curl -s -w "%{http_code}" -o /dev/null http://localhost:8080/health)
+    if ((res == 200)); then
+      echo "Nakadi is fully started"
+      return
+    fi
+    echo "Nakadi boots up"
+    sleep 5
+  done
+}
+
+function startNakadi() {
+  export SPRING_PROFILES_ACTIVE=local
+  docker-compose up -d --build
+  waitForNakadi
+}
+
+function stopNakadi() {
+  docker-compose down
+}
+
+function startStorages() {
+  docker-compose up -d postgres zookeeper kafka
+}
+
+function stopStorages() {
+  docker-compose down
+}
+
+function acceptanceTests() {
+  export SPRING_PROFILES_ACTIVE=acceptanceTest
+  docker-compose up -d --build
+  waitForNakadi
+  ./gradlew :acceptance-test:acceptanceTest
+  docker-compose down
+}
+
+function buildNakadi() {
+  ./gradlew clean
+  ./gradlew :app:bootJar
+}
+
+function help() {
+  echo "Usage: ./nakadi.sh COMMAND"
+  echo ""
+  echo "Commands:"
+  echo "  start-nakadi       build Nakadi and start docker-compose services: nakadi, postgresql, zookeeper and kafka"
+  echo "  stop-nakadi        shutdown docker-compose services"
+  echo "  start-storages     start docker-compose services: postgres, zookeeper and kafka (useful for development purposes)"
+  echo "  stop-storages      shutdown docker-compose services"
+  echo "  acceptance-tests   start Nakadi configured for acceptance tests and run acceptance tests"
+  exit 1
+}
+
+COMMAND="${1}"
+case $COMMAND in
+start-nakadi)
+  buildNakadi
+  startNakadi
+  ;;
+stop-nakadi)
+  stopNakadi
+  ;;
+start-storages)
+  startStorages
+  ;;
+stop-storages)
+  stopStorages
+  ;;
+acceptance-tests)
+  buildNakadi
+  acceptanceTests
+  ;;
+*)
+  help
+  ;;
+esac


### PR DESCRIPTION
# One-line summary
There are complications while adopting new gradle version. Moving logic for build and start of Nakadi to bash script to avoid changes in build gradle file functions whenever dsl changes.