### PR TITLE
Update: API definition of occurred_at vs. received_at event attributes

### DIFF
--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -2227,19 +2227,24 @@ definitions:
         example: 'pennybags.payment-business-event'
       occurred_at:
         description: |
-          Timestamp of when the event was created by the producer application. 
-          (Typically, it differs from when the event is posted by the producer and received by Nakadi via the API.)
+         Technical timestamp of when the event object was created during processing of the
+         business event by the producer application. Note, it may differ from the timestamp 
+         when the related real-world business event happened (e.g. when the packet was handed 
+         over to the customer), which should be passed separately via an event type specific 
+         attribute. 
+         Depending on the producer implementation, the timestamp is typically some milliseconds  
+         earlier than when the event is published and received by the API event post endpoint 
+         server -- see below.
         type: string
         format: RFC 3339 date-time
         example: '1996-12-19T16:39:57-08:00'
       received_at:
         type: string
         readOnly: true
-        description: |
-          Timestamp of when the event was received by Nakadi via the event post endpoints. 
-          It is automatically enriched, and events will be rejected if set by the Event producer.
-        format: RFC 3339 date-time
-        example: '1996-12-19T16:39:57-08:00'
+      description: |
+        Timestamp of when the event was received via the API event post endpoints. 
+        It is automatically enriched, and events will be rejected if set by the event producer.
+      example: '1996-12-19T16:39:57-08:00'
       version:
         type: string
         readOnly: true

--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -2227,24 +2227,25 @@ definitions:
         example: 'pennybags.payment-business-event'
       occurred_at:
         description: |
-         Technical timestamp of when the event object was created during processing of the
-         business event by the producer application. Note, it may differ from the timestamp 
-         when the related real-world business event happened (e.g. when the packet was handed 
-         over to the customer), which should be passed separately via an event type specific 
-         attribute. 
-         Depending on the producer implementation, the timestamp is typically some milliseconds  
-         earlier than when the event is published and received by the API event post endpoint 
-         server -- see below.
+          Technical timestamp of when the event object was created during processing of the
+          business event by the producer application. Note, it may differ from the timestamp 
+          when the related real-world business event happened (e.g. when the packet was handed 
+          over to the customer), which should be passed separately via an event type specific 
+          attribute. 
+          Depending on the producer implementation, the timestamp is typically some milliseconds  
+          earlier than when the event is published and received by the API event post endpoint 
+          server -- see below.
         type: string
         format: RFC 3339 date-time
         example: '1996-12-19T16:39:57-08:00'
       received_at:
         type: string
         readOnly: true
-      description: |
-        Timestamp of when the event was received via the API event post endpoints. 
-        It is automatically enriched, and events will be rejected if set by the event producer.
-      example: '1996-12-19T16:39:57-08:00'
+        description: |
+          Timestamp of when the event was received via the API event post endpoints. 
+          It is automatically enriched, and events will be rejected if set by the event producer.
+        format: RFC 3339 date-time
+        example: '1996-12-19T16:39:57-08:00'
       version:
         type: string
         readOnly: true


### PR DESCRIPTION
Minor editorial update to make it consistent with API Guideline definition (see https://github.com/zalando/restful-api-guidelines/pull/659) and to avoid misunderstandings still observed in production.

Just an update of field descriptions in API definition -- no semantic or code changes, no test needed, but re-deployment of API spec.
