### PR TITLE
Replace Hikari by Tomcat pool

### DIFF
--- a/api-consumption/build.gradle
+++ b/api-consumption/build.gradle
@@ -91,7 +91,10 @@ dependencies {
     compile "io.dropwizard.metrics:metrics-servlets:$dropwizardVersion"
     compile "io.dropwizard.metrics:metrics-jvm:$dropwizardVersion"
 
-    compile "org.springframework.boot:spring-boot-starter-jdbc"
+    compile("org.springframework.boot:spring-boot-starter-jdbc") {
+        exclude module: 'HikariCP'
+    }
+    compile 'org.apache.tomcat:tomcat-jdbc'
     compile 'org.postgresql:postgresql:42.2.5'
 
     compile('com.github.everit-org.json-schema:org.everit.json.schema:1.8.0') {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,7 +88,10 @@ dependencies {
     }
 
     // storage
-    compile "org.springframework.boot:spring-boot-starter-jdbc"
+    compile("org.springframework.boot:spring-boot-starter-jdbc") {
+        exclude module: 'HikariCP'
+    }
+    compile 'org.apache.tomcat:tomcat-jdbc'
     compile 'org.postgresql:postgresql:42.2.5'
 
     compile 'org.springframework.cloud:spring-cloud-starter-netflix-hystrix:2.2.3.RELEASE'

--- a/app/src/test/java/org/zalando/nakadi/security/AuthenticationTest.java
+++ b/app/src/test/java/org/zalando/nakadi/security/AuthenticationTest.java
@@ -55,6 +55,7 @@ import org.zalando.stups.oauth2.spring.security.expression.ExtendedOAuth2WebSecu
 
 import javax.annotation.PostConstruct;
 import javax.servlet.Filter;
+import javax.sql.DataSource;
 import java.security.MessageDigest;
 import java.util.HashMap;
 import java.util.List;
@@ -157,6 +158,12 @@ public abstract class AuthenticationTest {
 
         public ExtendedOAuth2WebSecurityExpressionHandler extendedOAuth2WebSecurityExpressionHandler() {
             return mock(ExtendedOAuth2WebSecurityExpressionHandler.class);
+        }
+
+        @Bean
+        @Primary
+        public DataSource mockDataSource() {
+            return mock(DataSource.class);
         }
 
         @Bean
@@ -294,7 +301,7 @@ public abstract class AuthenticationTest {
 
         @Bean
         @Primary
-        public PartitionsCalculator mockPartitionsCalculator(){
+        public PartitionsCalculator mockPartitionsCalculator() {
             return mock(PartitionsCalculator.class);
         }
     }

--- a/core-common/build.gradle
+++ b/core-common/build.gradle
@@ -91,7 +91,10 @@ dependencies {
     compile "io.dropwizard.metrics:metrics-servlets:$dropwizardVersion"
     compile "io.dropwizard.metrics:metrics-jvm:$dropwizardVersion"
 
-    compile "org.springframework.boot:spring-boot-starter-jdbc"
+    compile("org.springframework.boot:spring-boot-starter-jdbc") {
+        exclude module: 'HikariCP'
+    }
+    compile 'org.apache.tomcat:tomcat-jdbc'
     compile 'org.postgresql:postgresql:42.2.5'
 
     compile('com.github.everit-org.json-schema:org.everit.json.schema:1.8.0') {

--- a/core-metastore/build.gradle
+++ b/core-metastore/build.gradle
@@ -90,7 +90,10 @@ dependencies {
     compile "io.dropwizard.metrics:metrics-servlets:$dropwizardVersion"
     compile "io.dropwizard.metrics:metrics-jvm:$dropwizardVersion"
 
-    compile "org.springframework.boot:spring-boot-starter-jdbc"
+    compile("org.springframework.boot:spring-boot-starter-jdbc") {
+        exclude module: 'HikariCP'
+    }
+    compile 'org.apache.tomcat:tomcat-jdbc'
     compile 'org.postgresql:postgresql:42.2.5'
 
     compile('com.github.everit-org.json-schema:org.everit.json.schema:1.8.0') {

--- a/core-services/build.gradle
+++ b/core-services/build.gradle
@@ -91,7 +91,10 @@ dependencies {
     compile "io.dropwizard.metrics:metrics-servlets:$dropwizardVersion"
     compile "io.dropwizard.metrics:metrics-jvm:$dropwizardVersion"
 
-    compile "org.springframework.boot:spring-boot-starter-jdbc"
+    compile("org.springframework.boot:spring-boot-starter-jdbc") {
+        exclude module: 'HikariCP'
+    }
+    compile 'org.apache.tomcat:tomcat-jdbc'
     compile 'org.postgresql:postgresql:42.2.5'
 
     compile('com.github.everit-org.json-schema:org.everit.json.schema:1.8.0') {


### PR DESCRIPTION
In upgrading to spring boot 2 the default db pool was changed from
tomcat to hikari.

This was a non planned change and in the past we had problems with
hikari, leading us to sticking to tomcat's
https://github.com/zalando/nakadi/commit/8557790b4b5d861f56a3c44e8efb6deac8365236

Since hikari was also not configured, we end up running out of
connections on staging so we need to teardown staging, release a few
connections and then deploy this fix.

This change restores tomcat pool.
