### PR TITLE
Revert change to jakarta websocket api

### DIFF
--- a/acceptance-test/build.gradle
+++ b/acceptance-test/build.gradle
@@ -67,7 +67,6 @@ dependencies {
     compile "org.springframework:spring-web"
     compile "org.springframework:spring-webmvc"
     compile "org.springframework.boot:spring-boot-starter-jetty"
-    compile 'jakarta.websocket:jakarta.websocket-api:2.0.0-RC1'
 
     compile('org.springframework.boot:spring-boot-starter-security') {
         exclude module: "logback-classic"

--- a/api-consumption/build.gradle
+++ b/api-consumption/build.gradle
@@ -45,7 +45,6 @@ dependencies {
     }
     compile 'org.springframework.cloud:spring-cloud-starter-netflix-hystrix:2.2.3.RELEASE'
     compile "org.springframework.boot:spring-boot-starter-jetty"
-    compile 'jakarta.websocket:jakarta.websocket-api:2.0.0-RC1'
 
     // oauth
     compile('org.springframework.security.oauth:spring-security-oauth2:2.5.0.RELEASE') {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,7 +67,6 @@ dependencies {
     compile "org.springframework:spring-web"
     compile "org.springframework:spring-webmvc"
     compile "org.springframework.boot:spring-boot-starter-jetty"
-    compile 'jakarta.websocket:jakarta.websocket-api:2.0.0-RC1'
 
     // oauth
     compile('org.springframework.security.oauth:spring-security-oauth2:2.5.0.RELEASE') {

--- a/core-common/build.gradle
+++ b/core-common/build.gradle
@@ -43,7 +43,6 @@ dependencies {
     compile 'org.springframework.cloud:spring-cloud-starter-netflix-hystrix:2.2.3.RELEASE'
     //compile 'org.springframework.cloud:spring-cloud-starter-hystrix:1.4.5.RELEASE'
     compile "org.springframework.boot:spring-boot-starter-jetty"
-    compile 'jakarta.websocket:jakarta.websocket-api:2.0.0-RC1'
 
     // oauth
     compile('org.springframework.security.oauth:spring-security-oauth2:2.5.0.RELEASE') {

--- a/core-metastore/build.gradle
+++ b/core-metastore/build.gradle
@@ -44,7 +44,6 @@ dependencies {
     compile 'org.springframework.cloud:spring-cloud-starter-netflix-hystrix:2.2.3.RELEASE'
     //compile 'org.springframework.cloud:spring-cloud-starter-hystrix:1.4.5.RELEASE'
     compile "org.springframework.boot:spring-boot-starter-jetty"
-    compile 'jakarta.websocket:jakarta.websocket-api:2.0.0-RC1'
 
     // oauth
     compile('org.springframework.security.oauth:spring-security-oauth2:2.5.0.RELEASE') {

--- a/core-services/build.gradle
+++ b/core-services/build.gradle
@@ -45,7 +45,6 @@ dependencies {
     compile 'org.springframework.cloud:spring-cloud-starter-netflix-hystrix:2.2.3.RELEASE'
     //compile 'org.springframework.cloud:spring-cloud-starter-hystrix:1.4.5.RELEASE'
     compile "org.springframework.boot:spring-boot-starter-jetty"
-    compile 'jakarta.websocket:jakarta.websocket-api:2.0.0-RC1'
 
     // oauth
     compile('org.springframework.security.oauth:spring-security-oauth2:2.5.0.RELEASE') {


### PR DESCRIPTION
We are going to wait for jetty upgrade and not force the upgrade of
one of its dependencies.

