### PR TITLE
return 422 status when consumed offset is nonsense

### DIFF
--- a/api-metastore/src/main/java/org/zalando/nakadi/controller/advice/PartitionsExceptionHandler.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/controller/advice/PartitionsExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.zalando.nakadi.controller.PartitionsController;
+import org.zalando.nakadi.exceptions.runtime.InvalidCursorException;
 import org.zalando.nakadi.exceptions.runtime.InvalidCursorOperation;
 import org.zalando.nakadi.exceptions.runtime.NotFoundException;
 import org.zalando.problem.Problem;
@@ -33,4 +34,12 @@ public class PartitionsExceptionHandler implements AdviceTrait {
         AdviceTrait.LOG.debug(exception.getMessage());
         return create(Problem.valueOf(NOT_FOUND, exception.getMessage()), request);
     }
+
+    @ExceptionHandler(InvalidCursorException.class)
+    public ResponseEntity<?> handleInvalidCursorException(final InvalidCursorException exception,
+                                                          final NativeWebRequest request) {
+        AdviceTrait.LOG.debug("User provided invalid cursor for operation", exception);
+        return create(Problem.valueOf(UNPROCESSABLE_ENTITY, exception.getMessage()), request);
+    }
+
 }

--- a/api-metastore/src/test/java/org/zalando/nakadi/controller/PartitionsControllerTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/controller/PartitionsControllerTest.java
@@ -51,6 +51,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 import static org.zalando.problem.Status.NOT_FOUND;
 import static org.zalando.problem.Status.SERVICE_UNAVAILABLE;
+import static org.zalando.problem.Status.UNPROCESSABLE_ENTITY;
 
 public class PartitionsControllerTest {
 
@@ -269,6 +270,19 @@ public class PartitionsControllerTest {
         mockMvc.perform(
                 get(String.format("/event-types/%s/partitions/%s", TEST_EVENT_TYPE, TEST_PARTITION)))
                 .andExpect(status().isServiceUnavailable())
+                .andExpect(content().string(TestUtils.JSON_TEST_HELPER.matchesObject(expectedProblem)));
+    }
+
+    @Test
+    public void whenGetPartitionsFromIncorrectConsumedOffsetThenUnprocessable() throws Exception {
+        final String argUnderTest = "xer";
+        final ThrowableProblem expectedProblem =
+                Problem.valueOf(
+                        UNPROCESSABLE_ENTITY,
+                        String.format("invalid offset %s for partition 0", argUnderTest));
+        mockMvc.perform(
+                get("/event-types/{0}/partitions/0?consumed_offset={1}", TEST_EVENT_TYPE, argUnderTest))
+                .andExpect(status().isUnprocessableEntity())
                 .andExpect(content().string(TestUtils.JSON_TEST_HELPER.matchesObject(expectedProblem)));
     }
 


### PR DESCRIPTION
atm nakadi will return 503 http status code if consumed_offset argument is unknown to nakadi. instead it should return 422 unprocessable entity.