### PR TITLE
Filtering unknown topic warning from Fetcher

### DIFF
--- a/app/src/main/resources/log4j.properties
+++ b/app/src/main/resources/log4j.properties
@@ -6,6 +6,9 @@ LOG_PATTERN=[%d{yyyy-MM-dd HH:mm:ss.SSSXXX}] [%p] [%x] [%t] [%c] --- %m%n
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.EnhancedPatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=${LOG_PATTERN}
+log4j.appender.CONSOLE.filter.1=org.apache.log4j.varia.StringMatchFilter
+log4j.appender.CONSOLE.filter.1.StringToMatch=Received unknown topic or partition error in fetch for partition
+log4j.appender.CONSOLE.filter.1.AcceptOnMatch=false
 
 log4j.category.org.apache.catalina.startup.DigesterFactory=ERROR
 log4j.category.org.apache.catalina.util.LifecycleBase=ERROR


### PR DESCRIPTION
# Filtering unknown topic warning from Fetcher

> Zalando ticket : ARUHA-3153 

## Description
A huge number of Received unknown topic or partition error in fetch
for partition warnings are being logged by
`org.apache.kafka.clients.consumer.internals.Fetcher` in some edge cases.
These logs are filter as a quick fix to high cost of huge log volume.

## Review
- [ ] Tests
- [ ] Documentation

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
