### PR TITLE
rebalance uses optimistic locking

### DIFF
--- a/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClient.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClient.java
@@ -1,6 +1,7 @@
 package org.zalando.nakadi.service.subscription.zk;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.function.Function;
 import org.apache.commons.codec.binary.Hex;
 import org.zalando.nakadi.domain.EventTypePartition;
 import org.zalando.nakadi.exceptions.runtime.NakadiBaseException;
@@ -67,10 +68,13 @@ public interface ZkSubscriptionClient extends Closeable {
     void fillEmptySubscription(Collection<SubscriptionCursorWithoutToken> cursors);
 
     /**
-     * Updates specified partitions in zk.
+     * Updates topologies partitions by reading topology first and
+     * then writing the change back with usage of zookeeper node version.
+     * If zookeeper node version was changed in between it will retry
+     * by reading new zookeeper node version.
      */
-    void updatePartitionsConfiguration(String newSessionsHash, Partition[] partitions) throws NakadiRuntimeException,
-            SubscriptionNotInitializedException;
+    void updateTopology(String newSessionsHash, Function<Topology, Partition[]> partitioner)
+            throws NakadiRuntimeException, SubscriptionNotInitializedException;
 
     /**
      * Returns session list in zk related to this subscription.
@@ -83,9 +87,11 @@ public interface ZkSubscriptionClient extends Closeable {
     boolean isActiveSession(String streamId) throws ServiceTemporarilyUnavailableException;
 
     /**
-     * List partitions
+     * Returns subscription {@link Topology} object from Zookeeper
      *
-     * @return list of partitions related to this subscription.
+     * @return topology {@link Topology}
+     * @throws SubscriptionNotInitializedException
+     * @throws NakadiRuntimeException
      */
     Topology getTopology() throws SubscriptionNotInitializedException, NakadiRuntimeException;
 

--- a/core-common/src/test/java/org/zalando/nakadi/service/subscription/zk/NewZkSubscriptionClientTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/service/subscription/zk/NewZkSubscriptionClientTest.java
@@ -43,7 +43,8 @@ public class NewZkSubscriptionClientTest {
         topology = objectMapper.writeValueAsBytes(new ZkSubscriptionClient.Topology(
                 new Partition[]{new Partition(
                         "test-event-type", "0", "session-id-xxx", null, Partition.State.REASSIGNING)},
-                null, null
+                null,
+                null
         ));
     }
 


### PR DESCRIPTION
the commit changes used locking mechanism of rebalance function. the change removes  usage of global curator lock in favor of using optimistic locking meaning: 1)read topology with zk node version 2)prepare change set 3)try to write to zk node with the read version number in step 1 if failed retry. the obsolete logic related to hash generation for sessions transfer was removed.