### PR TITLE
Reject number formats for numbers that start with `.`

### DIFF
--- a/core-common/src/main/java/org/zalando/nakadi/domain/StrictJsonParser.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/StrictJsonParser.java
@@ -139,6 +139,9 @@ public class StrictJsonParser {
             throw syntaxError("Unexpected symbol '" + value + "'", tokenizer);
         }
         final int start = tokenizer.getCurrentPosition() - 1;
+        if (!Character.toString(tokenizer.value.charAt(start)).matches("\\d|-")) {
+            throw syntaxError("Numbers cannot start with:'" + value + "'", tokenizer);
+        }
         while (tokenizer.hasNext()) {
             if (POSSIBLE_NUMBER_DIGITS.indexOf(tokenizer.next()) < 0) {
                 tokenizer.back();

--- a/core-common/src/main/java/org/zalando/nakadi/domain/StrictJsonParser.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/StrictJsonParser.java
@@ -159,11 +159,15 @@ public class StrictJsonParser {
 
         if (stringNumber.indexOf('.') > -1 || stringNumber.indexOf('e') > -1
                 || stringNumber.indexOf('E') > -1 || "-0".equals(stringNumber)) {
-            final Double d = Double.valueOf(stringNumber);
-            if (!d.isInfinite() && !d.isNaN()) {
-                return d;
-            } else {
-                throw syntaxError(stringNumber + " can not be used", tokenizer);
+            try {
+                final Double d = Double.valueOf(stringNumber);
+                if (!d.isInfinite() && !d.isNaN()) {
+                    return d;
+                } else {
+                    throw syntaxError(stringNumber + " can not be used", tokenizer);
+                }
+            } catch (NumberFormatException e) {
+                throw syntaxError("The provided value '" + stringNumber + "' cannot be parsed to float", tokenizer);
             }
         } else {
             try {

--- a/core-common/src/main/java/org/zalando/nakadi/domain/StrictJsonParser.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/StrictJsonParser.java
@@ -11,6 +11,7 @@ public class StrictJsonParser {
     private static final Logger LOG = LoggerFactory.getLogger(StrictJsonParser.class);
 
     private static final String POSSIBLE_NUMBER_DIGITS = "0123456789-+.Ee";
+    private static final String POSSIBLE_INTEGER_DIGITS = "0123456789-";
 
     private static class StringTokenizer {
 
@@ -135,13 +136,10 @@ public class StrictJsonParser {
     }
 
     private static Object readNumberTillTheEnd(final char value, final StringTokenizer tokenizer) {
-        if (POSSIBLE_NUMBER_DIGITS.indexOf(value) < 0) {
+        if (POSSIBLE_INTEGER_DIGITS.indexOf(value) < 0) {
             throw syntaxError("Unexpected symbol '" + value + "'", tokenizer);
         }
         final int start = tokenizer.getCurrentPosition() - 1;
-        if (!Character.toString(tokenizer.value.charAt(start)).matches("\\d|-")) {
-            throw syntaxError("Numbers cannot start with:'" + value + "'", tokenizer);
-        }
         while (tokenizer.hasNext()) {
             if (POSSIBLE_NUMBER_DIGITS.indexOf(tokenizer.next()) < 0) {
                 tokenizer.back();

--- a/core-common/src/main/java/org/zalando/nakadi/domain/StrictJsonParser.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/StrictJsonParser.java
@@ -11,7 +11,6 @@ public class StrictJsonParser {
     private static final Logger LOG = LoggerFactory.getLogger(StrictJsonParser.class);
 
     private static final String POSSIBLE_NUMBER_DIGITS = "0123456789-+.Ee";
-    private static final String POSSIBLE_INTEGER_DIGITS = "0123456789-";
 
     private static class StringTokenizer {
 
@@ -114,8 +113,20 @@ public class StrictJsonParser {
                 return readTrueTillTheEnd(tokenizer);
             case 'f':
                 return readFalseTillTheEnd(tokenizer);
-            default:
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            case '-':
                 return readNumberTillTheEnd(value, tokenizer);
+            default:
+                throw syntaxError("Unexpected symbol '" + value + "'", tokenizer);
         }
     }
 
@@ -136,9 +147,6 @@ public class StrictJsonParser {
     }
 
     private static Object readNumberTillTheEnd(final char value, final StringTokenizer tokenizer) {
-        if (POSSIBLE_INTEGER_DIGITS.indexOf(value) < 0) {
-            throw syntaxError("Unexpected symbol '" + value + "'", tokenizer);
-        }
         final int start = tokenizer.getCurrentPosition() - 1;
         while (tokenizer.hasNext()) {
             if (POSSIBLE_NUMBER_DIGITS.indexOf(tokenizer.next()) < 0) {

--- a/core-common/src/test/java/org/zalando/nakadi/domain/StrictJsonParserTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/domain/StrictJsonParserTest.java
@@ -1,9 +1,12 @@
 package org.zalando.nakadi.domain;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.util.StreamUtils;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -14,6 +17,7 @@ public class StrictJsonParserTest {
     private void testSingleString(final String value) {
         final JSONObject orthodoxJson = new JSONObject(value);
         final JSONObject anarchyJson = StrictJsonParser.parseObject(value);
+        System.out.println(anarchyJson);
         Assert.assertEquals("Checking json " + value, orthodoxJson.toString(), anarchyJson.toString());
     }
 
@@ -39,5 +43,13 @@ public class StrictJsonParserTest {
         testSingleString("{\"test\":1e-2}");
         testSingleString("{\"test\":1e+2}");
         testSingleString("{\"test\":-1e+4}");
+    }
+
+    @Test
+    public void testItShouldValidateNumbersFormat() {
+        final JSONException jsonException = assertThrows(JSONException.class, () -> {
+            StrictJsonParser.parseObject("{\"test\":.1234}");
+        });
+        Assert.assertEquals("Numbers cannot start with:'.' at pos 9", jsonException.getMessage());
     }
 }

--- a/core-common/src/test/java/org/zalando/nakadi/domain/StrictJsonParserTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/domain/StrictJsonParserTest.java
@@ -46,9 +46,14 @@ public class StrictJsonParserTest {
 
     @Test
     public void testItShouldValidateNumbersFormat() {
-        final JSONException jsonException = assertThrows(JSONException.class, () -> {
+        JSONException jsonException = assertThrows(JSONException.class, () -> {
             StrictJsonParser.parseObject("{\"test\":.1234}");
         });
         Assert.assertEquals("Unexpected symbol '.' at pos 9", jsonException.getMessage());
+
+        jsonException = assertThrows(JSONException.class, () -> {
+            StrictJsonParser.parseObject("{\"test\":12.3.4E}");
+        });
+        Assert.assertEquals("The provided value '12.3.4E' cannot be parsed to float at pos 15", jsonException.getMessage());
     }
 }

--- a/core-common/src/test/java/org/zalando/nakadi/domain/StrictJsonParserTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/domain/StrictJsonParserTest.java
@@ -17,7 +17,6 @@ public class StrictJsonParserTest {
     private void testSingleString(final String value) {
         final JSONObject orthodoxJson = new JSONObject(value);
         final JSONObject anarchyJson = StrictJsonParser.parseObject(value);
-        System.out.println(anarchyJson);
         Assert.assertEquals("Checking json " + value, orthodoxJson.toString(), anarchyJson.toString());
     }
 

--- a/core-common/src/test/java/org/zalando/nakadi/domain/StrictJsonParserTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/domain/StrictJsonParserTest.java
@@ -49,6 +49,6 @@ public class StrictJsonParserTest {
         final JSONException jsonException = assertThrows(JSONException.class, () -> {
             StrictJsonParser.parseObject("{\"test\":.1234}");
         });
-        Assert.assertEquals("Numbers cannot start with:'.' at pos 9", jsonException.getMessage());
+        Assert.assertEquals("Unexpected symbol '.' at pos 9", jsonException.getMessage());
     }
 }

--- a/core-services/src/test/java/org/zalando/nakadi/validation/JSONSchemaValidationTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/validation/JSONSchemaValidationTest.java
@@ -175,17 +175,6 @@ public class JSONSchemaValidationTest {
     }
 
     @Test
-    public void testExperimenting() {
-        final JSONObject schema = new JSONObject("{\"properties\":{\"order_number\":{\"type\":\"number\"}}}");
-        final EventType et = EventTypeTestBuilder.builder().name("some-event-type").schema(schema).build();
-        et.setCategory(EventCategory.UNDEFINED);
-
-        final JSONObject event = new JSONObject("{\"order_number\": .1234}");
-        final Optional<ValidationError> error = eventValidatorBuilder.build(et).validate(event);
-        System.out.println(error);
-    }
-
-    @Test
     public void acceptsDefinitionsOnDataChangeEvents() throws Exception {
         final JSONObject schema = new JSONObject(TestUtils.readFile("product-json-schema.json"));
         final EventType et = EventTypeTestBuilder.builder().name("some-event-type").schema(schema).build();
@@ -215,7 +204,7 @@ public class JSONSchemaValidationTest {
     private JSONObject patternSchema() {
         final JSONObject schema = new JSONObject();
         final JSONObject string = new JSONObject();
-        string.put("type", "number");
+        string.put("type", "string");
         string.put("pattern", "a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?aaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 
         final JSONObject properties = new JSONObject();

--- a/core-services/src/test/java/org/zalando/nakadi/validation/JSONSchemaValidationTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/validation/JSONSchemaValidationTest.java
@@ -175,6 +175,17 @@ public class JSONSchemaValidationTest {
     }
 
     @Test
+    public void testExperimenting() {
+        final JSONObject schema = new JSONObject("{\"properties\":{\"order_number\":{\"type\":\"number\"}}}");
+        final EventType et = EventTypeTestBuilder.builder().name("some-event-type").schema(schema).build();
+        et.setCategory(EventCategory.UNDEFINED);
+
+        final JSONObject event = new JSONObject("{\"order_number\": .1234}");
+        final Optional<ValidationError> error = eventValidatorBuilder.build(et).validate(event);
+        System.out.println(error);
+    }
+
+    @Test
     public void acceptsDefinitionsOnDataChangeEvents() throws Exception {
         final JSONObject schema = new JSONObject(TestUtils.readFile("product-json-schema.json"));
         final EventType et = EventTypeTestBuilder.builder().name("some-event-type").schema(schema).build();
@@ -204,7 +215,7 @@ public class JSONSchemaValidationTest {
     private JSONObject patternSchema() {
         final JSONObject schema = new JSONObject();
         final JSONObject string = new JSONObject();
-        string.put("type", "string");
+        string.put("type", "number");
         string.put("pattern", "a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?aaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 
         final JSONObject properties = new JSONObject();


### PR DESCRIPTION
# One-line summary

> Zalando ticket : team-aruha#565

## Description
`StringJsonParser` does not complain for numbers that start with `.` and they are parsed to double by `Double.valueOf`

## Review
- [ ] Tests
