### PR TITLE
Introducing ThreadPoolTaskExecutor for Async support

### DIFF
--- a/app/src/main/java/org/zalando/nakadi/config/WebConfig.java
+++ b/app/src/main/java/org/zalando/nakadi/config/WebConfig.java
@@ -13,6 +13,7 @@ import org.springframework.http.converter.ResourceHttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.http.converter.xml.SourceHttpMessageConverter;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.web.context.request.async.TimeoutCallableProcessingInterceptor;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
@@ -46,6 +47,17 @@ public class WebConfig extends WebMvcConfigurationSupport {
     public void configureAsyncSupport(final AsyncSupportConfigurer configurer) {
         configurer.setDefaultTimeout(nakadiStreamTimeout);
         configurer.registerCallableInterceptors(timeoutInterceptor());
+        configurer.setTaskExecutor(buildThreadPoolForAsyncSupport());
+    }
+
+    private ThreadPoolTaskExecutor buildThreadPoolForAsyncSupport() {
+        final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(5);
+        executor.setThreadNamePrefix("async-support-pool-");
+        executor.initialize();
+        return executor;
     }
 
     @Bean


### PR DESCRIPTION
# Introducing ThreadPoolTaskExecutor for Async support

## Description
With spring boot upgrade, we get the following warning.

```
    !!!
    An Executor is required to handle java.util.concurrent.Callable return values.
    Please, configure a TaskExecutor in the MVC config under "async support".
    The SimpleAsyncTaskExecutor currently in use is not suitable under load.
    -------------------------------
    Request URI: '/subscriptions/a3e37570-817c-4b7d-9622-773695761d59/events'
    !!!
```
This commit is introducing a ThreadPoolTaskExecutor which is configured
to break under small load. The purpose is to observe the failure mode
before making a reasonable configuration for high load.

## Deployment Notes
This commit shall be used for validation, followed by proper configuration before deploying to production systems.