### PR TITLE
Make example in api definition better-looking

### DIFF
--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -2834,7 +2834,7 @@ definitions:
           structure is not enforced. For example a team name and data type can be used such as
           'acme-team.price-change'.
         pattern: '[a-zA-Z][-0-9a-zA-Z_]*(\.[0-9a-zA-Z][-0-9a-zA-Z_]*)*'
-        example: order.order_cancelled, acme-platform.users
+        example: order.order_cancelled
       owning_application:
         type: string
         description: |

--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -2831,8 +2831,7 @@ definitions:
 
           Note: the name can encode the owner/responsible for this EventType and ideally should
           follow a common pattern that makes it easy to read and understand, but this level of
-          structure is not enforced. For example a team name and data type can be used such as
-          'acme-team.price-change'.
+          structure is not enforced.
         pattern: '[a-zA-Z][-0-9a-zA-Z_]*(\.[0-9a-zA-Z][-0-9a-zA-Z_]*)*'
         example: order.order_cancelled
       owning_application:


### PR DESCRIPTION
While generating example of api definition the values that are used to provide several examples are leading to a weirdly-looking value with ` ,` in the middle. The better approach to avoid it - use single example