### PR TITLE
Aruha 2896 bugfix: adding metadata.published_by to effective schema

### DIFF
--- a/core-services/src/main/resources/schema_metadata.json
+++ b/core-services/src/main/resources/schema_metadata.json
@@ -34,6 +34,9 @@
       },
       "flow_id": {
         "type": "string"
+      },
+      "published_by": {
+        "type": "string"
       }
     },
     "required": [

--- a/core-services/src/main/resources/schema_metadata.json
+++ b/core-services/src/main/resources/schema_metadata.json
@@ -83,6 +83,9 @@
       "partition_compaction_key": {
         "minLength": 1,
         "type": "string"
+      },
+      "published_by": {
+        "type": "string"
       }
     },
     "required": [
@@ -129,6 +132,9 @@
       },
       "partition_compaction_key": {
         "minLength": 1,
+        "type": "string"
+      },
+      "published_by": {
         "type": "string"
       }
     },

--- a/core-services/src/test/java/org/zalando/nakadi/enrichment/MetadataEnrichmentStrategyTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/enrichment/MetadataEnrichmentStrategyTest.java
@@ -157,6 +157,7 @@ public class MetadataEnrichmentStrategyTest {
         when(authorizationService.getSubject()).thenReturn(Optional.of(() -> "test-user-123"));
         final EventType eventType = buildDefaultEventType();
         final JSONObject event = buildBusinessEvent();
+        event.getJSONObject("metadata").put("published_by", "test-invalid-publisher");
         final String partition = randomString();
         final BatchItem batch = createBatchItem(event);
         batch.setPartition(partition);

--- a/core-services/src/test/java/org/zalando/nakadi/validation/JSONSchemaValidationTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/validation/JSONSchemaValidationTest.java
@@ -143,6 +143,17 @@ public class JSONSchemaValidationTest {
     }
 
     @Test
+    public void allowsPublishedBy() {
+        final EventType et = EventTypeTestBuilder.builder().name("some-event-type").schema(basicSchema()).build();
+        et.setCategory(EventCategory.BUSINESS);
+
+        final JSONObject event = businessEvent();
+        event.getJSONObject("metadata").put("published_by", "test-invalid-publisher");
+
+        final Optional<ValidationError> noError = eventValidatorBuilder.build(et).validate(event);
+    }
+
+    @Test
     public void requireEidToBeFormattedAsUUID() {
         final EventType et = EventTypeTestBuilder.builder().name("some-event-type").schema(basicSchema()).build();
         et.setCategory(EventCategory.BUSINESS);

--- a/core-services/src/test/java/org/zalando/nakadi/validation/JSONSchemaValidationTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/validation/JSONSchemaValidationTest.java
@@ -151,6 +151,7 @@ public class JSONSchemaValidationTest {
         event.getJSONObject("metadata").put("published_by", "test-invalid-publisher");
 
         final Optional<ValidationError> noError = eventValidatorBuilder.build(et).validate(event);
+        Assert.assertThat(noError, IsOptional.isAbsent());
     }
 
     @Test


### PR DESCRIPTION
# bugfix: adding metadata.published_by to effective schema

> Zalando ticket : ARUHA-2896

## Description
Missing `metadata.published_by` in effective schema blocks clients that forward an event from one topic to another when Nakadi started enriching metadata with published_by. Adding the `published_by` to the schema of metadata should unblock such clients.

## Review
- [ ] Tests
- [ ] Documentation

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
