### PR TITLE
fix mismatch between the documentation and the implementation for problem-json

### DIFF
--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -2387,7 +2387,6 @@ definitions:
           An absolute URI that identifies the specific occurrence of the problem.
           It may or may not yield further information if dereferenced.
     required:
-      - type
       - title
       - status
 


### PR DESCRIPTION
# One-line summary

> Zalando ticket : ARUHA / issues / 118

## Description
There is a mismatch between the [documentation](https://nakadi.io/manual.html#definition_Problem) and the implementation.

In the documentation [type key](https://nakadi.io/manual.html#definition_Problem*type) looks like a mandatory one (can see a red star next to it) but it is absent in the response from the server.

As a result, a library implementation might incorrectly rely on this field (e.g. _kanadi_ that considers that the key is a mandatory one and cannot parse the problem response (but interprets it as a different type of error) ).

examples of the response:
```json
{"title":"Forbidden","status":403,"detail":"Access on READ subscription:e1eeeb6d-1819-48de-924e-ded2fe983c9e denied"}

{"title":"Conflict","status":409,"detail":"Resetting subscription cursors request is still in progress"}
```

^ as we can see, "type" key is absent.


**The PR fixes the problem by making this field optional.**