### PR TITLE
remove nakadi zookeeper lock call

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/SubscriptionAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/SubscriptionAT.java
@@ -389,9 +389,6 @@ public class SubscriptionAT extends BaseAT {
         assertThat(
                 CURATOR.checkExists().forPath(format("/nakadi/subscriptions/{0}", subscription.getId())),
                 not(nullValue()));
-        assertThat(
-                CURATOR.checkExists().forPath(format("/nakadi/locks/subscription_{0}", subscription.getId())),
-                not(nullValue()));
 
         // delete subscription
         when().delete("/subscriptions/{sid}", subscription.getId())

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -314,15 +314,13 @@ public class StreamingContext implements SubscriptionStreamer {
         if (null != sessionListSubscription) {
             // This call is needed to renew subscription for session list changes.
             sessionListSubscription.getData();
-            zkClient.runLocked(() -> {
-                log.info("Performing rebalance");
-                final Collection<Session> sessions = zkClient.listSessions();
-                final String actualHash = ZkSubscriptionClient.Topology.calculateSessionsHash(
-                        sessions.stream().map(Session::getId).collect(Collectors.toList()));
-                zkClient.updateTopology(actualHash, topology ->
-                        rebalancer.apply(sessions, topology.getPartitions())
-                );
-            });
+            log.info("Performing rebalance");
+            final Collection<Session> sessions = zkClient.listSessions();
+            final String actualHash = ZkSubscriptionClient.Topology.calculateSessionsHash(
+                    sessions.stream().map(Session::getId).collect(Collectors.toList()));
+            zkClient.updateTopology(actualHash, topology ->
+                    rebalancer.apply(sessions, topology.getPartitions())
+            );
         }
     }
 

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -42,7 +42,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
-import java.util.stream.Collectors;
 
 public class StreamingContext implements SubscriptionStreamer {
 
@@ -314,12 +313,10 @@ public class StreamingContext implements SubscriptionStreamer {
         if (null != sessionListSubscription) {
             // This call is needed to renew subscription for session list changes.
             sessionListSubscription.getData();
-            log.info("Performing rebalance");
-            final Collection<Session> sessions = zkClient.listSessions();
-            final String actualHash = ZkSubscriptionClient.Topology.calculateSessionsHash(
-                    sessions.stream().map(Session::getId).collect(Collectors.toList()));
-            zkClient.updateTopology(actualHash, topology ->
-                    rebalancer.apply(sessions, topology.getPartitions())
+            zkClient.updateTopology(topology ->
+                    rebalancer.apply(
+                            zkClient.listSessions(),
+                            topology.getPartitions())
             );
         }
     }

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/ClosingState.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/ClosingState.java
@@ -159,7 +159,7 @@ class ClosingState extends State {
                 }
             }
         }
-        getZk().runLocked(() -> getZk().transfer(getSessionId(), keys));
+        getZk().transfer(getSessionId(), keys);
         if (null != exceptionCaught) {
             throw exceptionCaught;
         }

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StartingState.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StartingState.java
@@ -25,7 +25,7 @@ public class StartingState extends State {
             switchState(new CleanupState(e));
             return;
         }
-        getZk().runLocked(this::registerSessionAndStartStreaming);
+        registerSessionAndStartStreaming();
     }
 
     /**
@@ -38,7 +38,7 @@ public class StartingState extends State {
      * 4. Switches to streaming state.
      */
     private void registerSessionAndStartStreaming() {
-        final boolean subscriptionJustInitialized = SubscriptionInitializer.initializeSubscriptionLocked(getZk(),
+        final boolean subscriptionJustInitialized = SubscriptionInitializer.initialize(getZk(),
                 getContext().getSubscription(), getContext().getTimelineService(), getContext().getCursorConverter());
         getContext().getCurrentSpan().setTag("session.id", getContext().getSessionId());
         if (!subscriptionJustInitialized) {

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -687,7 +687,7 @@ class StreamingState extends State {
             try {
                 keysToRelease.forEach(this::removeFromStreaming);
             } finally {
-                getZk().runLocked(() -> getZk().transfer(getSessionId(), keysToRelease));
+                getZk().transfer(getSessionId(), keysToRelease);
             }
         }
     }

--- a/api-cursors/src/main/java/org/zalando/nakadi/service/CursorsService.java
+++ b/api-cursors/src/main/java/org/zalando/nakadi/service/CursorsService.java
@@ -193,8 +193,8 @@ public class CursorsService {
                 subscription, LogPathBuilder.build(subscriptionId, "reset_cursors"));
 
         // In case if subscription was never initialized - initialize it
-        zkClient.runLocked(() -> SubscriptionInitializer.initializeSubscriptionLocked(
-                zkClient, subscription, timelineService, cursorConverter));
+        SubscriptionInitializer.initialize(
+                zkClient, subscription, timelineService, cursorConverter);
         // add 1 second to commit timeout in order to give time to finish reset if there is uncommitted events
         if (!cursors.isEmpty()) {
             final List<SubscriptionCursorWithoutToken> oldCursors = getSubscriptionCursors(subscriptionId);

--- a/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/AbstractZkSubscriptionClient.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/AbstractZkSubscriptionClient.java
@@ -11,7 +11,6 @@ import org.echocat.jomon.runtime.concurrent.RetryForSpecifiedCountStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zalando.nakadi.domain.EventTypePartition;
-import org.zalando.nakadi.exceptions.runtime.NakadiBaseException;
 import org.zalando.nakadi.exceptions.runtime.NakadiRuntimeException;
 import org.zalando.nakadi.exceptions.runtime.OperationInterruptedException;
 import org.zalando.nakadi.exceptions.runtime.OperationTimeoutException;
@@ -36,7 +35,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -89,25 +87,6 @@ public abstract class AbstractZkSubscriptionClient implements ZkSubscriptionClie
 
     protected Logger getLog() {
         return log;
-    }
-
-    @Override
-    public final <T> T runLocked(final Callable<T> function) {
-        final boolean acquired = nakadiLock.lock();
-        if (!acquired) {
-            throw new ServiceTemporarilyUnavailableException(
-                    "failed to acquire subscription lock");
-        }
-
-        try {
-            return function.call();
-        } catch (final NakadiRuntimeException | NakadiBaseException e) {
-            throw e;
-        } catch (final Exception e) {
-            throw new NakadiRuntimeException(e);
-        } finally {
-            nakadiLock.unlock();
-        }
     }
 
     @Override

--- a/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/NewZkSubscriptionClient.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/NewZkSubscriptionClient.java
@@ -107,8 +107,7 @@ public class NewZkSubscriptionClient extends AbstractZkSubscriptionClient {
     }
 
     @Override
-    public void updateTopology(final String sessionHash,
-                               final Function<Topology, Partition[]> partitioner)
+    public void updateTopology(final Function<Topology, Partition[]> partitioner)
             throws NakadiRuntimeException, SubscriptionNotInitializedException {
         Retryer.executeWithRetry(() -> {
                     final Stat stats = new Stat();
@@ -126,8 +125,7 @@ public class NewZkSubscriptionClient extends AbstractZkSubscriptionClient {
                     final Partition[] partitions = partitioner.apply(topology);
                     if (partitions.length > 0) {
                         final Topology newTopology = topology.withUpdatedPartitions(
-                                sessionHash == null ? topology.getSessionsHash() : sessionHash,
-                                partitions);
+                                null, partitions);
                         getLog().info("Updating topology to {}", newTopology);
                         try {
                             getCurator().setData().withVersion(stats.getVersion())
@@ -231,7 +229,7 @@ public class NewZkSubscriptionClient extends AbstractZkSubscriptionClient {
     public void transfer(final String sessionId, final Collection<EventTypePartition> partitions)
             throws NakadiRuntimeException, SubscriptionNotInitializedException {
         getLog().info("session " + sessionId + " releases partitions " + partitions);
-        updateTopology(null, topology -> {
+        updateTopology(topology -> {
             final List<Partition> changeSet = new ArrayList<>();
             for (final EventTypePartition etp : partitions) {
                 final Partition candidate = Stream.of(topology.getPartitions())

--- a/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClient.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClient.java
@@ -55,7 +55,7 @@ public interface ZkSubscriptionClient extends Closeable {
      * If zookeeper node version was changed in between it will retry
      * by reading new zookeeper node version.
      */
-    void updateTopology(String newSessionsHash, Function<Topology, Partition[]> partitioner)
+    void updateTopology(Function<Topology, Partition[]> partitioner)
             throws NakadiRuntimeException, SubscriptionNotInitializedException;
 
     /**

--- a/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClient.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClient.java
@@ -23,26 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.Callable;
 
 public interface ZkSubscriptionClient extends Closeable {
-
-    /**
-     * Makes runLocked on subscription, using zk path /nakadi/locks/subscription_{subscriptionId}
-     * Lock is created as an ephemeral node, so it will be deleted if nakadi goes down. After obtaining runLocked,
-     * provided function will be called under subscription runLocked
-     *
-     * @param function Function to call in context of runLocked.
-     */
-    <T> T runLocked(Callable<T> function);
-
-    default void runLocked(final Runnable function) {
-        runLocked((Callable<Void>) () -> {
-            function.run();
-            return null;
-        });
-    }
-
 
     /**
      * Creates subscription node in zookeeper on path /nakadi/subscriptions/{subscriptionId}

--- a/core-services/src/main/java/org/zalando/nakadi/service/RepartitioningService.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/RepartitioningService.java
@@ -153,7 +153,7 @@ public class RepartitioningService {
                 LogPathBuilder.build(subscription.getId(), "repartition"));
         try {
             // it could be that subscription was created, but never initialized
-            SubscriptionInitializer.initializeSubscriptionLocked(
+            SubscriptionInitializer.initialize(
                     zkClient, subscription, timelineService, cursorConverter);
             // get begin offset with timeline, partition does not matter, it will be the same for all partitions
             final Cursor cursor = cursorConverter.convert(

--- a/core-services/src/main/java/org/zalando/nakadi/service/SubscriptionInitializer.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/SubscriptionInitializer.java
@@ -21,7 +21,7 @@ import static java.util.stream.Collectors.groupingBy;
 
 public class SubscriptionInitializer {
     
-    public static boolean initializeSubscriptionLocked(
+    public static boolean initialize(
             final ZkSubscriptionClient zkClient,
             final Subscription subscription,
             final TimelineService timelineService,


### PR DESCRIPTION
methods which used `runLocked` method were migrated to optimistic locking. in this commit `runLocked] method is removed leaving only not locking methods to update subscription states