### PR TITLE
Adding published_by to metadata

### DIFF
--- a/core-common/src/main/java/org/zalando/nakadi/enrichment/EnrichmentsRegistry.java
+++ b/core-common/src/main/java/org/zalando/nakadi/enrichment/EnrichmentsRegistry.java
@@ -1,18 +1,25 @@
 package org.zalando.nakadi.enrichment;
 
 import com.google.common.collect.ImmutableMap;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.zalando.nakadi.domain.EnrichmentStrategyDescriptor;
+import org.zalando.nakadi.plugin.api.authz.AuthorizationService;
 
 import java.util.Map;
 
 @Component
 public class EnrichmentsRegistry {
 
-    private static final Map<EnrichmentStrategyDescriptor, EnrichmentStrategy> ENRICHMENT_STRATEGIES =
-        ImmutableMap.of(EnrichmentStrategyDescriptor.METADATA_ENRICHMENT, new MetadataEnrichmentStrategy());
+    private final Map<EnrichmentStrategyDescriptor, EnrichmentStrategy> enrichmentStrategies;
+
+    @Autowired
+    public EnrichmentsRegistry(final AuthorizationService authorizationService) {
+        final MetadataEnrichmentStrategy metadataEnrichment = new MetadataEnrichmentStrategy(authorizationService);
+        enrichmentStrategies = ImmutableMap.of(EnrichmentStrategyDescriptor.METADATA_ENRICHMENT, metadataEnrichment);
+    }
 
     public EnrichmentStrategy getStrategy(final EnrichmentStrategyDescriptor descriptor) {
-        return ENRICHMENT_STRATEGIES.get(descriptor);
+        return enrichmentStrategies.get(descriptor);
     }
 }

--- a/core-common/src/main/java/org/zalando/nakadi/enrichment/MetadataEnrichmentStrategy.java
+++ b/core-common/src/main/java/org/zalando/nakadi/enrichment/MetadataEnrichmentStrategy.java
@@ -4,12 +4,22 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.zalando.nakadi.config.SecuritySettings;
 import org.zalando.nakadi.domain.BatchItem;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.exceptions.runtime.EnrichmentException;
+import org.zalando.nakadi.plugin.api.authz.AuthorizationService;
+import org.zalando.nakadi.plugin.api.authz.Subject;
 import org.zalando.nakadi.util.FlowIdUtils;
 
 public class MetadataEnrichmentStrategy implements EnrichmentStrategy {
+
+    private final AuthorizationService authorizationService;
+
+    public MetadataEnrichmentStrategy(final AuthorizationService authorizationService) {
+        this.authorizationService = authorizationService;
+    }
+
     @Override
     public void enrich(final BatchItem batchItem, final EventType eventType) throws EnrichmentException {
         try {
@@ -17,6 +27,7 @@ public class MetadataEnrichmentStrategy implements EnrichmentStrategy {
                     .getEvent()
                     .getJSONObject(BatchItem.Injection.METADATA.name);
 
+            setPublisher(metadata);
             setReceivedAt(metadata);
             setEventTypeName(metadata, eventType);
             setFlowId(metadata);
@@ -26,6 +37,12 @@ public class MetadataEnrichmentStrategy implements EnrichmentStrategy {
         } catch (final JSONException e) {
             throw new EnrichmentException("enrichment error", e);
         }
+    }
+
+    private void setPublisher(final JSONObject metadata) {
+        final String publisher = authorizationService.getSubject().map(Subject::getName)
+                .orElse(SecuritySettings.UNAUTHENTICATED_CLIENT_ID);
+        metadata.put("published_by", publisher);
     }
 
     private void setVersion(final JSONObject metadata, final EventType eventType) {

--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -2251,6 +2251,12 @@ definitions:
             Event identifier of the Event that caused the generation of this Event.
             Set by the producer.
           example: '105a76d8-db49-4144-ace7-e683e8f4ba46'
+      published_by:
+        description: |
+          ID of the subject that published this specific event to Nakadi.
+          NOTE: Enriched by Nakadi, should not be specified when publishing event.
+        type: string
+        example: 'jane'
       flow_id:
         description: |
           The flow-id of the producer of this Event. As this is usually a HTTP header, this is


### PR DESCRIPTION
# Adding published_by to metadata

> Zalando ticket : ARUHA-2896

## Description
Adding `published_by` field to metadata with the id of the publisher; 
the subject that published this specific event to Nakadi.

## Review
- [ ] Tests
- [ ] Documentation

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
