### PR TITLE
Use more optimal way of publishing events to internal event types, to reduce the chance of overload.

### DIFF
--- a/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventsProcessor.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventsProcessor.java
@@ -137,7 +137,7 @@ public class EventsProcessor {
      * Generates batches from {@link #eventsQueue} single events with the following constraints:
      * <ul>
      *     <li>Batch size is not more than {@link #maxBatchSize} events each</li>
-     *     <li>Eatch batch is assembled for at most {@link #batchCollectionTimeout} ms (or close to it)</li>
+     *     <li>Each batch is assembled for at most {@link #batchCollectionTimeout} ms (or close to it)</li>
      * </ul>
      */
     private void dispatch() {

--- a/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventsProcessor.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventsProcessor.java
@@ -10,11 +10,13 @@ import org.springframework.stereotype.Component;
 import org.zalando.nakadi.util.FlowIdUtils;
 import org.zalando.nakadi.util.UUIDGenerator;
 
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -23,71 +25,143 @@ import java.util.concurrent.TimeUnit;
 public class EventsProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(EventsProcessor.class);
+
     private final EventPublisher eventPublisher;
-    private final Map<String, BlockingQueue<JSONObject>> eventTypeEvents;
     private final ExecutorService executorService;
     private final UUIDGenerator uuidGenerator;
 
     private final long batchCollectionTimeout;
-    private final int batchSize;
-    private final long pollTimeout;
-    private final int eventsQueueSize;
+    private final int maxBatchSize;
+
+    private final BlockingQueue<EventToPublish> eventsQueue;
+    private final Thread dispatcherThread;
+
+    private static class EventToPublish {
+        private final String eventType;
+        private final JSONObject object;
+
+        public EventToPublish(final String eventType, final JSONObject object) {
+            this.eventType = eventType;
+            this.object = object;
+        }
+    }
 
     @Autowired
     public EventsProcessor(final EventPublisher eventPublisher,
                            final UUIDGenerator uuidGenerator,
                            @Value("${nakadi.kpi.config.batch-collection-timeout}") final long batchCollectionTimeout,
-                           @Value("${nakadi.kpi.config.batch-size}") final int batchSize,
+                           @Value("${nakadi.kpi.config.batch-size}") final int maxBatchSize,
                            @Value("${nakadi.kpi.config.workers}") final int workers,
-                           @Value("${nakadi.kpi.config.poll-timeout}") final long pollTimeout,
                            @Value("${nakadi.kpi.config.events-queue-size}") final int eventsQueueSize) {
         this.eventPublisher = eventPublisher;
         this.uuidGenerator = uuidGenerator;
         this.batchCollectionTimeout = batchCollectionTimeout;
-        this.batchSize = batchSize;
-        this.pollTimeout = pollTimeout;
-        this.eventsQueueSize = eventsQueueSize;
-        this.eventTypeEvents = new ConcurrentHashMap<>();
+        this.maxBatchSize = maxBatchSize;
+
         this.executorService = Executors.newFixedThreadPool(workers);
+        this.eventsQueue = new ArrayBlockingQueue<>(eventsQueueSize);
+        this.dispatcherThread = new Thread(this::dispatch, "processor-dispatch");
     }
 
-    private void sendEventBatch(final String etName) {
-        LOG.trace("Collecting batch for {} on {}", etName, Thread.currentThread().getName());
-        try {
-            final BlockingQueue<JSONObject> events = eventTypeEvents.get(etName);
-            if (events == null) {
-                return;
-            }
+    @PostConstruct
+    public void start() {
+        dispatcherThread.start();
+    }
 
-            final long finishAt = System.currentTimeMillis() + batchCollectionTimeout;
-            int eventsCount = 0;
-            JSONArray jsonArray = null;
-            while (eventsCount != batchSize && System.currentTimeMillis() < finishAt) {
-                try {
-                    final JSONObject event = events.poll(pollTimeout, TimeUnit.MILLISECONDS);
-                    if (event != null) {
-                        if (jsonArray == null) {
-                            jsonArray = new JSONArray();
-                        }
-                        jsonArray.put(event);
-                        eventsCount++;
-                    }
-                } catch (final InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                }
-            }
+    @PreDestroy
+    public void stop() throws InterruptedException {
+        dispatcherThread.interrupt();
+        dispatcherThread.join();
+        executorService.shutdown();
+    }
+
+    private static class BatchedRequest {
+        private final String eventType;
+        private final long finishCollectionAt;
+        private final JSONArray data;
+        private int size = 0;
+
+        public BatchedRequest(final String eventType, final long finishCollectionAt) {
+            this.eventType = eventType;
+            this.finishCollectionAt = finishCollectionAt;
+            this.data = new JSONArray();
+        }
+
+        public int add(final JSONObject obj) {
+            this.data.put(obj);
+            return ++size;
+        }
+
+        @Override
+        public String toString() {
+            return "Batch{et=" + eventType + ",size:" + size + "}";
+        }
+    }
+
+    private void scheduleSendBatchedRequest(final BatchedRequest req) {
+        executorService.submit(() -> {
             try {
-                if (eventsCount == 0) {
-                    LOG.trace("No kpi events send to {}", etName);
-                    return;
-                }
-                eventPublisher.processInternal(jsonArray.toString(), etName, false, null, false);
-                LOG.trace("Published batch of {} to {}", eventsCount, etName);
-            } catch (final Exception e) {
-                LOG.error("Error occurred while publishing events to {}, {}", etName, e.getMessage(), e);
+                eventPublisher.processInternal(req.data.toString(), req.eventType, false, null, false);
+            } catch (final RuntimeException ex) {
+                LOG.info("Failed to send single batch for unknown reason", ex);
             }
-        } finally {
-            executorService.submit(() -> sendEventBatch(etName));
+        });
+    }
+
+    private void dispatch() {
+        final Map<String, BatchedRequest> batchesBeingAssembled = new HashMap<>();
+        try {
+            long nextTimeCheck = System.currentTimeMillis() + batchCollectionTimeout;
+            while (true) {
+                long currentTime = System.currentTimeMillis();
+                final EventToPublish data = eventsQueue.poll(
+                        Math.max(nextTimeCheck - currentTime, 1), TimeUnit.MILLISECONDS);
+                currentTime = System.currentTimeMillis();
+                boolean batchWasSent = false;
+                if (data != null) {
+                    BatchedRequest batch = batchesBeingAssembled.get(data.eventType);
+                    if (null == batch) {
+                        batch = new BatchedRequest(data.eventType, currentTime + batchCollectionTimeout);
+                        batchesBeingAssembled.put(data.eventType, batch);
+                    }
+                    if (batch.add(data.object) >= maxBatchSize) {
+                        scheduleSendBatchedRequest(batch);
+                        batchesBeingAssembled.remove(batch.eventType);
+                        currentTime = System.currentTimeMillis();
+                        batchWasSent = true;
+                    }
+                }
+                if (batchWasSent || currentTime > nextTimeCheck) {
+                    nextTimeCheck = currentTime + batchCollectionTimeout;
+                    for (Map.Entry<String, BatchedRequest> entry : batchesBeingAssembled.entrySet()) {
+                        if (entry.getValue().finishCollectionAt < currentTime) {
+                            scheduleSendBatchedRequest(entry.getValue());
+                            batchesBeingAssembled.remove(entry.getKey());
+                        } else if (nextTimeCheck > entry.getValue().finishCollectionAt) {
+                            nextTimeCheck = entry.getValue().finishCollectionAt;
+                        }
+                    }
+                }
+            }
+        } catch (InterruptedException ex) {
+            LOG.info("Was interrupted while dispatching batches");
+        }
+        // now we have a lot of stuff to send
+        EventToPublish taken;
+        while (null != (taken = eventsQueue.poll())) {
+            BatchedRequest batchedRequest = batchesBeingAssembled.get(taken.eventType);
+            if (null == batchedRequest) {
+                batchedRequest = new BatchedRequest(taken.eventType, System.currentTimeMillis());
+                batchesBeingAssembled.put(taken.eventType, batchedRequest);
+            }
+            if (batchedRequest.add(taken.object) >= maxBatchSize) {
+                scheduleSendBatchedRequest(batchedRequest);
+                batchesBeingAssembled.remove(batchedRequest.eventType);
+            }
+        }
+        for (final BatchedRequest req : batchesBeingAssembled.values()) {
+            scheduleSendBatchedRequest(req);
+            batchesBeingAssembled.remove(req.eventType);
         }
     }
 
@@ -98,14 +172,7 @@ public class EventsProcessor {
                 .put("flow_id", FlowIdUtils.peek());
         event.put("metadata", metadata);
 
-        final BlockingQueue<JSONObject> events =
-                eventTypeEvents.computeIfAbsent(etName, etn -> {
-                    LOG.trace("Schedule events collection");
-                    executorService.submit(() -> sendEventBatch(etName));
-                    return new ArrayBlockingQueue<>(eventsQueueSize);
-                });
-
-        if (!events.offer(event)) {
+        if (!eventsQueue.offer(new EventToPublish(etName, event))) {
             LOG.warn("Rejecting events to be queued for {} due to queue overload", etName);
         }
     }

--- a/core-services/src/main/java/org/zalando/nakadi/service/publishing/NamedThreadFactory.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/publishing/NamedThreadFactory.java
@@ -1,0 +1,20 @@
+package org.zalando.nakadi.service.publishing;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class NamedThreadFactory implements ThreadFactory {
+    private final String prefix;
+    private final AtomicInteger counter = new AtomicInteger(0);
+
+    public NamedThreadFactory(final String prefix) {
+        this.prefix = prefix;
+    }
+
+    @Override
+    public Thread newThread(final Runnable runnable) {
+        final Thread t = new Thread(runnable);
+        t.setName(this.prefix + counter.incrementAndGet());
+        return t;
+    }
+}

--- a/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventsProcessorTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventsProcessorTest.java
@@ -16,7 +16,7 @@ public class EventsProcessorTest {
 
     @Test
     public void shouldSendEventWhenSubmitted() {
-        final EventsProcessor eventsProcessor = new EventsProcessor(eventPublisher, uuidGenerator, 100, 1, 1, 100, 10);
+        final EventsProcessor eventsProcessor = new EventsProcessor(eventPublisher, uuidGenerator, 100, 1, 1, 10);
         final JSONObject event = new JSONObject().put("path", "/path/to/event").put("user", "adyachkov");
 
         eventsProcessor.enrichAndSubmit("test_et_name", event);

--- a/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventsProcessorTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventsProcessorTest.java
@@ -15,18 +15,23 @@ public class EventsProcessorTest {
     private final UUIDGenerator uuidGenerator = Mockito.mock(UUIDGenerator.class);
 
     @Test
-    public void shouldSendEventWhenSubmitted() {
-        final EventsProcessor eventsProcessor = new EventsProcessor(eventPublisher, uuidGenerator, 100, 1, 1, 10);
-        final JSONObject event = new JSONObject().put("path", "/path/to/event").put("user", "adyachkov");
+    public void shouldSendEventWhenSubmitted() throws InterruptedException {
+        final EventsProcessor eventsProcessor = new EventsProcessor(eventPublisher, uuidGenerator, 100, 1, 1, 10, 10);
+        eventsProcessor.start();
+        try {
+            final JSONObject event = new JSONObject().put("path", "/path/to/event").put("user", "adyachkov");
 
-        eventsProcessor.enrichAndSubmit("test_et_name", event);
-        TestUtils.waitFor(() -> {
-            try {
-                Mockito.verify(eventPublisher).processInternal(any(), any(), eq(false), any(), eq(false));
-            } catch (final Exception e) {
-                throw new AssertionError(e);
-            }
-        }, 500);
+            eventsProcessor.enrichAndSubmit("test_et_name", event);
+            TestUtils.waitFor(() -> {
+                try {
+                    Mockito.verify(eventPublisher).processInternal(any(), any(), eq(false), any(), eq(false));
+                } catch (final Exception e) {
+                    throw new AssertionError(e);
+                }
+            }, 500);
+        } finally {
+            eventsProcessor.stop();
+        }
     }
 
 }


### PR DESCRIPTION
There is inoptimal thread usage for kpi and supplementary message publishing.
One or several threads may actually block whole the processing flow.
In order to avoid it intermediate batcher thread was introduced, with the only purpose of batching requests.
In case if publishing is stuck, assembled batches are dropped with error message.