### PR TITLE
Update kafka-clients dependency.

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaTestHelper.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaTestHelper.java
@@ -3,16 +3,17 @@ package org.zalando.nakadi.repository.kafka;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
+import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
 import org.assertj.core.util.Lists;
-import org.springframework.kafka.config.TopicBuilder;
 import org.zalando.nakadi.view.Cursor;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -101,7 +102,7 @@ public class KafkaTestHelper {
     public void createTopic(final String topic) {
         try (AdminClient adminClient = AdminClient.create(createKafkaProperties())) {
             adminClient.createTopics(Lists.newArrayList(
-                    TopicBuilder.name(topic).partitions(1).replicas(1).build()
+                    new NewTopic(topic, Optional.of(1), Optional.of((short) 1))
             ));
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ subprojects {
     }
     dependencies {
         ext {
-            kafkaClientVersion = '2.6.0'
+            kafkaClientVersion = '2.7.0'
             dropwizardVersion = '3.1.3'
             curatorVersion = '5.1.0'
             zookeeperVersion = '3.6.1'

--- a/core-common/build.gradle
+++ b/core-common/build.gradle
@@ -64,7 +64,6 @@ dependencies {
     compile 'io.opentracing:opentracing-api:0.31.0'
     compile 'io.opentracing:opentracing-util:0.31.0'
 
-    compile 'org.springframework.kafka:spring-kafka'
     compile "org.apache.kafka:kafka-clients:$kafkaClientVersion"
 
     compile("org.apache.curator:curator-recipes:$curatorVersion") {


### PR DESCRIPTION
Some time ago kafka 2.7.0 was released. This PR gets rid of spring-boot kafka-clients dependency and adds dependency to a `2.7.0` kafka client version .