### PR TITLE
Support for compact and delete cleanup policy

### DIFF
--- a/api-metastore/src/main/java/org/zalando/nakadi/controller/EventTypeController.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/controller/EventTypeController.java
@@ -144,8 +144,7 @@ public class EventTypeController {
 
         final List<String> warnings = Lists.newArrayList(nakadiSettings.getWarnAllDataAccessMessage());
 
-        if (eventType.getCleanupPolicy().equals(CleanupPolicy.COMPACT) ||
-                eventType.getCleanupPolicy().equals(CleanupPolicy.COMPACT_AND_DELETE)) {
+        if (eventType.getCleanupPolicy().equals(CleanupPolicy.COMPACT)) {
             warnings.add(nakadiSettings.getLogCompactionWarnMessage());
         }
 

--- a/api-metastore/src/main/java/org/zalando/nakadi/controller/EventTypeController.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/controller/EventTypeController.java
@@ -144,7 +144,8 @@ public class EventTypeController {
 
         final List<String> warnings = Lists.newArrayList(nakadiSettings.getWarnAllDataAccessMessage());
 
-        if (eventType.getCleanupPolicy().equals(CleanupPolicy.COMPACT)) {
+        if (eventType.getCleanupPolicy().equals(CleanupPolicy.COMPACT) ||
+                eventType.getCleanupPolicy().equals(CleanupPolicy.COMPACT_AND_DELETE)) {
             warnings.add(nakadiSettings.getLogCompactionWarnMessage());
         }
 

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -160,7 +160,8 @@ public class EventTypeService {
             throw new DbWriteOperationsBlockedException("Cannot create event type: write operations on DB " +
                     "are blocked by feature flag.");
         }
-        if (eventType.getCleanupPolicy() == CleanupPolicy.COMPACT
+        if ((eventType.getCleanupPolicy() == CleanupPolicy.COMPACT ||
+                eventType.getCleanupPolicy() == CleanupPolicy.COMPACT_AND_DELETE)
                 && featureToggleService.isFeatureEnabled(Feature.DISABLE_LOG_COMPACTION)) {
             throw new FeatureNotAvailableException("log compaction is not available",
                     Feature.DISABLE_LOG_COMPACTION);
@@ -247,7 +248,8 @@ public class EventTypeService {
     private void validateCompaction(final EventTypeBase eventType) throws
             InvalidEventTypeException {
         if (eventType.getCategory() == EventCategory.UNDEFINED &&
-                eventType.getCleanupPolicy() == CleanupPolicy.COMPACT) {
+                (eventType.getCleanupPolicy() == CleanupPolicy.COMPACT ||
+                        eventType.getCleanupPolicy() == CleanupPolicy.COMPACT_AND_DELETE)) {
             throw new InvalidEventTypeException(
                     "cleanup_policy 'compact' is not available for 'undefined' event type category");
         }

--- a/core-common/src/main/java/org/zalando/nakadi/domain/CleanupPolicy.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/CleanupPolicy.java
@@ -1,5 +1,5 @@
 package org.zalando.nakadi.domain;
 
 public enum CleanupPolicy {
-    DELETE, COMPACT
+    DELETE, COMPACT, COMPACT_AND_DELETE
 }

--- a/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventPublisher.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventPublisher.java
@@ -211,7 +211,8 @@ public class EventPublisher {
     }
 
     private void setEventKey(final List<BatchItem> batch, final EventType eventType) {
-        if (eventType.getCleanupPolicy() == CleanupPolicy.COMPACT) {
+        if (eventType.getCleanupPolicy() == CleanupPolicy.COMPACT ||
+                 eventType.getCleanupPolicy() == CleanupPolicy.COMPACT_AND_DELETE) {
             for (final BatchItem item : batch) {
                 final String compactionKey = item.getEvent()
                         .getJSONObject("metadata")
@@ -264,7 +265,7 @@ public class EventPublisher {
         final Span validationSpan = TracingService.getNewSpanWithParent("validation", System.currentTimeMillis(),
                 parentSpan);
         validationSpan.setTag("event_type", eventType.getName());
-        if (delete && eventType.getCleanupPolicy() != CleanupPolicy.COMPACT) {
+        if (delete && eventType.getCleanupPolicy() == CleanupPolicy.DELETE) {
             throw new EventValidationException("It is not allowed to delete events from non compacted event type");
         }
         try {

--- a/core-services/src/main/java/org/zalando/nakadi/service/timeline/TimelineService.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/timeline/TimelineService.java
@@ -194,7 +194,6 @@ public class TimelineService {
                 eventType.getCleanupPolicy() == CleanupPolicy.COMPACT_AND_DELETE) {
             storage = storageDbRepository.getStorage(compactedStorageName).orElseThrow(() ->
                     new TopicCreationException("No storage defined for compacted topics"));
-            retentionTime = Optional.empty();
         }
 
         final NakadiTopicConfig nakadiTopicConfig = new NakadiTopicConfig(partitionsCount, eventType.getCleanupPolicy(),

--- a/core-services/src/main/java/org/zalando/nakadi/service/timeline/TimelineService.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/timeline/TimelineService.java
@@ -120,7 +120,8 @@ public class TimelineService {
             if (!adminService.isAdmin(AuthorizationService.Operation.WRITE)) {
                 throw new AccessDeniedException(AuthorizationService.Operation.ADMIN, eventType.asResource());
             }
-            if (eventType.getCleanupPolicy() == CleanupPolicy.COMPACT) {
+            if (eventType.getCleanupPolicy() == CleanupPolicy.COMPACT ||
+                    eventType.getCleanupPolicy() == CleanupPolicy.COMPACT_AND_DELETE) {
                 throw new TimelinesNotSupportedException("It is not possible to create a timeline " +
                         "for event type with 'compact' cleanup_policy");
             }
@@ -189,7 +190,8 @@ public class TimelineService {
 
         Storage storage = defaultStorage.getStorage();
         Optional<Long> retentionTime = Optional.ofNullable(eventType.getOptions().getRetentionTime());
-        if (eventType.getCleanupPolicy() == CleanupPolicy.COMPACT) {
+        if (eventType.getCleanupPolicy() == CleanupPolicy.COMPACT ||
+                eventType.getCleanupPolicy() == CleanupPolicy.COMPACT_AND_DELETE) {
             storage = storageDbRepository.getStorage(compactedStorageName).orElseThrow(() ->
                     new TopicCreationException("No storage defined for compacted topics"));
             retentionTime = Optional.empty();

--- a/core-services/src/main/java/org/zalando/nakadi/service/timeline/TimelineService.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/timeline/TimelineService.java
@@ -189,7 +189,7 @@ public class TimelineService {
         }
 
         Storage storage = defaultStorage.getStorage();
-        Optional<Long> retentionTime = Optional.ofNullable(eventType.getOptions().getRetentionTime());
+        final Optional<Long> retentionTime = Optional.ofNullable(eventType.getOptions().getRetentionTime());
         if (eventType.getCleanupPolicy() == CleanupPolicy.COMPACT ||
                 eventType.getCleanupPolicy() == CleanupPolicy.COMPACT_AND_DELETE) {
             storage = storageDbRepository.getStorage(compactedStorageName).orElseThrow(() ->

--- a/core-services/src/main/resources/schema_metadata.json
+++ b/core-services/src/main/resources/schema_metadata.json
@@ -87,5 +87,52 @@
       "occurred_at",
       "partition_compaction_key"
     ]
+  },
+  "compact_and_delete": {
+    "additionalProperties": false,
+    "type": "object",
+    "properties": {
+      "occurred_at": {
+        "type": "string"
+      },
+      "eid": {
+        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+        "type": "string"
+      },
+      "event_type": {
+        "type": "string",
+        "enum": [
+          "{{EVENT_TYPE_NAME}}"
+        ]
+      },
+      "partition": {
+        "type": "string"
+      },
+      "span_ctx": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "parent_eids": {
+        "type": "array",
+        "items": {
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+          "type": "string"
+        }
+      },
+      "flow_id": {
+        "type": "string"
+      },
+      "partition_compaction_key": {
+        "minLength": 1,
+        "type": "string"
+      }
+    },
+    "required": [
+      "eid",
+      "occurred_at",
+      "partition_compaction_key"
+    ]
   }
 }

--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -2150,7 +2150,8 @@ definitions:
         description: |
           Value used for per-partition compaction of the event type. Given two events with the same
           partition_compaction_key value are published to the same partition, the later overwrites the former.
-          Required when 'cleanup_policy' of event type is set to 'compact'. Must be absent otherwise.
+          Required when 'cleanup_policy' of event type is set to 'compact' or 'compact_and_delete'. Must be absent
+          otherwise.
 
           When using more than one partition for event type - it will make sense to specify 'partition_compaction_key'
           and partitioning parameters in a way that events with the same partition_compaction_key are published to the
@@ -2691,9 +2692,10 @@ definitions:
         x-extensible-enum:
           - delete
           - compact
+          - compact_and_delete
         default: 'delete'
         description: |
-          Event type cleanup policy. There are two possible values:
+          Event type cleanup policy. Possible values:
 
           - 'delete' cleanup policy will delete old events after retention time expires. Nakadi guarantees that each
             event will be available for at least the retention time period. However Nakadi doesn't guarantee that event
@@ -2704,7 +2706,13 @@ definitions:
             specified in 'partition_compaction_key' field of event metadata. This cleanup policy is not available for
             'undefined' category of event types.
 
-            The compaction can be not applied to events that were published recently and located at the head of the
+          - 'compact_and_delete' cleanup policy combines both time based retention and per key compaction. It's
+            useful in situations where the entire keyset may be too large and require too much disk space to keep a
+            copy of each event but at the same time allowing users to benefit from compaction in order to reduce
+            duplication of events with the same key within the retention time. Its usage requires events to have a
+            `partition_compaction_key` in the `metadata` in the same way as `compact` option.
+
+            The compaction can not be applied to events that were published recently and located at the head of the
             queue, which means that the actual amount of events received by consumers can be different depending on time
             when the consumption happened.
 


### PR DESCRIPTION
Since Kafka 0.10.1.0 log compaction and log deletion are no longer
multually exclusive cleanup policies. They can be used in a combined
way as described in the KIP used to design it
https://cwiki.apache.org/confluence/display/KAFKA/KIP-71:+Enable+log+compaction+and+deletion+to+co-exist

This PR adds support for such an option.