### PR TITLE
Respond with status 400 for invalid requests handled by spring security firewall

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/InvalidRequestAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/InvalidRequestAT.java
@@ -4,7 +4,6 @@ import org.apache.http.HttpStatus;
 import org.junit.Test;
 
 import static com.jayway.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.notNullValue;
 
 public class InvalidRequestAT {
     @Test(timeout = 10000)

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/InvalidRequestAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/InvalidRequestAT.java
@@ -1,0 +1,18 @@
+package org.zalando.nakadi.webservice;
+
+import org.apache.http.HttpStatus;
+import org.junit.Test;
+
+import static com.jayway.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class InvalidRequestAT {
+    @Test(timeout = 10000)
+    public void whenRequestRejectedExceptionThrownThenResponseIs400() {
+        given()
+                .when()
+                .get("//")
+                .then()
+                .statusCode(HttpStatus.SC_BAD_REQUEST);
+    }
+}

--- a/app/src/main/java/org/zalando/nakadi/filters/RequestRejectedFilter.java
+++ b/app/src/main/java/org/zalando/nakadi/filters/RequestRejectedFilter.java
@@ -1,23 +1,30 @@
 package org.zalando.nakadi.filters;
 
-import org.aspectj.lang.ProceedingJoinPoint;
-import org.aspectj.lang.annotation.Around;
-import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.web.firewall.RequestRejectedException;
 import org.springframework.stereotype.Component;
+import org.springframework.web.filter.GenericFilterBean;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
-@Aspect
+
 @Component
-public class RequestRejectedFilter {
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RequestRejectedFilter extends GenericFilterBean {
 
-    @Around("execution(public void org.springframework.security.web.FilterChainProxy.doFilter(..))")
-    public void handleRequestRejectedException(ProceedingJoinPoint pjp) throws Throwable {
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
         try {
-            pjp.proceed();
-        } catch (RequestRejectedException exception) {
-            HttpServletResponse response = (HttpServletResponse) pjp.getArgs()[1];
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            chain.doFilter(req, res);
+        } catch (RequestRejectedException e) {
+            HttpServletResponse response = (HttpServletResponse) res;
+
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
         }
     }
 }

--- a/app/src/main/java/org/zalando/nakadi/filters/RequestRejectedFilter.java
+++ b/app/src/main/java/org/zalando/nakadi/filters/RequestRejectedFilter.java
@@ -1,0 +1,23 @@
+package org.zalando.nakadi.filters;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.security.web.firewall.RequestRejectedException;
+import org.springframework.stereotype.Component;
+import javax.servlet.http.HttpServletResponse;
+
+@Aspect
+@Component
+public class RequestRejectedFilter {
+
+    @Around("execution(public void org.springframework.security.web.FilterChainProxy.doFilter(..))")
+    public void handleRequestRejectedException(ProceedingJoinPoint pjp) throws Throwable {
+        try {
+            pjp.proceed();
+        } catch (RequestRejectedException exception) {
+            HttpServletResponse response = (HttpServletResponse) pjp.getArgs()[1];
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+        }
+    }
+}

--- a/app/src/main/java/org/zalando/nakadi/filters/RequestRejectedFilter.java
+++ b/app/src/main/java/org/zalando/nakadi/filters/RequestRejectedFilter.java
@@ -24,7 +24,7 @@ public class RequestRejectedFilter extends GenericFilterBean {
         } catch (RequestRejectedException e) {
             HttpServletResponse response = (HttpServletResponse) res;
 
-            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST);
         }
     }
 }

--- a/app/src/main/java/org/zalando/nakadi/filters/RequestRejectedFilter.java
+++ b/app/src/main/java/org/zalando/nakadi/filters/RequestRejectedFilter.java
@@ -5,6 +5,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.security.web.firewall.RequestRejectedException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.GenericFilterBean;
+
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
@@ -18,11 +19,14 @@ import java.io.IOException;
 public class RequestRejectedFilter extends GenericFilterBean {
 
     @Override
-    public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
+    public void doFilter(final ServletRequest req,
+                         final ServletResponse res,
+                         final FilterChain chain)
+            throws IOException, ServletException {
         try {
             chain.doFilter(req, res);
         } catch (RequestRejectedException e) {
-            HttpServletResponse response = (HttpServletResponse) res;
+            final HttpServletResponse response = (HttpServletResponse) res;
 
             response.sendError(HttpServletResponse.SC_BAD_REQUEST);
         }


### PR DESCRIPTION
# Spring firewall returns 500 when RequestRejectedException is thrown. The correct status code is 400.
This is going to be addressed by https://github.com/spring-projects/spring-security/issues/7568

> Zalando ticket : team-aruha/521

## Review
- [x] Implementation
- [x] Tests
