### PR TITLE
log less useless messages

### DIFF
--- a/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/AbstractZkSubscriptionClient.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/AbstractZkSubscriptionClient.java
@@ -234,7 +234,6 @@ public abstract class AbstractZkSubscriptionClient implements ZkSubscriptionClie
     @Override
     public final Collection<Session> listSessions()
             throws SubscriptionNotInitializedException, NakadiRuntimeException, ServiceTemporarilyUnavailableException {
-        getLog().info("fetching sessions information");
         for (int i = 0; i < 5; i++) {
             try {
                 final List<String> sessions = getCurator().getChildren().forPath(getSubscriptionPath("/sessions"));


### PR DESCRIPTION
The message to remove is never used, and is executed many times a second, flooding logs with info level (while it is more of a trace level). 
Instead of changing the level it was intentionally removed.