### PR TITLE
Be able to set client.rack for KafkaConsumer

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -103,7 +103,7 @@ public class KafkaRepositoryAT extends BaseAT {
 
         kafkaSettings = new KafkaSettings(KAFKA_REQUEST_TIMEOUT, KAFKA_BATCH_SIZE, KAFKA_BUFFER_MEMORY,
                 KAFKA_LINGER_MS, KAFKA_ENABLE_AUTO_COMMIT, KAFKA_MAX_REQUEST_SIZE,
-                KAFKA_DELIVERY_TIMEOUT, KAFKA_MAX_BLOCK_TIMEOUT);
+                KAFKA_DELIVERY_TIMEOUT, KAFKA_MAX_BLOCK_TIMEOUT, "");
         zookeeperSettings = new ZookeeperSettings(ZK_SESSION_TIMEOUT, ZK_CONNECTION_TIMEOUT, ZK_MAX_IN_FLIGHT_REQUESTS);
         kafkaHelper = new KafkaTestHelper(KAFKA_URL);
         defaultTopicConfig = new NakadiTopicConfig(DEFAULT_PARTITION_COUNT, DEFAULT_CLEANUP_POLICY,

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -112,6 +112,7 @@ public class KafkaLocationManager {
         properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
                 "org.apache.kafka.common.serialization.ByteArrayDeserializer");
         properties.put(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, kafkaSettings.getMaxBlockMs());
+        properties.put(ConsumerConfig.CLIENT_RACK_CONFIG, kafkaSettings.getClientRack());
         return properties;
     }
 

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSettings.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSettings.java
@@ -21,6 +21,7 @@ public class KafkaSettings {
     private final int maxRequestSize;
     private final int deliveryTimeoutMs;
     private final int maxBlockMs;
+    private final String clientRack;
 
     @Autowired
     public KafkaSettings(@Value("${nakadi.kafka.request.timeout.ms}") final int requestTimeoutMs,
@@ -30,7 +31,8 @@ public class KafkaSettings {
                          @Value("${nakadi.kafka.enable.auto.commit}") final boolean enableAutoCommit,
                          @Value("${nakadi.kafka.max.request.size}") final int maxRequestSize,
                          @Value("${nakadi.kafka.delivery.timeout.ms}") final int deliveryTimeoutMs,
-                         @Value("${nakadi.kafka.max.block.ms}") final int maxBlockMs) {
+                         @Value("${nakadi.kafka.max.block.ms}") final int maxBlockMs,
+                         @Value("${nakadi.kafka.client.rack:}") final String clientRack) {
         this.requestTimeoutMs = requestTimeoutMs;
         this.batchSize = batchSize;
         this.bufferMemory = bufferMemory;
@@ -39,6 +41,7 @@ public class KafkaSettings {
         this.maxRequestSize = maxRequestSize;
         this.deliveryTimeoutMs = deliveryTimeoutMs;
         this.maxBlockMs = maxBlockMs;
+        this.clientRack = clientRack;
     }
 
     public int getRequestTimeoutMs() {
@@ -71,5 +74,9 @@ public class KafkaSettings {
 
     public int getMaxBlockMs() {
         return maxBlockMs;
+    }
+
+    public String getClientRack() {
+        return clientRack;
     }
 }


### PR DESCRIPTION
In order to utilize kafka feature of closest replica consumption, the `client.rack` property should become available to for modification. 
This PR exposes the property as a spring property with name `nakadi.kafka.client.rack`