### PR TITLE
Fix failing test due to eventual consistency of default storage update

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/StorageControllerAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/StorageControllerAT.java
@@ -1,12 +1,18 @@
 package org.zalando.nakadi.webservice;
 
+import org.apache.http.HttpStatus;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
+import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.utils.EventTypeTestBuilder;
 import org.zalando.nakadi.webservice.utils.NakadiTestUtils;
 
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.http.ContentType.JSON;
+import static org.junit.Assert.fail;
+import static org.zalando.nakadi.utils.TestUtils.waitFor;
+import static org.zalando.nakadi.webservice.utils.NakadiTestUtils.createEventType;
 
 public class StorageControllerAT extends BaseAT {
 
@@ -21,18 +27,32 @@ public class StorageControllerAT extends BaseAT {
                         "\"addresses\":[{\"address\":\"zookeeper\", \"port\":2181}]" +
                         "}" +
                         "},\"storage_type\": \"kafka\"}")
-                .contentType(JSON).post("/storages");
+                .contentType(JSON).post("/storages")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED);
 
         NakadiTestUtils.createEventTypeInNakadi(EventTypeTestBuilder.builder().name("event_a").build());
         String storageId = (String) NakadiTestUtils.listTimelines("event_a").get(0).get("storage_id");
         Assert.assertEquals("default", storageId);
 
-        given().contentType(JSON).put("/storages/default/default-test");
-        NakadiTestUtils.createEventTypeInNakadi(EventTypeTestBuilder.builder().name("event_b").build());
-        storageId = (String) NakadiTestUtils.listTimelines("event_b").get(0).get("storage_id");
-        Assert.assertEquals("default-test", storageId);
+        given().contentType(JSON).put("/storages/default/default-test")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
 
-        // cleanup
+        // change of default storage is eventually consistent and relies on zookeeper watcher being processed
+        waitFor(() -> {
+            try {
+                final EventType et = createEventType();
+                final String storage = (String) NakadiTestUtils.listTimelines(et.getName()).get(0).get("storage_id");
+                Assert.assertEquals("default-test", storage);
+            } catch (final Exception e) {
+                fail(e.getMessage());
+            }
+        });
+    }
+
+    @After
+    public void cleanUp() {
         given().contentType(JSON).put("/storages/default/default");
     }
 }


### PR DESCRIPTION
When updating the default storage one has to wait for the zk watcher
to be processed. This may take some time. In fact, we may have a bug
here when the watcher for some reason is missed (for example lost
connectivity to zk and recreation of watcher). But I'm not fixing
Nakadi, instead my goal is to first have more stable tests.

Also using teardown to avoid the failure of this particular test
cascade interfere with other tests which makes it harder to find the
"root cause" of the failures.
