### PR TITLE
Fix acceptance test build

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -22,18 +22,18 @@ pipeline:
           apt-get update
       - desc: Install dependencies
         cmd: |
-          apt-get install -q -y --no-install-recommends python3.6 \
-                                                        python3.6-dev \
+          apt-get install -q -y --no-install-recommends python3.7 \
+                                                        python3.7-dev \
                                                         python3-pip \
                                                         python3-venv \
-                                                        python3.6-venv \
+                                                        python3.7-venv \
                                                         python3-setuptools \
                                                         python3-wheel \
                                                         gcc \
                                                         libffi-dev \
                                                         libssl-dev \
                                                         make
-          update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 10
+          update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 10
           pip3 install --no-cache-dir docker-compose==1.27.4
       - desc: Acceptance Test
         cmd: |

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -22,18 +22,18 @@ pipeline:
           apt-get update
       - desc: Install dependencies
         cmd: |
-          apt-get install -q -y --no-install-recommends python3.8 \
-                                                        python3.8-dev \
+          apt-get install -q -y --no-install-recommends python3.6 \
+                                                        python3.6-dev \
                                                         python3-pip \
                                                         python3-venv \
-                                                        python3.8-venv \
+                                                        python3.6-venv \
                                                         python3-setuptools \
                                                         python3-wheel \
                                                         gcc \
                                                         libffi-dev \
                                                         libssl-dev \
                                                         make
-          update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 10
+          update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 10
           pip3 install docker-compose==1.27.4
       - desc: Acceptance Test
         cmd: |

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -34,7 +34,7 @@ pipeline:
                                                         libssl-dev \
                                                         make
           update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 10
-          pip3 install docker-compose==1.27.4
+          pip3 install --no-cache-dir docker-compose==1.27.4
       - desc: Acceptance Test
         cmd: |
           ./gradlew fullAcceptanceTest --stacktrace

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -17,7 +17,7 @@ pipeline:
       - desc: Install dependencies
         cmd: |
           apt-get update
-          apt-get install -y python3-pip python3-setuptools python3-wheel gcc python3-dev libffi-dev gcc libc-dev make
+          apt-get install -y python3.8-pip python3.8-setuptools python3.8-wheel gcc python3.8-dev libffi-dev gcc libc-dev make
           pip3 install docker-compose==1.27.4
       - desc: Acceptance Test
         cmd: |

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -14,9 +14,10 @@ pipeline:
     overlay: ci/java
     type: script
     commands:
-      - desc: Add PPA
+      - desc: Install dependencies
         cmd: |
           sudo curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          echo '04216d65ce0cd3c27223eab035abfeb20a8bef20259398e3b9d9aa8de633286d */usr/local/bin/docker-compose' | sha256sum -c
           sudo chmod +x /usr/local/bin/docker-compose
           docker-compose --version
       - desc: Acceptance Test

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -18,7 +18,7 @@ pipeline:
         cmd: |
           apt-get update
           apt-get install -y python3-pip python3-setuptools python3-wheel gcc python3-dev libffi-dev gcc libc-dev make
-          pip3 install docker-compose==1.26.2
+          pip3 install docker-compose==1.27.4
       - desc: Acceptance Test
         cmd: |
           ./gradlew fullAcceptanceTest --stacktrace

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -15,26 +15,10 @@ pipeline:
     type: script
     commands:
       - desc: Add PPA
-        cmd: |
-          apt-get update
-          apt-get install -q -y --no-install-recommends software-properties-common
-          add-apt-repository -y ppa:deadsnakes/ppa
-          apt-get update
-      - desc: Install dependencies
-        cmd: |
-          apt-get install -q -y --no-install-recommends python3.7 \
-                                                        python3.7-dev \
-                                                        python3-pip \
-                                                        python3-venv \
-                                                        python3.7-venv \
-                                                        python3-setuptools \
-                                                        python3-wheel \
-                                                        gcc \
-                                                        libffi-dev \
-                                                        libssl-dev \
-                                                        make
-          update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 10
-          pip3 install --no-cache-dir docker-compose==1.27.4
+        cmd:
+          sudo curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose --version
       - desc: Acceptance Test
         cmd: |
           ./gradlew fullAcceptanceTest --stacktrace

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -15,7 +15,7 @@ pipeline:
     type: script
     commands:
       - desc: Add PPA
-        cmd:
+        cmd: |
           sudo curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
           docker-compose --version

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -14,10 +14,26 @@ pipeline:
     overlay: ci/java
     type: script
     commands:
-      - desc: Install dependencies
+      - desc: Add PPA
         cmd: |
           apt-get update
-          apt-get install -y python3.8-pip python3.8-setuptools python3.8-wheel gcc python3.8-dev libffi-dev gcc libc-dev make
+          apt-get install -q -y --no-install-recommends software-properties-common
+          add-apt-repository -y ppa:deadsnakes/ppa
+          apt-get update
+      - desc: Install dependencies
+        cmd: |
+          apt-get install -q -y --no-install-recommends python3.8 \
+                                                        python3.8-dev \
+                                                        python3-pip \
+                                                        python3-venv \
+                                                        python3.8-venv \
+                                                        python3-setuptools \
+                                                        python3-wheel \
+                                                        gcc \
+                                                        libffi-dev \
+                                                        libssl-dev \
+                                                        make
+          update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 10
           pip3 install docker-compose==1.27.4
       - desc: Acceptance Test
         cmd: |


### PR DESCRIPTION
The build is failing currently with the following error:

```
2020-11-25T14:44:52.350Z /usr/local/lib/python3.5/dist-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
2020-11-25T14:44:54.357Z   from cryptography.hazmat.backends import default_backend
2020-11-25T14:44:54.357Z Traceback (most recent call last):
2020-11-25T14:44:54.357Z   File "/usr/local/lib/python3.5/dist-packages/jsonschema/__init__.py", line 31, in <module>
2020-11-25T14:44:54.357Z     from importlib import metadata
2020-11-25T14:44:54.357Z ImportError: cannot import name 'metadata'
2020-11-25T14:44:54.357Z 
2020-11-25T14:44:54.357Z During handling of the above exception, another exception occurred:
2020-11-25T14:44:54.357Z 
2020-11-25T14:44:54.357Z Traceback (most recent call last):
2020-11-25T14:44:54.357Z   File "/usr/local/bin/docker-compose", line 7, in <module>
2020-11-25T14:44:54.357Z     from compose.cli.main import main
2020-11-25T14:44:54.357Z   File "/usr/local/lib/python3.5/dist-packages/compose/cli/main.py", line 24, in <module>
2020-11-25T14:44:54.357Z     from ..config import ConfigurationError
2020-11-25T14:44:54.357Z   File "/usr/local/lib/python3.5/dist-packages/compose/config/__init__.py", line 6, in <module>
2020-11-25T14:44:54.357Z     from .config import ConfigurationError
2020-11-25T14:44:54.357Z   File "/usr/local/lib/python3.5/dist-packages/compose/config/config.py", line 51, in <module>
2020-11-25T14:44:54.357Z     from .validation import match_named_volumes
2020-11-25T14:44:54.357Z   File "/usr/local/lib/python3.5/dist-packages/compose/config/validation.py", line 12, in <module>
2020-11-25T14:44:54.357Z     from jsonschema import Draft4Validator
2020-11-25T14:44:54.357Z   File "/usr/local/lib/python3.5/dist-packages/jsonschema/__init__.py", line 33, in <module>
2020-11-25T14:44:54.357Z     import importlib_metadata as metadata
2020-11-25T14:44:54.357Z   File "/usr/local/lib/python3.5/dist-packages/importlib_metadata/__init__.py", line 43, in <module>
2020-11-25T14:44:54.357Z     class PackageNotFoundError(ModuleNotFoundError):
2020-11-25T14:44:54.357Z NameError: name 'ModuleNotFoundError' is not defined
```

# One-line summary

> Zalando ticket : ARUHA-XXX (only if appropriate)

## Description
A few sentences describing the overall goals of the pull request's
commits.

## Review
- [ ] Tests
- [ ] Documentation

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
