### PR TITLE
Disabling connection close crutch to validate springboot2 without it

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaAT.java
@@ -302,7 +302,7 @@ public class HilaAT extends BaseAT {
                 .statusCode(HttpStatus.SC_CONFLICT);
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 30000)
     public void whenConnectionIsClosedByClientNakadiRecognizesIt() throws Exception {
 
         final TestStreamingClient client = TestStreamingClient
@@ -311,7 +311,7 @@ public class HilaAT extends BaseAT {
         waitFor(() -> assertThat(client.getBatches(), Matchers.hasSize(1)));
 
         client.close();
-        ThreadUtils.sleep(2500);
+        ThreadUtils.sleep(10000);
 
         final TestStreamingClient anotherClient = TestStreamingClient
                 .create(URL, subscription.getId(), "batch_flush_timeout=1");

--- a/api-consumption/src/main/java/org/zalando/nakadi/controller/EventStreamController.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/controller/EventStreamController.java
@@ -42,9 +42,9 @@ import org.zalando.nakadi.service.AuthorizationValidator;
 import org.zalando.nakadi.service.ClosedConnectionsCrutch;
 import org.zalando.nakadi.service.CursorConverter;
 import org.zalando.nakadi.service.EventStream;
+import org.zalando.nakadi.service.EventStreamChecks;
 import org.zalando.nakadi.service.EventStreamConfig;
 import org.zalando.nakadi.service.EventStreamFactory;
-import org.zalando.nakadi.service.EventStreamChecks;
 import org.zalando.nakadi.service.EventTypeChangeListener;
 import org.zalando.nakadi.service.timeline.TimelineService;
 import org.zalando.nakadi.util.FlowIdUtils;
@@ -206,7 +206,9 @@ public class EventStreamController {
                 return;
             }
 
-            final AtomicBoolean connectionReady = closedConnectionsCrutch.listenForConnectionClose(request);
+            final AtomicBoolean connectionReady = new AtomicBoolean(true);
+            // Setting always true to validate that ClosedConnectionsCrutch is not needed in Springboot 2 version.
+            //closedConnectionsCrutch.listenForConnectionClose(request);
             Counter consumerCounter = null;
             EventStream eventStream = null;
             final AtomicBoolean needCheckAuthorization = new AtomicBoolean(false);

--- a/api-consumption/src/main/java/org/zalando/nakadi/controller/SubscriptionStreamController.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/controller/SubscriptionStreamController.java
@@ -214,7 +214,9 @@ public class SubscriptionStreamController {
             final String metricName = metricNameForSubscription(subscriptionId, CONSUMERS_COUNT_METRIC_NAME);
             final Counter consumerCounter = metricRegistry.counter(metricName);
             consumerCounter.inc();
-            final AtomicBoolean connectionReady = closedConnectionsCrutch.listenForConnectionClose(request);
+            // Setting always true to validate that ClosedConnectionsCrutch is not needed in Springboot 2 version.
+            final AtomicBoolean connectionReady = new AtomicBoolean(true);
+            // closedConnectionsCrutch.listenForConnectionClose(request);
             SubscriptionStreamer streamer = null;
             final SubscriptionOutputImpl output = new SubscriptionOutputImpl(response, outputStream);
             try {

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/ClosedConnectionsCrutch.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/ClosedConnectionsCrutch.java
@@ -13,7 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.zalando.nakadi.domain.Feature;
 

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/ClosedConnectionsCrutch.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/ClosedConnectionsCrutch.java
@@ -156,7 +156,8 @@ public class ClosedConnectionsCrutch {
         }
     }
 
-    @Scheduled(fixedDelay = 1000)
+    // Disabling as to validate that ClosedConnectionsCrutch is not needed in Springboot 2 version.
+    //@Scheduled(fixedDelay = 1000)
     public void refresh() throws IOException {
         if (!featureToggleService.isFeatureEnabled(Feature.CONNECTION_CLOSE_CRUTCH)) {
             return;


### PR DESCRIPTION
# Disabling connection close crutch to validate springboot2 without it


## Description
The ClosedConnectionsCrutch is likely unnecessary and creates problems with SpringBoot 2 update.
This PR disables it in place to validate this before completely removing ClosedConnectionsCrutch.
