### PR TITLE
remove unused session hash

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/CursorsServiceAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/CursorsServiceAT.java
@@ -293,7 +293,7 @@ public class CursorsServiceAT extends BaseAT {
     private void setPartitions(final Partition[] partitions) throws Exception {
         final String topologyPath = subscriptionPath() + "/topology";
         final byte[] topologyData = MAPPER.writeValueAsBytes(
-                new NewZkSubscriptionClient.Topology(partitions, null, 0));
+                new NewZkSubscriptionClient.Topology(partitions, 0));
         if (null == CURATOR.checkExists().forPath(topologyPath)) {
             CURATOR.create().forPath(topologyPath, topologyData);
         } else {

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRepartitionAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRepartitionAT.java
@@ -92,7 +92,7 @@ public class HilaRepartitionAT extends BaseAT {
     private void setInitialTopology(final Partition[] partitions) throws Exception {
         final String topologyPath = subscriptionPath() + "/topology";
         final byte[] topologyData = MAPPER.writeValueAsBytes(
-                new NewZkSubscriptionClient.Topology(partitions, null, 0));
+                new NewZkSubscriptionClient.Topology(partitions, 0));
         if (null == CURATOR.checkExists().forPath(topologyPath)) {
             CURATOR.create().creatingParentsIfNeeded().forPath(topologyPath, topologyData);
         } else {

--- a/api-consumption/src/test/java/org/zalando/nakadi/service/subscription/state/StreamingStateTest.java
+++ b/api-consumption/src/test/java/org/zalando/nakadi/service/subscription/state/StreamingStateTest.java
@@ -120,7 +120,7 @@ public class StreamingStateTest {
     public void ensureTopologyEventListenerRegisteredRefreshedClosed() {
         final ZkSubscription topologySubscription = mock(ZkSubscription.class);
         Mockito.when(topologySubscription.getData())
-                .thenReturn(new ZkSubscriptionClient.Topology(new Partition[]{}, null, 1));
+                .thenReturn(new ZkSubscriptionClient.Topology(new Partition[]{}, 1));
         Mockito.when(zkMock.subscribeForTopologyChanges(Mockito.anyObject())).thenReturn(topologySubscription);
 
         state.onEnter();
@@ -149,7 +149,7 @@ public class StreamingStateTest {
         // mock topology
         final ZkSubscription topologySubscription = mock(ZkSubscription.class);
         Mockito.when(topologySubscription.getData())
-                .thenReturn(new ZkSubscriptionClient.Topology(partitions, null, 1));
+                .thenReturn(new ZkSubscriptionClient.Topology(partitions, 1));
         Mockito.when(zkMock.subscribeForTopologyChanges(Mockito.anyObject())).thenReturn(topologySubscription);
 
         // prepare mocks for assigned partitions

--- a/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/NewZkSubscriptionClient.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/NewZkSubscriptionClient.java
@@ -91,7 +91,7 @@ public class NewZkSubscriptionClient extends AbstractZkSubscriptionClient {
                 null,
                 Partition.State.UNASSIGNED
         )).toArray(Partition[]::new);
-        final Topology topology = new Topology(partitions, "", 0);
+        final Topology topology = new Topology(partitions, 0);
         getLog().info("Creating topology ZNode for {}", topology);
         final byte[] topologyData = objectMapper.writeValueAsBytes(topology);
         try {
@@ -121,8 +121,8 @@ public class NewZkSubscriptionClient extends AbstractZkSubscriptionClient {
 
                     final Partition[] partitions = partitioner.apply(topology);
                     if (partitions.length > 0) {
-                        final Topology newTopology = topology.withUpdatedPartitions(
-                                null, partitions);
+                        final Topology newTopology =
+                                topology.withUpdatedPartitions(partitions);
                         getLog().info("Updating topology to {}", newTopology);
                         try {
                             getCurator().setData().withVersion(stats.getVersion())
@@ -273,7 +273,6 @@ public class NewZkSubscriptionClient extends AbstractZkSubscriptionClient {
 
         final Topology partitionedTopology = new Topology(
                 partitionsList.toArray(new Partition[0]),
-                currentTopology.getSessionsHash(),
                 Optional.ofNullable(currentTopology.getVersion()).map(v -> v + 1).orElse(0)
         );
 

--- a/core-common/src/test/java/org/zalando/nakadi/service/subscription/zk/NewZkSubscriptionClientTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/service/subscription/zk/NewZkSubscriptionClientTest.java
@@ -40,7 +40,6 @@ public class NewZkSubscriptionClientTest {
         topology = objectMapper.writeValueAsBytes(new ZkSubscriptionClient.Topology(
                 new Partition[]{new Partition(
                         "test-event-type", "0", "session-id-xxx", null, Partition.State.REASSIGNING)},
-                null,
                 null
         ));
         client = new NewZkSubscriptionClient(

--- a/core-common/src/test/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClientTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClientTest.java
@@ -31,7 +31,6 @@ public class ZkSubscriptionClientTest {
     public void testSerializationDeserialization() throws IOException {
         final ZkSubscriptionClient.Topology first = new ZkSubscriptionClient.Topology(
                 new Partition[]{new Partition("1", "2", "3", "4", Partition.State.ASSIGNED)},
-                "123",
                 456);
 
         final String serialized = TestUtils.OBJECT_MAPPER.writer().writeValueAsString(first);


### PR DESCRIPTION
since migration to optimistic locking(https://github.com/zalando/nakadi/pull/1280) there is no need to have session hash to perform rebalance