### PR TITLE
Allow event type admins and nakadi admins to edit schema compatibility

### DIFF
--- a/api-metastore/src/main/java/org/zalando/nakadi/config/SchemaValidatorConfig.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/config/SchemaValidatorConfig.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.zalando.nakadi.domain.SchemaChange;
+import org.zalando.nakadi.plugin.api.authz.AuthorizationService;
 import org.zalando.nakadi.service.AdminService;
 import org.zalando.nakadi.service.SchemaEvolutionService;
 import org.zalando.nakadi.validation.schema.CategoryChangeConstraint;
@@ -47,10 +48,12 @@ import static org.zalando.nakadi.domain.SchemaChange.Type.TYPE_NARROWED;
 public class SchemaValidatorConfig {
 
     private final AdminService adminService;
+    private final AuthorizationService authorizationService;
 
     @Autowired
-    public SchemaValidatorConfig(final AdminService adminService) {
+    public SchemaValidatorConfig(final AdminService adminService, final AuthorizationService authorizationService) {
         this.adminService = adminService;
+        this.authorizationService = authorizationService;
     }
 
     @Bean
@@ -61,7 +64,7 @@ public class SchemaValidatorConfig {
 
         final List<SchemaEvolutionConstraint> schemaEvolutionConstraints = Lists.newArrayList(
                 new CategoryChangeConstraint(),
-                new CompatibilityModeChangeConstraint(adminService),
+                new CompatibilityModeChangeConstraint(adminService, authorizationService),
                 new PartitionKeyFieldsConstraint(),
                 new PartitionStrategyConstraint(),
                 new EnrichmentStrategyConstraint()

--- a/api-metastore/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
@@ -86,11 +86,11 @@ public class EventTypeControllerTestCase {
     protected final TimelineSync timelineSync = mock(TimelineSync.class);
     protected final TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
     protected final AdminService adminService = mock(AdminService.class);
-    protected final SchemaEvolutionService schemaEvolutionService = new SchemaValidatorConfig(adminService)
-            .schemaEvolutionService();
+    protected final AuthorizationService authorizationService = mock(AuthorizationService.class);
+    protected final SchemaEvolutionService schemaEvolutionService = new SchemaValidatorConfig(adminService,
+            authorizationService).schemaEvolutionService();
     protected final AuthorizationValidator authorizationValidator = mock(AuthorizationValidator.class);
     protected final NakadiKpiPublisher nakadiKpiPublisher = mock(NakadiKpiPublisher.class);
-    protected final AuthorizationService authorizationService = mock(AuthorizationService.class);
     protected final NakadiAuditLogPublisher nakadiAuditLogPublisher = mock(NakadiAuditLogPublisher.class);
     protected final TracingService tracingService = mock(TracingService.class);
     private final SchemaService schemaService = mock(SchemaService.class);

--- a/api-metastore/src/test/java/org/zalando/nakadi/validation/schema/CompatibilityModeChangeConstraintTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/validation/schema/CompatibilityModeChangeConstraintTest.java
@@ -10,6 +10,7 @@ import org.zalando.nakadi.service.AdminService;
 import org.zalando.nakadi.utils.EventTypeTestBuilder;
 import org.zalando.nakadi.utils.IsOptional;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
 public class CompatibilityModeChangeConstraintTest {
@@ -18,7 +19,8 @@ public class CompatibilityModeChangeConstraintTest {
         final EventTypeTestBuilder builder = new EventTypeTestBuilder();
         final EventType oldET = builder.compatibilityMode(CompatibilityMode.COMPATIBLE).build();
         final EventType newET = builder.compatibilityMode(CompatibilityMode.NONE).build();
-        final CompatibilityModeChangeConstraint constraint = new CompatibilityModeChangeConstraint(adminMock(false));
+        final CompatibilityModeChangeConstraint constraint = new CompatibilityModeChangeConstraint(adminMock(false),
+                eventTypeAdmin(false));
 
         Assert.assertThat(constraint.validate(oldET, newET), IsOptional.isPresent());
     }
@@ -28,7 +30,19 @@ public class CompatibilityModeChangeConstraintTest {
         final EventTypeTestBuilder builder = new EventTypeTestBuilder();
         final EventType oldET = builder.compatibilityMode(CompatibilityMode.COMPATIBLE).build();
         final EventType newET = builder.compatibilityMode(CompatibilityMode.NONE).build();
-        final CompatibilityModeChangeConstraint constraint = new CompatibilityModeChangeConstraint(adminMock(true));
+        final CompatibilityModeChangeConstraint constraint = new CompatibilityModeChangeConstraint(adminMock(true),
+                eventTypeAdmin(false));
+
+        Assert.assertThat(constraint.validate(oldET, newET), IsOptional.isAbsent());
+    }
+
+    @Test
+    public void eventTypeAdminsCanDowngradeCompatibilityMode() throws Exception {
+        final EventTypeTestBuilder builder = new EventTypeTestBuilder();
+        final EventType oldET = builder.compatibilityMode(CompatibilityMode.COMPATIBLE).build();
+        final EventType newET = builder.compatibilityMode(CompatibilityMode.NONE).build();
+        final CompatibilityModeChangeConstraint constraint = new CompatibilityModeChangeConstraint(adminMock(false),
+                eventTypeAdmin(true));
 
         Assert.assertThat(constraint.validate(oldET, newET), IsOptional.isAbsent());
     }
@@ -38,7 +52,8 @@ public class CompatibilityModeChangeConstraintTest {
         final EventTypeTestBuilder builder = new EventTypeTestBuilder();
         final EventType oldET = builder.compatibilityMode(CompatibilityMode.FORWARD).build();
         final EventType newET = builder.compatibilityMode(CompatibilityMode.COMPATIBLE).build();
-        final CompatibilityModeChangeConstraint constraint = new CompatibilityModeChangeConstraint(adminMock(false));
+        final CompatibilityModeChangeConstraint constraint = new CompatibilityModeChangeConstraint(adminMock(false),
+                eventTypeAdmin(false));
 
         Assert.assertThat(constraint.validate(oldET, newET), IsOptional.isAbsent());
     }
@@ -48,7 +63,8 @@ public class CompatibilityModeChangeConstraintTest {
         final EventTypeTestBuilder builder = new EventTypeTestBuilder();
         final EventType oldET = builder.compatibilityMode(CompatibilityMode.NONE).build();
         final EventType newET = builder.compatibilityMode(CompatibilityMode.FORWARD).build();
-        final CompatibilityModeChangeConstraint constraint = new CompatibilityModeChangeConstraint(adminMock(false));
+        final CompatibilityModeChangeConstraint constraint = new CompatibilityModeChangeConstraint(adminMock(false),
+                eventTypeAdmin(false));
 
         Assert.assertThat(constraint.validate(oldET, newET), IsOptional.isAbsent());
     }
@@ -58,7 +74,8 @@ public class CompatibilityModeChangeConstraintTest {
         final EventTypeTestBuilder builder = new EventTypeTestBuilder();
         final EventType oldET = builder.compatibilityMode(CompatibilityMode.NONE).build();
         final EventType newET = builder.compatibilityMode(CompatibilityMode.NONE).build();
-        final CompatibilityModeChangeConstraint constraint = new CompatibilityModeChangeConstraint(adminMock(false));
+        final CompatibilityModeChangeConstraint constraint = new CompatibilityModeChangeConstraint(adminMock(false),
+                eventTypeAdmin(false));
 
         Assert.assertThat(constraint.validate(oldET, newET), IsOptional.isAbsent());
     }
@@ -67,5 +84,12 @@ public class CompatibilityModeChangeConstraintTest {
         final AdminService adminService = mock(AdminService.class);
         Mockito.when(adminService.isAdmin(AuthorizationService.Operation.WRITE)).thenReturn(isAdmin);
         return adminService;
+    }
+
+    private AuthorizationService eventTypeAdmin(final boolean isAdmin) {
+        final AuthorizationService authorizationService = mock(AuthorizationService.class);
+        Mockito.when(authorizationService.isAuthorized(any(), any()))
+                .thenReturn(isAdmin);
+        return authorizationService;
     }
 }


### PR DESCRIPTION
Users often want to make incompatible changes to schema by removing
required properties or any other sort of change that has the potential
of causing consumers to break.

Often they are the sole consumer of that data or they have already
aligned with downstream service owners that such change will be
handled gracefully.

They have the confidence that making such changes is the least
disruptive way of delivering something and want to do it.

Our team ends up acting a bottleneck.

This change grants them with such freedom to change.
