### PR TITLE
close zk client when it was taken

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/CursorsServiceAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/CursorsServiceAT.java
@@ -17,6 +17,7 @@ import org.zalando.nakadi.domain.Timeline;
 import org.zalando.nakadi.exceptions.runtime.InvalidStreamIdException;
 import org.zalando.nakadi.repository.TopicRepository;
 import org.zalando.nakadi.repository.db.SubscriptionDbRepository;
+import org.zalando.nakadi.repository.zookeeper.CuratorFrameworkRotator;
 import org.zalando.nakadi.repository.zookeeper.ZooKeeperHolder;
 import org.zalando.nakadi.service.AuthorizationValidator;
 import org.zalando.nakadi.service.CursorConverter;
@@ -97,8 +98,10 @@ public class CursorsServiceAT extends BaseAT {
 
         final ZooKeeperHolder zkHolder = mock(ZooKeeperHolder.class);
         when(zkHolder.get()).thenReturn(CURATOR);
+        final CuratorFrameworkRotator curatorRotator = new CuratorFrameworkRotator(
+                () -> ZookeeperTestUtils.createCurator(ZOOKEEPER_URL), 300_000, 10_000);
         when(zkHolder.getSubscriptionCurator(anyLong()))
-                .thenReturn(new ZooKeeperHolder.DisposableCuratorFramework(CURATOR));
+                .thenReturn(new ZooKeeperHolder.RotatingCuratorFramework(curatorRotator));
 
         final TopicRepository topicRepository = mock(TopicRepository.class);
         final TimelineService timelineService = mock(TimelineService.class);

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -82,6 +82,7 @@ public class StreamingContext implements SubscriptionStreamer {
     private ZkSubscription<List<String>> sessionListSubscription;
     private Closeable authorizationCheckSubscription;
     private boolean sessionRegistered;
+    private boolean zkClientClosed;
 
     private final Logger log;
 
@@ -252,6 +253,13 @@ public class StreamingContext implements SubscriptionStreamer {
         log.info("Registering session {}", session);
         zkClient.registerSession(session);
         sessionRegistered = true;
+    }
+
+    public void closeZkClient() throws IOException {
+        if (!zkClientClosed) {
+            zkClient.close();
+            zkClientClosed = true;
+        }
     }
 
     public void subscribeToSessionListChangeAndRebalance() throws NakadiRuntimeException {

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/CleanupState.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/CleanupState.java
@@ -36,7 +36,7 @@ public class CleanupState extends State {
             }
 
             try {
-                getContext().getZkClient().close();
+                getContext().closeZkClient();
             } catch (final IOException e) {
                 getLog().error("Unexpected fail to release zk connection", e);
             }

--- a/core-common/src/main/java/org/zalando/nakadi/repository/zookeeper/ZooKeeperHolder.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/zookeeper/ZooKeeperHolder.java
@@ -41,7 +41,8 @@ public class ZooKeeperHolder {
         this.maxCommitTimeoutMs = TimeUnit.SECONDS.toMillis(nakadiSettings.getMaxCommitTimeout());
 
         zooKeeper = createCuratorFramework(sessionTimeoutMs, connectionTimeoutMs);
-        curatorFrameworkRotator = new CuratorFrameworkRotator(this,
+        curatorFrameworkRotator = new CuratorFrameworkRotator(
+                () -> newCuratorFramework(),
                 nakadiSettings.getCuratorMaxLifetimeMs(),
                 nakadiSettings.getCuratorRotationCheckMs());
     }

--- a/core-common/src/test/java/org/zalando/nakadi/repository/zookeeper/CuratorFrameworkRotatorTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/zookeeper/CuratorFrameworkRotatorTest.java
@@ -15,7 +15,8 @@ public class CuratorFrameworkRotatorTest {
 
         Mockito.when(zkh.newCuratorFramework()).thenReturn(cf1);
 
-        final CuratorFrameworkRotator curatorFrameworkRotator = new CuratorFrameworkRotator(zkh, 10, 10000);
+        final CuratorFrameworkRotator curatorFrameworkRotator = new CuratorFrameworkRotator(
+                () -> zkh.newCuratorFramework(), 10, 10000);
 
         CuratorFramework cfTmp = curatorFrameworkRotator.takeCuratorFramework();
         Assert.assertEquals(cf1, cfTmp);
@@ -39,7 +40,8 @@ public class CuratorFrameworkRotatorTest {
 
         Mockito.when(zkh.newCuratorFramework()).thenReturn(cf1);
 
-        final CuratorFrameworkRotator curatorFrameworkRotator = new CuratorFrameworkRotator(zkh, 10, 10000);
+        final CuratorFrameworkRotator curatorFrameworkRotator = new CuratorFrameworkRotator(
+                () -> zkh.newCuratorFramework(), 10, 10000);
 
         CuratorFramework cfTmp = curatorFrameworkRotator.takeCuratorFramework();
         Assert.assertEquals(cf1, cfTmp);


### PR DESCRIPTION
at the moment when zk client is taken it is not always closed which violaties a good practice to release whatever you acquired. it also prevents rotating curator framework from working properly because it is taken, but never returned.