### PR TITLE
Fix acceptance test build

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -18,7 +18,7 @@ pipeline:
         cmd: |
           apt-get update
           apt-get install -y python3-pip python3-setuptools python3-wheel gcc python3-dev libffi-dev gcc libc-dev make
-          pip3 install docker-compose==1.26.2
+          pip3 install docker-compose==1.27.4
       - desc: Acceptance Test
         cmd: |
           ./gradlew fullAcceptanceTest --stacktrace


### PR DESCRIPTION
The build is failing currently with the following error:
```
2020-11-25T14:44:52.350Z /usr/local/lib/python3.5/dist-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
2020-11-25T14:44:54.357Z   from cryptography.hazmat.backends import default_backend
2020-11-25T14:44:54.357Z Traceback (most recent call last):
2020-11-25T14:44:54.357Z   File "/usr/local/lib/python3.5/dist-packages/jsonschema/__init__.py", line 31, in <module>
2020-11-25T14:44:54.357Z     from importlib import metadata
2020-11-25T14:44:54.357Z ImportError: cannot import name 'metadata'
2020-11-25T14:44:54.357Z 
2020-11-25T14:44:54.357Z During handling of the above exception, another exception occurred:
2020-11-25T14:44:54.357Z 
2020-11-25T14:44:54.357Z Traceback (most recent call last):
2020-11-25T14:44:54.357Z   File "/usr/local/bin/docker-compose", line 7, in <module>
2020-11-25T14:44:54.357Z     from compose.cli.main import main
2020-11-25T14:44:54.357Z   File "/usr/local/lib/python3.5/dist-packages/compose/cli/main.py", line 24, in <module>
2020-11-25T14:44:54.357Z     from ..config import ConfigurationError
2020-11-25T14:44:54.357Z   File "/usr/local/lib/python3.5/dist-packages/compose/config/__init__.py", line 6, in <module>
2020-11-25T14:44:54.357Z     from .config import ConfigurationError
2020-11-25T14:44:54.357Z   File "/usr/local/lib/python3.5/dist-packages/compose/config/config.py", line 51, in <module>
2020-11-25T14:44:54.357Z     from .validation import match_named_volumes
2020-11-25T14:44:54.357Z   File "/usr/local/lib/python3.5/dist-packages/compose/config/validation.py", line 12, in <module>
2020-11-25T14:44:54.357Z     from jsonschema import Draft4Validator
2020-11-25T14:44:54.357Z   File "/usr/local/lib/python3.5/dist-packages/jsonschema/__init__.py", line 33, in <module>
2020-11-25T14:44:54.357Z     import importlib_metadata as metadata
2020-11-25T14:44:54.357Z   File "/usr/local/lib/python3.5/dist-packages/importlib_metadata/__init__.py", line 43, in <module>
2020-11-25T14:44:54.357Z     class PackageNotFoundError(ModuleNotFoundError):
2020-11-25T14:44:54.357Z NameError: name 'ModuleNotFoundError' is not defined
```

# One-line summary

> Zalando ticket : ARUHA-XXX (only if appropriate)

## Description
A few sentences describing the overall goals of the pull request's
commits.

## Review
- [ ] Tests
- [ ] Documentation

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
