### PR TITLE
Removed exhibitor support, upgrading curator to 5.1.0

### DIFF
--- a/acceptance-test/build.gradle
+++ b/acceptance-test/build.gradle
@@ -36,7 +36,7 @@ configurations {
 dependencies {
     ext {
         dropwizardVersion = '3.1.3'
-        curatorVersion = '4.2.0'
+        curatorVersion = '5.1.0'
         zookeeperVersion = '3.6.1'
         jacksonVersion = '2.9.8'
     }

--- a/acceptance-test/build.gradle
+++ b/acceptance-test/build.gradle
@@ -34,12 +34,6 @@ configurations {
 }
 
 dependencies {
-    ext {
-        dropwizardVersion = '3.1.3'
-        curatorVersion = '5.1.0'
-        zookeeperVersion = '3.6.1'
-        jacksonVersion = '2.9.8'
-    }
     // Override spring-boot BOM versions
     ext['json.version'] = '20180130'
     ext['json-path'] = '2.4.0'

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/db/StorageDbRepositoryTest.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/db/StorageDbRepositoryTest.java
@@ -49,7 +49,7 @@ public class StorageDbRepositoryTest extends AbstractDbRepositoryTest {
     @Test
     public void testStorageCreated() {
         final String name = randomUUID();
-        final Storage storage = createStorage(name, ZookeeperConnection.valueOf("exhibitor://exaddress:8181/path"));
+        final Storage storage = createStorage(name, ZookeeperConnection.valueOf("zookeeper://exaddress:8181/path"));
 
         repository.createStorage(storage);
 
@@ -65,11 +65,11 @@ public class StorageDbRepositoryTest extends AbstractDbRepositoryTest {
         final String namePrefix = randomValidStringOfLength(31);
 
         final Storage storage2 = repository.createStorage(
-                createStorage(namePrefix + "2", ZookeeperConnection.valueOf("exhibitor://exaddress1:8181/path3")));
+                createStorage(namePrefix + "2", ZookeeperConnection.valueOf("zookeeper://exaddress1:8181/path3")));
         final Storage storage1 = repository.createStorage(
-                createStorage(namePrefix + "1", ZookeeperConnection.valueOf("exhibitor://exaddress2:8181/path2")));
+                createStorage(namePrefix + "1", ZookeeperConnection.valueOf("zookeeper://exaddress2:8181/path2")));
         final Storage storage3 = repository.createStorage(
-                createStorage(namePrefix + "3", ZookeeperConnection.valueOf("exhibitor://exaddress3:8181/path1")));
+                createStorage(namePrefix + "3", ZookeeperConnection.valueOf("zookeeper://exaddress3:8181/path1")));
 
         final List<Storage> storages = repository.listStorages().stream()
                 .filter(st -> st.getId() != null)
@@ -86,7 +86,7 @@ public class StorageDbRepositoryTest extends AbstractDbRepositoryTest {
     public void testStorageDeleted() {
         final String name = randomUUID();
         final Storage storage = repository.createStorage(
-                createStorage(name, ZookeeperConnection.valueOf("exhibitor://exaddress:8181/path")));
+                createStorage(name, ZookeeperConnection.valueOf("zookeeper://exaddress:8181/path")));
         assertEquals(storage, repository.getStorage(storage.getId()).get());
         repository.deleteStorage(storage.getId());
         assertFalse(repository.getStorage(storage.getId()).isPresent());
@@ -101,7 +101,7 @@ public class StorageDbRepositoryTest extends AbstractDbRepositoryTest {
     public void testDeleteUsedStorage() {
         final String name = randomUUID();
         final Storage storage = repository.createStorage(
-                createStorage(name, ZookeeperConnection.valueOf("exhibitor://exaddress:8181/path")));
+                createStorage(name, ZookeeperConnection.valueOf("zookeeper://exaddress:8181/path")));
 
         final EventType eventType = eventTypeDbRepository.saveEventType(TestUtils.buildDefaultEventType());
         final Timeline timeline = TimelineDbRepositoryTest.createTimeline(storage, UUID.randomUUID(), 0, "topic",

--- a/api-consumption/build.gradle
+++ b/api-consumption/build.gradle
@@ -22,12 +22,6 @@ configurations {
 }
 
 dependencies {
-    ext {
-        dropwizardVersion = '3.1.3'
-        curatorVersion = '5.1.0'
-        zookeeperVersion = '3.6.1'
-        jacksonVersion = '2.9.8'
-    }
     // Override spring-boot BOM versions
     ext['json.version'] = '20180130'
     ext['json-path'] = '2.4.0'

--- a/api-consumption/build.gradle
+++ b/api-consumption/build.gradle
@@ -24,7 +24,7 @@ configurations {
 dependencies {
     ext {
         dropwizardVersion = '3.1.3'
-        curatorVersion = '4.2.0'
+        curatorVersion = '5.1.0'
         zookeeperVersion = '3.6.1'
         jacksonVersion = '2.9.8'
     }

--- a/api-cursors/build.gradle
+++ b/api-cursors/build.gradle
@@ -22,12 +22,6 @@ configurations {
 }
 
 dependencies {
-    ext {
-        dropwizardVersion = '3.1.3'
-        curatorVersion = '5.1.0'
-        zookeeperVersion = '3.6.1'
-        jacksonVersion = '2.9.8'
-    }
     // Override spring-boot BOM versions
     ext['json.version'] = '20180130'
     ext['json-path'] = '2.4.0'

--- a/api-cursors/build.gradle
+++ b/api-cursors/build.gradle
@@ -24,7 +24,7 @@ configurations {
 dependencies {
     ext {
         dropwizardVersion = '3.1.3'
-        curatorVersion = '4.2.0'
+        curatorVersion = '5.1.0'
         zookeeperVersion = '3.6.1'
         jacksonVersion = '2.9.8'
     }

--- a/api-misc/build.gradle
+++ b/api-misc/build.gradle
@@ -22,12 +22,6 @@ configurations {
 }
 
 dependencies {
-    ext {
-        dropwizardVersion = '3.1.3'
-        curatorVersion = '5.1.0'
-        zookeeperVersion = '3.6.1'
-        jacksonVersion = '2.9.8'
-    }
     // Override spring-boot BOM versions
     ext['json.version'] = '20180130'
     ext['json-path'] = '2.4.0'

--- a/api-misc/build.gradle
+++ b/api-misc/build.gradle
@@ -24,7 +24,7 @@ configurations {
 dependencies {
     ext {
         dropwizardVersion = '3.1.3'
-        curatorVersion = '4.2.0'
+        curatorVersion = '5.1.0'
         zookeeperVersion = '3.6.1'
         jacksonVersion = '2.9.8'
     }

--- a/api-misc/src/test/java/org/zalando/nakadi/controller/StoragesControllerTest.java
+++ b/api-misc/src/test/java/org/zalando/nakadi/controller/StoragesControllerTest.java
@@ -124,7 +124,7 @@ public class StoragesControllerTest {
         storage.setId(id);
         storage.setType(Storage.Type.KAFKA);
         final KafkaConfiguration config = new KafkaConfiguration(
-                ZookeeperConnection.valueOf("exhibitor://localhost:8181/path/to/kafka"));
+                ZookeeperConnection.valueOf("zookeeper://localhost:8181/path/to/kafka"));
         storage.setConfiguration(config);
 
         return storage;
@@ -135,7 +135,7 @@ public class StoragesControllerTest {
         json.put("id", id);
         json.put("storage_type", "kafka");
         final JSONObject config = new JSONObject();
-        config.put("zoookeeper_connection", "exhibitor://localhost:8181/path/to/kafka");
+        config.put("zoookeeper_connection", "zookeeper://localhost:8181/path/to/kafka");
         json.put("kafka_configuration", config);
 
         return json;

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,7 +26,7 @@ configurations {
 dependencies {
     ext {
         dropwizardVersion = '3.1.3'
-        curatorVersion = '4.2.0'
+        curatorVersion = '5.1.0'
         zookeeperVersion = '3.6.1'
         jacksonVersion = '2.9.8'
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,12 +24,6 @@ configurations {
 }
 
 dependencies {
-    ext {
-        dropwizardVersion = '3.1.3'
-        curatorVersion = '5.1.0'
-        zookeeperVersion = '3.6.1'
-        jacksonVersion = '2.9.8'
-    }
     // Override spring-boot BOM versions
     ext['json.version'] = '20180130'
     ext['json-path'] = '2.4.0'

--- a/app/src/test/java/org/zalando/nakadi/config/NakadiConfigTest.java
+++ b/app/src/test/java/org/zalando/nakadi/config/NakadiConfigTest.java
@@ -29,7 +29,7 @@ public class NakadiConfigTest {
         Mockito.when(zooKeeperHolder.get()).thenReturn(curatorFramework);
         Mockito.when(curatorFramework.getData()).thenReturn(dataBuilder);
         Mockito.when(environment.getProperty("nakadi.zookeeper.connection-string"))
-                .thenReturn("exhibitor://localhost:8181/path");
+                .thenReturn("zookeeper://localhost:8181/path");
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,10 @@ subprojects {
     dependencies {
         ext {
             kafkaClientVersion = '2.6.0'
+            dropwizardVersion = '3.1.3'
+            curatorVersion = '5.1.0'
+            zookeeperVersion = '3.6.1'
+            jacksonVersion = '2.9.8'
         }
     }
 }

--- a/core-common/build.gradle
+++ b/core-common/build.gradle
@@ -23,12 +23,6 @@ configurations {
 }
 
 dependencies {
-    ext {
-        dropwizardVersion = '3.1.3'
-        curatorVersion = '5.1.0'
-        zookeeperVersion = '3.6.1'
-        jacksonVersion = '2.9.8'
-    }
     // Override spring-boot BOM versions
     ext['json.version'] = '20180130'
     ext['json-path'] = '2.4.0'

--- a/core-common/build.gradle
+++ b/core-common/build.gradle
@@ -25,7 +25,7 @@ configurations {
 dependencies {
     ext {
         dropwizardVersion = '3.1.3'
-        curatorVersion = '4.2.0'
+        curatorVersion = '5.1.0'
         zookeeperVersion = '3.6.1'
         jacksonVersion = '2.9.8'
     }

--- a/core-common/src/main/java/org/zalando/nakadi/domain/storage/ZookeeperConnectionType.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/storage/ZookeeperConnectionType.java
@@ -2,5 +2,4 @@ package org.zalando.nakadi.domain.storage;
 
 public enum ZookeeperConnectionType {
     ZOOKEEPER,
-    EXHIBITOR,
 }

--- a/core-common/src/main/java/org/zalando/nakadi/repository/zookeeper/ZooKeeperHolder.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/zookeeper/ZooKeeperHolder.java
@@ -106,8 +106,6 @@ public class ZooKeeperHolder {
 
     private EnsembleProvider createEnsembleProvider() throws Exception {
         switch (conn.getType()) {
-            case EXHIBITOR:
-                throw new RuntimeException("Exhibitor support is removed on 2020-12-15; use zookeeper connection");
             case ZOOKEEPER:
                 final String addressesJoined = conn.getAddresses().stream()
                         .map(AddressPort::asAddressPort)

--- a/core-common/src/main/java/org/zalando/nakadi/repository/zookeeper/ZooKeeperHolder.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/zookeeper/ZooKeeperHolder.java
@@ -15,8 +15,8 @@ import java.util.stream.Collectors;
 
 public class ZooKeeperHolder {
 
-    private static final int EXHIBITOR_RETRY_TIME = 1000;
-    private static final int EXHIBITOR_RETRY_MAX = 3;
+    private static final int CURATOR_RETRY_TIME = 1000;
+    private static final int CURATOR_RETRY_MAX = 3;
 
     private final Integer connectionTimeoutMs;
     private final long maxCommitTimeoutMs;
@@ -96,7 +96,7 @@ public class ZooKeeperHolder {
                                                     final int connectionTimeoutMs) throws Exception {
         final CuratorFramework curatorFramework = CuratorFrameworkFactory.builder()
                 .ensembleProvider(createEnsembleProvider())
-                .retryPolicy(new ExponentialBackoffRetry(EXHIBITOR_RETRY_TIME, EXHIBITOR_RETRY_MAX))
+                .retryPolicy(new ExponentialBackoffRetry(CURATOR_RETRY_TIME, CURATOR_RETRY_MAX))
                 .sessionTimeoutMs(sessionTimeoutMs)
                 .connectionTimeoutMs(connectionTimeoutMs)
                 .build();

--- a/core-common/src/main/java/org/zalando/nakadi/repository/zookeeper/ZooKeeperHolder.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/zookeeper/ZooKeeperHolder.java
@@ -1,10 +1,6 @@
 package org.zalando.nakadi.repository.zookeeper;
 
 import org.apache.curator.ensemble.EnsembleProvider;
-import org.apache.curator.ensemble.exhibitor.DefaultExhibitorRestClient;
-import org.apache.curator.ensemble.exhibitor.ExhibitorEnsembleProvider;
-import org.apache.curator.ensemble.exhibitor.ExhibitorRestClient;
-import org.apache.curator.ensemble.exhibitor.Exhibitors;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
@@ -21,7 +17,6 @@ public class ZooKeeperHolder {
 
     private static final int EXHIBITOR_RETRY_TIME = 1000;
     private static final int EXHIBITOR_RETRY_MAX = 3;
-    private static final int EXHIBITOR_POLLING_MS = 300000;
 
     private final Integer connectionTimeoutMs;
     private final long maxCommitTimeoutMs;
@@ -112,26 +107,7 @@ public class ZooKeeperHolder {
     private EnsembleProvider createEnsembleProvider() throws Exception {
         switch (conn.getType()) {
             case EXHIBITOR:
-                final Exhibitors exhibitors = new Exhibitors(
-                        conn.getAddresses().stream().map(AddressPort::getAddress).collect(Collectors.toList()),
-                        conn.getAddresses().get(0).getPort(),
-                        () -> {
-                            throw new RuntimeException("There is no backup connection string (or it is wrong)");
-                        });
-                final ExhibitorRestClient exhibitorRestClient = new DefaultExhibitorRestClient();
-                final ExhibitorEnsembleProvider result = new ExhibitorEnsembleProvider(
-                        exhibitors,
-                        exhibitorRestClient,
-                        "/exhibitor/v1/cluster/list",
-                        EXHIBITOR_POLLING_MS,
-                        new ExponentialBackoffRetry(EXHIBITOR_RETRY_TIME, EXHIBITOR_RETRY_MAX)) {
-                    @Override
-                    public String getConnectionString() {
-                        return super.getConnectionString() + conn.getPathPrepared();
-                    }
-                };
-                result.pollForInitialEnsemble();
-                return result;
+                throw new RuntimeException("Exhibitor support is removed on 2020-12-15; use zookeeper connection");
             case ZOOKEEPER:
                 final String addressesJoined = conn.getAddresses().stream()
                         .map(AddressPort::asAddressPort)

--- a/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/AbstractZkSubscriptionClient.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/AbstractZkSubscriptionClient.java
@@ -301,7 +301,6 @@ public abstract class AbstractZkSubscriptionClient implements ZkSubscriptionClie
 
         return () -> {
             try {
-                cursorResetCache.getListenable().clear();
                 cursorResetCache.close();
             } catch (final IOException e) {
                 throw new NakadiRuntimeException(e);

--- a/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionImpl.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionImpl.java
@@ -67,7 +67,7 @@ public abstract class ZkSubscriptionImpl<ReturnType, ZkType> implements ZkSubscr
 
     @Override
     public void close() {
-        if (listener != null && !curatorFramework.isZk34CompatibilityMode()) {
+        if (listener != null) {
             try {
                 curatorFramework.watches().remove(this).forPath(key);
             } catch (final Exception ex) {

--- a/core-common/src/test/java/org/zalando/nakadi/domain/storage/ZookeeperConnectionTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/domain/storage/ZookeeperConnectionTest.java
@@ -16,12 +16,6 @@ public class ZookeeperConnectionTest {
     public static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[]{
-                        "exhibitor://localhost:8181/path",
-                        new ZookeeperConnection(
-                                ZookeeperConnectionType.EXHIBITOR,
-                                Collections.singletonList(new AddressPort("localhost", 8181)),
-                                "/path")
-                }, new Object[]{
                         "zookeeper://localhost:8181/path",
                         new ZookeeperConnection(
                                 ZookeeperConnectionType.ZOOKEEPER,

--- a/core-metastore/build.gradle
+++ b/core-metastore/build.gradle
@@ -22,12 +22,6 @@ configurations {
 }
 
 dependencies {
-    ext {
-        dropwizardVersion = '3.1.3'
-        curatorVersion = '5.1.0'
-        zookeeperVersion = '3.6.1'
-        jacksonVersion = '2.9.8'
-    }
     // Override spring-boot BOM versions
     ext['json.version'] = '20180130'
     ext['json-path'] = '2.4.0'

--- a/core-metastore/build.gradle
+++ b/core-metastore/build.gradle
@@ -24,7 +24,7 @@ configurations {
 dependencies {
     ext {
         dropwizardVersion = '3.1.3'
-        curatorVersion = '4.2.0'
+        curatorVersion = '5.1.0'
         zookeeperVersion = '3.6.1'
         jacksonVersion = '2.9.8'
     }

--- a/core-services/build.gradle
+++ b/core-services/build.gradle
@@ -22,12 +22,6 @@ configurations {
 }
 
 dependencies {
-    ext {
-        dropwizardVersion = '3.1.3'
-        curatorVersion = '5.1.0'
-        zookeeperVersion = '3.6.1'
-        jacksonVersion = '2.9.8'
-    }
     // Override spring-boot BOM versions
     ext['json.version'] = '20180130'
     ext['json-path'] = '2.4.0'

--- a/core-services/build.gradle
+++ b/core-services/build.gradle
@@ -24,7 +24,7 @@ configurations {
 dependencies {
     ext {
         dropwizardVersion = '3.1.3'
-        curatorVersion = '4.2.0'
+        curatorVersion = '5.1.0'
         zookeeperVersion = '3.6.1'
         jacksonVersion = '2.9.8'
     }

--- a/core-services/src/test/java/org/zalando/nakadi/service/StorageServiceTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/StorageServiceTest.java
@@ -90,7 +90,7 @@ public class StorageServiceTest {
         storage.setType(Storage.Type.KAFKA);
         storage.setId("123-abc");
         final KafkaConfiguration configuration =
-                new KafkaConfiguration(ZookeeperConnection.valueOf("exhibitor://localhost:8181/path/to/kafka"));
+                new KafkaConfiguration(ZookeeperConnection.valueOf("zookeeper://localhost:8181/path/to/kafka"));
         storage.setConfiguration(configuration);
         return storage;
     }

--- a/core-services/src/test/java/org/zalando/nakadi/service/StorageServiceTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/StorageServiceTest.java
@@ -77,8 +77,6 @@ public class StorageServiceTest {
         json.put("id", id);
         json.put("storage_type", "kafka");
         final JSONObject configuration = new JSONObject();
-        configuration.put("exhibitor_address", "https://localhost");
-        configuration.put("exhibitor_port", 8181);
         configuration.put("zk_address", "https://localhost");
         configuration.put("zk_path", "/path/to/kafka");
         json.put("kafka_configuration", configuration);


### PR DESCRIPTION
# Removed exhibitor support, upgrading curator to 5.1.0

> Zalando ticket : ARUHA-3237

## Description
Incompatible versions of zookeeper and curator causes some runtime exceptions (`java.lang.NoSuchFieldError: addr`), which are fixed by upgrading curator to latest compatible version. Exhibitor support had to be removed when curator is upgraded.

## Review
- [ ] Tests
- [ ] Documentation

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
