### PR TITLE
Documented deletion of log compacted event-type

### DIFF
--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -946,12 +946,14 @@ paths:
       security:
         - oauth2: ['nakadi.event_stream.write']
       description: |
-        Once an event is published to a logcompacted event-type in nakadi, it
+        Once an event is published to a log compacted event-type in nakadi, it
         will stay there until another event with the same key is published.
-        In order to delete an event from a logcompacted event-type, it can be
+        In order to delete an event from a log compacted event-type, it can be
         posted to the deleted-events endpoint. The content of the event is not
         validated, but the information required to generate key and select
-        partition should be present.
+        partition should be present. On next log compaction, which could be
+        hours later based on configurations, any previous events with the same
+        key is removed from the specified partition + event-type.
       parameters:
         - name: name
           in: path
@@ -982,7 +984,7 @@ paths:
         '200':
           description: |
             Deletion event successfully published; any existing events with
-            same key will be deleted on log compaction.
+            same key will be deleted on next log compaction.
           headers:
             span_ctx:
               type: string

--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -539,7 +539,7 @@ paths:
         [event types](https://zalando.github.io/nakadi/manual.html#using_event-types) section of the documentation.
 
         For API backward compatibility, adding a new schema can also be done by updating the entire event type via PUT.
-    parameters:
+      parameters:
       - name: name
         in: path
         description: EventType name
@@ -551,24 +551,24 @@ paths:
         schema:
           $ref: '#/definitions/EventTypeSchema'
         required: true
-    responses:
-      '201':
-        description: |
-          New schema registered with success.
-      '401':
-        description: Not authenticated
-        schema:
-          $ref: '#/definitions/Problem'
-      '422':
-        description: |
-          Unprocessable entity. For understanding the rules on what can be changed in a schema, please refer to
-          the [schema evolution documentation](https://zalando.github.io/nakadi/manual.html#using_event-types).
-        schema:
-          $ref: '#/definitions/Problem'
-      '403':
-        description: Access is forbidden for the client or event type
-        schema:
-          $ref: '#/definitions/Problem'
+      responses:
+        '201':
+          description: |
+            New schema registered with success.
+        '401':
+          description: Not authenticated
+          schema:
+            $ref: '#/definitions/Problem'
+        '422':
+          description: |
+            Unprocessable entity. For understanding the rules on what can be changed in a schema, please refer to
+            the [schema evolution documentation](https://zalando.github.io/nakadi/manual.html#using_event-types).
+          schema:
+            $ref: '#/definitions/Problem'
+        '403':
+          description: Access is forbidden for the client or event type
+          schema:
+            $ref: '#/definitions/Problem'
 
     get:
       tags:
@@ -938,6 +938,71 @@ paths:
           description: Access forbidden because of missing scope or EventType authorization failure.
           schema:
             $ref: '#/definitions/Problem'
+
+  '/event-types/{name}/deleted-events':
+    post:
+      tags:
+        - stream-api
+      security:
+        - oauth2: ['nakadi.event_stream.write']
+      description: |
+        Once an event is published to a logcompacted event-type in nakadi, it
+        will stay there until another event with the same key is published.
+        In order to delete an event from a logcompacted event-type, it can be
+        posted to the deleted-events endpoint. The content of the event is not
+        validated, but the information required to generate key and select
+        partition should be present.
+      parameters:
+        - name: name
+          in: path
+          type: string
+          description: Name of the EventType
+          required: true
+        - name: X-Flow-Id
+          in: header
+          description: |
+            The flow id of the request, which is written into the logs and passed to called services. Helpful
+            for operational troubleshooting and log analysis.
+          type: string
+        - name: span_ctx
+          in: header
+          description: |
+            The span context, which is used to trace the spans and passed to called services. Helpful
+            for operational troubleshooting and will help users integrate Nakadi as a part of their trace.
+          type: string
+        - name: event
+          in: body
+          description: The Event being deleted.
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Event'
+          required: true
+      responses:
+        '200':
+          description: |
+            Deletion event successfully published; any existing events with
+            same key will be deleted on log compaction.
+          headers:
+            span_ctx:
+              type: string
+              description: Span context of the span used to trace the request in Nakadi
+        '401':
+          description: Client is not authenticated
+          schema:
+            $ref: '#/definitions/Problem'
+          headers:
+            span_ctx:
+              type: string
+              description: Span context of the span used to trace the request in Nakadi
+        '403':
+          description: Access is forbidden for the client or event type
+          schema:
+            $ref: '#/definitions/Problem'
+          headers:
+            span_ctx:
+              type: string
+              description: Span context of the span used to trace the request in Nakadi
 
   /subscriptions:
     post:


### PR DESCRIPTION
# Documented deletion of log compacted event-type

> Zalando ticket : ARUHA-2982 

## Description
Endpoint to delete an event from a log compacted event-type is missing documentation. This is added in this PR.

## Review
- [ ] Tests
- [x] Documentation
