### PR TITLE
Use latest base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/library/openjdk-11-jre-slim:11-jre-slim-20201005
+FROM registry.opensource.zalan.do/library/openjdk-11-jre-slim:latest
 
 MAINTAINER Team Aruha, team-aruha@zalando.de
 


### PR DESCRIPTION
That makes it easier to stay on top of the latest security release by just re-triggering the build pipeline.
