### PR TITLE
Building and running on Java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:1.8.0-191-19
+FROM registry.opensource.zalan.do/library/openjdk-11-jre-slim:11-jre-slim-20201005
 
 MAINTAINER Team Aruha, team-aruha@zalando.de
 

--- a/acceptance-test/build.gradle
+++ b/acceptance-test/build.gradle
@@ -14,8 +14,6 @@ apply plugin: 'io.spring.dependency-management'
 apply plugin: 'org.owasp.dependencycheck'
 
 group 'org.zalando'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 sourceSets {
     acceptanceTest {

--- a/api-consumption/build.gradle
+++ b/api-consumption/build.gradle
@@ -14,8 +14,6 @@ apply plugin: 'io.spring.dependency-management'
 apply plugin: 'org.owasp.dependencycheck'
 
 group 'org.zalando'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 configurations {
     all*.exclude module: 'spring-boot-starter-logging'

--- a/api-cursors/build.gradle
+++ b/api-cursors/build.gradle
@@ -14,8 +14,6 @@ apply plugin: 'io.spring.dependency-management'
 apply plugin: 'org.owasp.dependencycheck'
 
 group 'org.zalando'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 configurations {
     all*.exclude module: 'spring-boot-starter-logging'

--- a/api-metastore/build.gradle
+++ b/api-metastore/build.gradle
@@ -14,8 +14,6 @@ apply plugin: 'io.spring.dependency-management'
 apply plugin: 'org.owasp.dependencycheck'
 
 group 'org.zalando'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 configurations {
     all*.exclude module: 'spring-boot-starter-logging'

--- a/api-misc/build.gradle
+++ b/api-misc/build.gradle
@@ -14,8 +14,6 @@ apply plugin: 'io.spring.dependency-management'
 apply plugin: 'org.owasp.dependencycheck'
 
 group 'org.zalando'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 configurations {
     all*.exclude module: 'spring-boot-starter-logging'

--- a/api-publishing/build.gradle
+++ b/api-publishing/build.gradle
@@ -14,8 +14,6 @@ apply plugin: 'io.spring.dependency-management'
 apply plugin: 'org.owasp.dependencycheck'
 
 group 'org.zalando'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 configurations {
     all*.exclude module: 'spring-boot-starter-logging'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,6 @@ apply plugin: 'io.spring.dependency-management'
 apply plugin: 'org.owasp.dependencycheck'
 
 group 'org.zalando'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 configurations {
     all*.exclude module: 'spring-boot-starter-logging'
@@ -44,6 +42,8 @@ dependencies {
     compile project(':api-metastore')
     compile project(':api-cursors')
     compile project(':api-misc')
+
+    compile "org.glassfish.jaxb:jaxb-runtime"
 
     compile "org.apache.kafka:kafka-clients:$kafkaClientVersion"
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,12 @@ subprojects {
     apply plugin: 'checkstyle'
     apply plugin: 'jacoco'
 
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(11)
+        }
+    }
+
     checkstyle {
         configFile = new File(rootDir, "checkstyle.xml")
         toolVersion = "8.34"

--- a/core-common/build.gradle
+++ b/core-common/build.gradle
@@ -14,8 +14,6 @@ apply plugin: 'io.spring.dependency-management'
 apply plugin: 'org.owasp.dependencycheck'
 
 group 'org.zalando'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 configurations {
     all*.exclude module: 'spring-boot-starter-logging'

--- a/core-metastore/build.gradle
+++ b/core-metastore/build.gradle
@@ -14,8 +14,6 @@ apply plugin: 'io.spring.dependency-management'
 apply plugin: 'org.owasp.dependencycheck'
 
 group 'org.zalando'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 configurations {
     all*.exclude module: 'spring-boot-starter-logging'

--- a/core-services/build.gradle
+++ b/core-services/build.gradle
@@ -14,8 +14,6 @@ apply plugin: 'io.spring.dependency-management'
 apply plugin: 'org.owasp.dependencycheck'
 
 group 'org.zalando'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 configurations {
     all*.exclude module: 'spring-boot-starter-logging'

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -1,7 +1,7 @@
 version: "2017-09-20"
 pipeline:
   - id: test
-    overlay: ci/java
+    overlay: ci/java11
     type: script
     commands:
       - desc: Checkstyle
@@ -11,7 +11,7 @@ pipeline:
         cmd: |
           ./gradlew test --stacktrace
   - id: acceptance-test
-    overlay: ci/java
+    overlay: ci/java11
     type: script
     commands:
       - desc: Install dependencies
@@ -24,7 +24,7 @@ pipeline:
         cmd: |
           ./gradlew fullAcceptanceTest --stacktrace
   - id: build-push
-    overlay: ci/java
+    overlay: ci/java11
     type: script
     commands:
       - desc: Build and push to repo

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Mon Jul 06 11:38:21 CEST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
https://jira.zalando.net/browse/ARUHA-3111

This PR makes the least changes necessary to build and run Nakadi on
Java 11.

- uses approved base image
https://cloud.docs.zalando.net/howtos/compliant-images/#use-of-allowed-docker-base-images
- upgraded gradle to 6.7.1 which introduced `toolchain`
https://docs.gradle.org/current/userguide/toolchains.html which helps
us make sure that the same java version is used everywhere
- included an extra dependency (unfortunatelly) to fix springboot
dependency which is no longer part of default java module
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-with-Java-9-and-above

This way the app builds and passes acceptance tests. I'm not sure this
is production ready yet as there could be changes in GC, for
example. Some work is still required.
