### PR TITLE
Using different image name for PR build

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -30,5 +30,8 @@ pipeline:
         cmd: |
           ./gradlew clean app:bootJar
           IMAGE="registry-write.opensource.zalan.do/aruha/nakadi-oss:${CDP_BUILD_VERSION}"
+          if [ "$CDP_PULL_REQUEST_NUMBER" ]; then
+            IMAGE="registry-write.opensource.zalan.do/aruha/nakadi-oss-pr:${CDP_BUILD_VERSION}"
+          fi
           docker build -t ${IMAGE} .
           docker push ${IMAGE}


### PR DESCRIPTION
# Using different image name for PR build

> Zalando ticket : ARUHA-3086

## Description
Adding `-pr` to the image name of the docker images built from a pull request to identify them easily.

## Review
- [ ] Tests
- [ ] Documentation

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
