### PR TITLE
Migrate subscription to idempotent approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ## [Nakadi Event Broker](https://zalando.github.io/nakadi/)
 
 [![Build Status](https://travis-ci.org/zalando/nakadi.svg?branch=master)](https://travis-ci.org/zalando/nakadi)
-[![codecov.io](https://codecov.io/github/zalando/nakadi/coverage.svg?branch=master)](https://codecov.io/github/zalando/nakadi?branch=master)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/785ccd4ab5e34867b760a8b07c3b62f1)](https://www.codacy.com/app/aruha/nakadi?utm_source=www.github.com&amp;utm_medium=referral&amp;utm_content=zalando/nakadi&amp;utm_campaign=Badge_Grade)
 
 Nakadi is a distributed event bus broker that implements a RESTful API abstraction on top of Kafka-like queues, which can be used to send, receive, and analyze streaming data in real time, in a reliable and highly available manner.

--- a/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/AbstractZkSubscriptionClient.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/AbstractZkSubscriptionClient.java
@@ -145,7 +145,7 @@ public abstract class AbstractZkSubscriptionClient implements ZkSubscriptionClie
         try {
             createSessionsZNode();
             createOffsetZNodes(cursors);
-            createTopologyZNode(generateTopology(cursors));
+            createTopologyZNode(cursors);
             createStateZNodeAsInitialized();
         } catch (final Exception e) {
             throw new NakadiRuntimeException(e);
@@ -175,16 +175,6 @@ public abstract class AbstractZkSubscriptionClient implements ZkSubscriptionClie
                 getLog().info("Offset ZNode {}/{} exists, not creating a new one",
                         cursor.getEventType(), cursor.getPartition());
             }
-        }
-    }
-
-    private void createTopologyZNode(final byte[] topologyData) throws Exception {
-        try {
-            getCurator().create()
-                    .withMode(CreateMode.PERSISTENT)
-                    .forPath(getSubscriptionPath(NODE_TOPOLOGY), topologyData);
-        } catch (final KeeperException.NodeExistsException ex) {
-            getLog().info("ZNode exist for topology, not creating a new one");
         }
     }
 
@@ -482,8 +472,7 @@ public abstract class AbstractZkSubscriptionClient implements ZkSubscriptionClie
         }
     }
 
-    protected abstract byte[] generateTopology(Collection<SubscriptionCursorWithoutToken> cursors)
-            throws Exception;
+    protected abstract void createTopologyZNode(Collection<SubscriptionCursorWithoutToken> cursors) throws Exception;
 
     protected abstract String getOffsetPath(EventTypePartition etp);
 

--- a/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/NewZkSubscriptionClient.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/NewZkSubscriptionClient.java
@@ -81,13 +81,8 @@ public class NewZkSubscriptionClient extends AbstractZkSubscriptionClient {
     }
 
     @Override
-    protected byte[] createTopologyAndOffsets(final Collection<SubscriptionCursorWithoutToken> cursors)
+    protected byte[] generateTopology(final Collection<SubscriptionCursorWithoutToken> cursors)
             throws Exception {
-        for (final SubscriptionCursorWithoutToken cursor : cursors) {
-            getCurator().create().creatingParentsIfNeeded().forPath(
-                    getOffsetPath(cursor.getEventTypePartition()),
-                    cursor.getOffset().getBytes(UTF_8));
-        }
         final Partition[] partitions = cursors.stream().map(cursor -> new Partition(
                 cursor.getEventType(),
                 cursor.getPartition(),


### PR DESCRIPTION
# Initializing ZNode for subscription optimistically

> Zalando ticket : team-aruha/issues/692

## Description
Handling KeeperException.NodeExistsException when creating individual
children of subscription ZNode. This can happen during concurrent
initialization of subscription ZNode by multiple instances. We can
safely ignore this exception as two concurrent initialization should
ideally produce the same set of children.

## Review
- [ ] Tests
- [ ] Documentation

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
