### PR TITLE
better track inability to join streaming on consumption

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRebalanceAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRebalanceAT.java
@@ -327,7 +327,7 @@ public class HilaRebalanceAT extends BaseAT {
     }
 
     @Test(timeout = 10000)
-    public void testNoConflictOnTheSamePartitionRequest() throws Exception {
+    public void testAtLeastOneClientGets409OnTheSamePartitionRequest() throws Exception {
         final TestStreamingClient client1 = new TestStreamingClient(
                 URL, subscription.getId(), "batch_flush_timeout=1",
                 Optional.empty(),
@@ -341,8 +341,9 @@ public class HilaRebalanceAT extends BaseAT {
         client1.start();
         client2.start();
 
-        waitFor(() -> assertThat(client1.getResponseCode(), Matchers.is(HttpStatus.CONFLICT.value())));
-        waitFor(() -> assertThat(client2.getResponseCode(), Matchers.is(HttpStatus.CONFLICT.value())));
+        waitFor(() -> assertThat("at least once client should get 409 conflict",
+                        client1.getResponseCode() != HttpStatus.CONFLICT.value() ||
+                        client1.getResponseCode() != HttpStatus.CONFLICT.value()));
     }
 
     public List<SubscriptionCursor> getLastCursorsForPartitions(final TestStreamingClient client,

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRebalanceAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRebalanceAT.java
@@ -3,6 +3,7 @@ package org.zalando.nakadi.webservice.hila;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.hamcrest.Matchers;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
@@ -323,6 +324,25 @@ public class HilaRebalanceAT extends BaseAT {
 
         // check that we get 204
         assertThat(commitStatusCode, Matchers.is(HttpStatus.NO_CONTENT.value()));
+    }
+
+    @Test(timeout = 10000)
+    public void testNoConflictOnTheSamePartitionRequest() throws Exception {
+        final TestStreamingClient client1 = new TestStreamingClient(
+                URL, subscription.getId(), "batch_flush_timeout=1",
+                Optional.empty(),
+                Optional.of("{\"partitions\":[" +
+                        "{\"event_type\":\"" + eventType.getName() + "\",\"partition\":\"0\"}]}"));
+        final TestStreamingClient client2 = new TestStreamingClient(
+                URL, subscription.getId(), "batch_flush_timeout=1",
+                Optional.empty(),
+                Optional.of("{\"partitions\":[" +
+                        "{\"event_type\":\"" + eventType.getName() + "\",\"partition\":\"0\"}]}"));
+        client1.start();
+        client2.start();
+
+        waitFor(() -> assertThat(client1.getResponseCode(), Matchers.is(HttpStatus.CONFLICT.value())));
+        waitFor(() -> assertThat(client2.getResponseCode(), Matchers.is(HttpStatus.CONFLICT.value())));
     }
 
     public List<SubscriptionCursor> getLastCursorsForPartitions(final TestStreamingClient client,

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRebalanceAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRebalanceAT.java
@@ -341,9 +341,9 @@ public class HilaRebalanceAT extends BaseAT {
         client1.start();
         client2.start();
 
-        waitFor(() -> assertThat("at least once client should get 409 conflict",
-                        client1.getResponseCode() != HttpStatus.CONFLICT.value() ||
-                        client1.getResponseCode() != HttpStatus.CONFLICT.value()));
+        waitFor(() -> assertThat("at least one client should get 409 conflict",
+                        client1.getResponseCode() == HttpStatus.CONFLICT.value() ||
+                        client1.getResponseCode() == HttpStatus.CONFLICT.value()));
     }
 
     public List<SubscriptionCursor> getLastCursorsForPartitions(final TestStreamingClient client,

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -314,15 +314,16 @@ public class StreamingContext implements SubscriptionStreamer {
         if (null != sessionListSubscription) {
             // This call is needed to renew subscription for session list changes.
             sessionListSubscription.getData();
-            try {
-                zkClient.updateTopology(topology ->
-                        rebalancer.apply(
-                                zkClient.listSessions(),
-                                topology.getPartitions())
-                );
-            } catch (final RebalanceConflictException e) {
-                log.warn("failed to rebalance partitions: {}", e.getMessage(), e);
-            }
+                zkClient.updateTopology(topology -> {
+                try {
+                    return rebalancer.apply(
+                            zkClient.listSessions(),
+                            topology.getPartitions());
+                } catch (final RebalanceConflictException e) {
+                    log.warn("failed to rebalance partitions: {}", e.getMessage(), e);
+                    return new Partition[0];
+                }
+            });
         }
     }
 

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -314,7 +314,7 @@ public class StreamingContext implements SubscriptionStreamer {
         if (null != sessionListSubscription) {
             // This call is needed to renew subscription for session list changes.
             sessionListSubscription.getData();
-                zkClient.updateTopology(topology -> {
+            zkClient.updateTopology(topology -> {
                 try {
                     return rebalancer.apply(
                             zkClient.listSessions(),

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -12,6 +12,7 @@ import org.zalando.nakadi.domain.NakadiCursor;
 import org.zalando.nakadi.domain.Subscription;
 import org.zalando.nakadi.exceptions.runtime.AccessDeniedException;
 import org.zalando.nakadi.exceptions.runtime.NakadiRuntimeException;
+import org.zalando.nakadi.exceptions.runtime.RebalanceConflictException;
 import org.zalando.nakadi.service.AuthorizationValidator;
 import org.zalando.nakadi.service.CursorConverter;
 import org.zalando.nakadi.service.CursorOperationsService;
@@ -313,11 +314,15 @@ public class StreamingContext implements SubscriptionStreamer {
         if (null != sessionListSubscription) {
             // This call is needed to renew subscription for session list changes.
             sessionListSubscription.getData();
-            zkClient.updateTopology(topology ->
-                    rebalancer.apply(
-                            zkClient.listSessions(),
-                            topology.getPartitions())
-            );
+            try {
+                zkClient.updateTopology(topology ->
+                        rebalancer.apply(
+                                zkClient.listSessions(),
+                                topology.getPartitions())
+                );
+            } catch (final RebalanceConflictException e) {
+                log.warn("failed to rebalance partitions: {}", e.getMessage(), e);
+            }
         }
     }
 

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionRebalancer.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionRebalancer.java
@@ -1,8 +1,9 @@
 package org.zalando.nakadi.service.subscription;
 
 import com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.zalando.nakadi.domain.EventTypePartition;
-import org.zalando.nakadi.exceptions.runtime.RebalanceConflictException;
 import org.zalando.nakadi.service.subscription.model.Partition;
 import org.zalando.nakadi.service.subscription.model.Session;
 
@@ -11,12 +12,15 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 class SubscriptionRebalancer implements BiFunction<Collection<Session>, Partition[], Partition[]> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SubscriptionRebalancer.class);
 
     @Override
     public Partition[] apply(final Collection<Session> sessions, final Partition[] currentPartitions) {
@@ -36,11 +40,15 @@ class SubscriptionRebalancer implements BiFunction<Collection<Session>, Partitio
             for (final EventTypePartition requestedPartition : session.getRequestedPartitions()) {
 
                 // find a partition that is requested and assign it to a session that requests it
-                final Partition partition = partitionsLeft.stream()
+                final Optional<Partition> partitionOpt = partitionsLeft.stream()
                         .filter(p -> p.getKey().equals(requestedPartition))
-                        .findFirst()
-                        .orElseThrow(() -> new RebalanceConflictException(
-                                "Two existing sessions request the same partition: " + requestedPartition));
+                        .findFirst();
+                if (!partitionOpt.isPresent()) {
+                    LOG.warn("Two existing sessions request the same partition: " + requestedPartition);
+                    return new Partition[0];
+                }
+
+                final Partition partition = partitionOpt.get();
                 partitionsLeft.remove(partition);
 
                 // if this partition is not assigned to this session - move it

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StartingState.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StartingState.java
@@ -3,7 +3,6 @@ package org.zalando.nakadi.service.subscription.state;
 import org.zalando.nakadi.domain.EventTypePartition;
 import org.zalando.nakadi.exceptions.runtime.AccessDeniedException;
 import org.zalando.nakadi.exceptions.runtime.ConflictException;
-import org.zalando.nakadi.exceptions.runtime.NakadiRuntimeException;
 import org.zalando.nakadi.exceptions.runtime.NoStreamingSlotsAvailable;
 import org.zalando.nakadi.exceptions.runtime.SubscriptionPartitionConflictException;
 import org.zalando.nakadi.service.SubscriptionInitializer;

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StartingState.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StartingState.java
@@ -3,6 +3,7 @@ package org.zalando.nakadi.service.subscription.state;
 import org.zalando.nakadi.domain.EventTypePartition;
 import org.zalando.nakadi.exceptions.runtime.AccessDeniedException;
 import org.zalando.nakadi.exceptions.runtime.ConflictException;
+import org.zalando.nakadi.exceptions.runtime.NakadiRuntimeException;
 import org.zalando.nakadi.exceptions.runtime.NoStreamingSlotsAvailable;
 import org.zalando.nakadi.exceptions.runtime.SubscriptionPartitionConflictException;
 import org.zalando.nakadi.service.SubscriptionInitializer;
@@ -45,7 +46,7 @@ public class StartingState extends State {
         getContext().getCurrentSpan().setTag("session.id", getContext().getSessionId());
         try {
             checkStreamingSlotsAvailable(getZk().listSessions());
-        } catch (Exception ex) {
+        } catch (NoStreamingSlotsAvailable | SubscriptionPartitionConflictException ex) {
             switchState(new CleanupState(ex));
             return;
         }
@@ -63,7 +64,7 @@ public class StartingState extends State {
             checkStreamingSlotsAvailable(getZk().listSessions().stream()
                     .filter(s -> !s.getId().equals(getSessionId()))
                     .collect(Collectors.toList()));
-        } catch (Exception ex) {
+        } catch (RuntimeException ex) {
             switchState(new CleanupState(ex));
             return;
         }

--- a/api-consumption/src/test/java/org/zalando/nakadi/service/subscription/SubscriptionRebalancerTest.java
+++ b/api-consumption/src/test/java/org/zalando/nakadi/service/subscription/SubscriptionRebalancerTest.java
@@ -3,6 +3,7 @@ package org.zalando.nakadi.service.subscription;
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import org.zalando.nakadi.domain.EventTypePartition;
+import org.zalando.nakadi.exceptions.runtime.RebalanceConflictException;
 import org.zalando.nakadi.service.subscription.model.Partition;
 import org.zalando.nakadi.service.subscription.model.Session;
 
@@ -22,7 +23,7 @@ import static org.zalando.nakadi.service.subscription.model.Partition.State.UNAS
 
 public class SubscriptionRebalancerTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = RebalanceConflictException.class)
     public void splitByWeightShouldAcceptOnlyCorrectData1() {
         SubscriptionRebalancer.splitByWeight(1, new int[]{1, 1});
     }

--- a/core-services/src/main/java/org/zalando/nakadi/service/SubscriptionInitializer.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/SubscriptionInitializer.java
@@ -21,7 +21,7 @@ import static java.util.stream.Collectors.groupingBy;
 
 public class SubscriptionInitializer {
     
-    public static boolean initialize(
+    public static void initialize(
             final ZkSubscriptionClient zkClient,
             final Subscription subscription,
             final TimelineService timelineService,
@@ -30,9 +30,7 @@ public class SubscriptionInitializer {
             final List<SubscriptionCursorWithoutToken> cursors = calculateStartPosition(
                     subscription, timelineService, cursorConverter);
             zkClient.fillEmptySubscription(cursors);
-            return true;
         }
-        return false;
     }
 
     public interface PositionCalculator {


### PR DESCRIPTION
In order to synchronize behavior of several instances, there is an optimistic lock is in use.
Unfortunately one place was not handled properly - registration of the streaming session.
The problem is that streaming code is allowing to have more streaming sessions, than there are partitions, or have more than 1 streaming connections for manually assigned partition.
This causes some problems - after unsuccessful rebalance (obviously rebalance is saying that it can't stream 2 partitions to 3 connections) some of streaming connections are dying.

In order to avoid that, there should be 2 changes made:
1. Session should be registered in optimistic manner (check, register, check. If not - session must be removed, https://github.com/zalando/nakadi/blob/master/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StartingState.java#L46-L87)
2. It should be expected, that rebalance may predictably fail for a very short amount of time, and if it is - it should retry (usage of https://github.com/zalando/nakadi/blob/master/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionRebalancer.java).
