### PR TITLE
return 409 http status if subscription exists

### DIFF
--- a/api-metastore/src/main/java/org/zalando/nakadi/controller/PostSubscriptionController.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/controller/PostSubscriptionController.java
@@ -13,7 +13,6 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.util.UriComponents;
 import org.zalando.nakadi.domain.Subscription;
 import org.zalando.nakadi.domain.SubscriptionBase;
-import org.zalando.nakadi.exceptions.runtime.DuplicatedSubscriptionException;
 import org.zalando.nakadi.exceptions.runtime.InconsistentStateException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchEventTypeException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchSubscriptionException;
@@ -67,8 +66,6 @@ public class PostSubscriptionController {
             try {
                 final Subscription subscription = subscriptionService.createSubscription(subscriptionBase);
                 return prepareLocationResponse(subscription);
-            } catch (final DuplicatedSubscriptionException ex) {
-                throw new InconsistentStateException("Unexpected problem occurred when creating subscription", ex);
             } catch (final NoSuchEventTypeException ex) {
                 throw new UnprocessableSubscriptionException(ex.getMessage());
             }

--- a/api-metastore/src/main/java/org/zalando/nakadi/controller/advice/PostSubscriptionExceptionHandler.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/controller/advice/PostSubscriptionExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.zalando.nakadi.controller.PostSubscriptionController;
 import org.zalando.nakadi.exceptions.runtime.AuthorizationNotPresentException;
+import org.zalando.nakadi.exceptions.runtime.DuplicatedSubscriptionException;
 import org.zalando.nakadi.exceptions.runtime.NakadiBaseException;
 import org.zalando.nakadi.exceptions.runtime.SubscriptionCreationDisabledException;
 import org.zalando.nakadi.exceptions.runtime.SubscriptionUpdateConflictException;
@@ -14,6 +15,7 @@ import org.zalando.nakadi.exceptions.runtime.UnableProcessException;
 import org.zalando.nakadi.exceptions.runtime.UnprocessableSubscriptionException;
 import org.zalando.nakadi.exceptions.runtime.WrongInitialCursorsException;
 import org.zalando.problem.Problem;
+import org.zalando.problem.Status;
 import org.zalando.problem.spring.web.advice.AdviceTrait;
 
 import javax.annotation.Priority;
@@ -51,4 +53,13 @@ public class PostSubscriptionExceptionHandler implements AdviceTrait {
         AdviceTrait.LOG.debug(exception.getMessage());
         return create(Problem.valueOf(UNPROCESSABLE_ENTITY, exception.getMessage()), request);
     }
+
+    @ExceptionHandler(DuplicatedSubscriptionException.class)
+    public ResponseEntity<Problem> handleDuplicatedSubscriptionException(
+            final DuplicatedSubscriptionException exception,
+            final NativeWebRequest request) {
+        AdviceTrait.LOG.warn(exception.getMessage());
+        return create(Problem.valueOf(Status.CONFLICT, exception.getMessage()), request);
+    }
+
 }


### PR DESCRIPTION
when the same subscription was created by several requests at almost the same time the first request gets 201 http status code, but the second - 503 status code. the expected response status code in such case is 409 conflict.