### PR TITLE
validate control characters while parsing events

### DIFF
--- a/core-common/src/main/java/org/zalando/nakadi/domain/StrictJsonParser.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/StrictJsonParser.java
@@ -240,6 +240,9 @@ public class StrictJsonParser {
         boolean finished = false;
         while (!finished) {
             char c = tokenizer.next();
+            if (isControlCharacter(c)) {
+                throw syntaxError("Illegal escape.", tokenizer);
+            }
             switch (c) {
                 case 0:
                 case '\n':
@@ -289,6 +292,10 @@ public class StrictJsonParser {
             }
         }
         return sb.toString();
+    }
+
+    private static boolean isControlCharacter(final char c) {
+        return c >= '\u0000' && c <= '\u001F';
     }
 
 }


### PR DESCRIPTION
Added support for control characters in custom implementation of JSON parser. The commit provides validation of unicode control characters and throws exception whenever it can not parse incoming events. Accroding to JSON spec[1] only the following characters should be escaped: from '\u0000' to '\u001F'.

[1]: https://www.ietf.org/rfc/rfc4627.txt, chapter 2.5. Strings