### PR TITLE
ARUHA-2225: Publish to Audit log and Event Type log for POST /event-types/{et}/schemas

### DIFF
--- a/api-metastore/src/test/java/org/zalando/nakadi/service/SchemaServiceTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/service/SchemaServiceTest.java
@@ -19,6 +19,8 @@ import org.zalando.nakadi.exceptions.runtime.InvalidLimitException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchSchemaException;
 import org.zalando.nakadi.repository.db.EventTypeRepository;
 import org.zalando.nakadi.repository.db.SchemaRepository;
+import org.zalando.nakadi.service.publishing.NakadiAuditLogPublisher;
+import org.zalando.nakadi.service.publishing.NakadiKpiPublisher;
 import org.zalando.nakadi.service.timeline.TimelineSync;
 import org.zalando.nakadi.utils.TestUtils;
 import org.zalando.nakadi.validation.JsonSchemaEnrichment;
@@ -43,6 +45,8 @@ public class SchemaServiceTest {
     private EventType eventType;
     private TimelineSync timelineSync;
     private NakadiSettings nakadiSettings;
+    private NakadiAuditLogPublisher nakadiAuditLogPublisher;
+    private NakadiKpiPublisher nakadiKpiPublisher;
 
     @Before
     public void setUp() throws IOException {
@@ -58,10 +62,12 @@ public class SchemaServiceTest {
         Mockito.when(eventTypeRepository.findByName(any())).thenReturn(eventType);
         timelineSync = Mockito.mock(TimelineSync.class);
         nakadiSettings = Mockito.mock(NakadiSettings.class);
+        nakadiKpiPublisher = Mockito.mock(NakadiKpiPublisher.class);
+        nakadiAuditLogPublisher = Mockito.mock(NakadiAuditLogPublisher.class);
         schemaService = new SchemaService(schemaRepository, paginationService,
                 new JsonSchemaEnrichment(new DefaultResourceLoader(), "classpath:schema_metadata.json"),
                 schemaEvolutionService, eventTypeRepository, adminService, authorizationValidator, eventTypeCache,
-                timelineSync, nakadiSettings);
+                timelineSync, nakadiSettings, nakadiAuditLogPublisher, nakadiKpiPublisher, "test");
     }
 
     @Test(expected = InvalidLimitException.class)


### PR DESCRIPTION
# One-line summary

> Zalando ticket : ARUHA-2225 

The new endpoint for addition of a schema (`POST /event-types/{et}/schemas`) to an event-type doesn't publish to audit log or the event-type log event-types. The changes ensure that in case if the new schema version is different from the previous, an event is published to the event-type log and audit log event types