### PR TITLE
Indempotent repartitioning

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/UserJourneyAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/UserJourneyAT.java
@@ -250,6 +250,22 @@ public class UserJourneyAT extends RealEnvironmentAT {
                 .then()
                 .statusCode(OK.value())
                 .body("size()", equalTo(3));
+
+        // check idempotency
+        jsonRequestSpec()
+                .body(MAPPER.writeValueAsString(new PartitionsNumberView(3)))
+                .when()
+                .put("/event-types/" + eventTypeName + "/partitions-number")
+                .then()
+                .body(equalTo(""))
+                .statusCode(NO_CONTENT.value());
+
+        jsonRequestSpec()
+                .when()
+                .get("/event-types/" + eventTypeName + "/partitions")
+                .then()
+                .statusCode(OK.value())
+                .body("size()", equalTo(3));
     }
 
     @Test(timeout = 3000)

--- a/core-services/src/main/java/org/zalando/nakadi/service/RepartitioningService.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/RepartitioningService.java
@@ -83,7 +83,7 @@ public class RepartitioningService {
         }
         final int currentPartitionsNumber = Math.max(defaultStatistic.getReadParallelism(),
                 defaultStatistic.getWriteParallelism());
-        if (partitions <= currentPartitionsNumber) {
+        if (partitions < currentPartitionsNumber) {
             throw new InvalidEventTypeException("Number of partitions should be greater " +
                     "than existing values.");
         }


### PR DESCRIPTION
Repartitioning an event type is a complex operation that requires
changing multiple database tables and zookeeper nodes. Since at least
two different storages have to be modified in order to perform a
repartitioning, we cannot do it atomically.

This means that if in the middle of the process it eventually fails,
the changes would be left half done.

Implementing some kind of "rollback" is not a good idea because the
rollback itself can fail and leave the state in an even more obscure
state.

In situations like this, the cleanest solution is to go for an
indempotent change.

I checked all the code and from the tests I performed, it works
incrementally, in the sense that it always "adds" structures when if
finds something missing.

This means we can run this same command multiple times and it would
only change things in the first time. But if this first run fails, we
can run it again and it would basically just continue from where the
previous one stopped.

In case we get a 500 because it couldn't finish modifying
subscriptions or left some timelines half changed, we can just trigger
it again and again until it finishes.

The change is surprisingly simple but I found it effective and I put
some thought before doing it.