### PR TITLE
Copying api to /zalando-apis directory as well

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ MAINTAINER Team Aruha, team-aruha@zalando.de
 WORKDIR /
 ADD app/build/libs/app.jar nakadi.jar
 COPY app/api/nakadi-event-bus-api.yaml api/nakadi-event-bus-api.yaml
+COPY app/api/nakadi-event-bus-api.yaml /zalando-apis/nakadi-event-bus-api.yaml
+
 
 EXPOSE 8080
 


### PR DESCRIPTION
According to API guild: 

> An API is published by copying its Open API specification into the reserved /zalando-apis directory of the deployment artifact used to deploy the provisioning service. The directory must only contain self-contained YAML files that each describe one API (exception see MUST only use durable and immutable remote references). We prefer this deployment artifact-based method over the past (now legacy) .well-known/schema-discovery service endpoint-based publishing process, that we only support for backward compatibility reasons.

As we removed twintip, we are adding the API to `/zalando-apis` 