### PR TITLE
503 when token info down

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRebalanceAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRebalanceAT.java
@@ -3,7 +3,6 @@ package org.zalando.nakadi.webservice.hila;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.hamcrest.Matchers;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
@@ -342,7 +341,7 @@ public class HilaRebalanceAT extends BaseAT {
         client2.start();
 
         waitFor(() -> assertThat("at least one client should get 409 conflict",
-                        client1.getResponseCode() == HttpStatus.CONFLICT.value() ||
+                client1.getResponseCode() == HttpStatus.CONFLICT.value() ||
                         client1.getResponseCode() == HttpStatus.CONFLICT.value()));
     }
 

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRepartitionAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/HilaRepartitionAT.java
@@ -5,7 +5,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zalando.nakadi.domain.EventType;

--- a/app/src/main/java/org/zalando/nakadi/config/AuthenticationConfig.java
+++ b/app/src/main/java/org/zalando/nakadi/config/AuthenticationConfig.java
@@ -6,20 +6,37 @@ import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
+import org.springframework.util.Assert;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
+import org.zalando.nakadi.exceptions.runtime.ServiceTemporarilyUnavailableException;
 import org.zalando.nakadi.service.FeatureToggleService;
 import org.zalando.stups.oauth2.spring.authorization.DefaultUserRolesProvider;
 import org.zalando.stups.oauth2.spring.server.DefaultAuthenticationExtractor;
+import org.zalando.stups.oauth2.spring.server.TokenInfoRequestExecutor;
 import org.zalando.stups.oauth2.spring.server.TokenInfoResourceServerTokenServices;
 import org.zalando.stups.oauth2.spring.server.TokenResponseErrorHandler;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Map;
+
 
 @Configuration
 @Profile("!test")
@@ -31,11 +48,10 @@ public class AuthenticationConfig {
             final RestTemplate restTemplate,
             final SecuritySettings securitySettings) {
         return new TokenInfoResourceServerTokenServices(
-                securitySettings.getTokenInfoUrl(),
                 securitySettings.getClientId(),
                 new DefaultAuthenticationExtractor(),
                 new DefaultUserRolesProvider(),
-                restTemplate
+                new NakadiTokenInfoRequestExecutor(securitySettings.getTokenInfoUrl(), restTemplate)
         );
     }
 
@@ -45,11 +61,10 @@ public class AuthenticationConfig {
             final RestTemplate restTemplate,
             final SecuritySettings securitySettings) {
         return new TokenInfoResourceServerTokenServices(
-                securitySettings.getLocalTokenInfoUrl(),
                 securitySettings.getClientId(),
                 new DefaultAuthenticationExtractor(),
                 new DefaultUserRolesProvider(),
-                restTemplate
+                new NakadiTokenInfoRequestExecutor(securitySettings.getTokenInfoUrl(), restTemplate)
         );
     }
 
@@ -106,6 +121,46 @@ public class AuthenticationConfig {
         final RestTemplate restTemplate = new RestTemplate(requestFactory);
         restTemplate.setErrorHandler(TokenResponseErrorHandler.getDefault());
         return restTemplate;
+    }
+
+    public static class NakadiTokenInfoRequestExecutor implements TokenInfoRequestExecutor {
+        private static final Logger LOGGER = LoggerFactory.getLogger(NakadiTokenInfoRequestExecutor.class);
+        private static final String BEARER_TOKEN_TEMPLATE = "Bearer %s";
+        private static final ParameterizedTypeReference<Map<String, Object>> TOKENINFO_MAP =
+                new ParameterizedTypeReference<>() {
+                };
+
+        private final URI tokenInfoURL;
+        private final RestTemplate restTemplate;
+
+        public NakadiTokenInfoRequestExecutor(final String tokenInfoURL, final RestTemplate restTemplate) {
+            this.restTemplate = restTemplate;
+            Assert.notNull(restTemplate, "'restTemplate' should never be null");
+            Assert.hasText(tokenInfoURL, "TokenInfoEndpointUrl should never be null or empty");
+            try {
+                new URL(tokenInfoURL);
+            } catch (MalformedURLException e) {
+                throw new IllegalArgumentException("TokenInfoEndpointUrl is not an URL", e);
+            }
+
+            this.tokenInfoURL = URI.create(tokenInfoURL);
+        }
+
+        @Override
+        public Map<String, Object> getMap(final String accessToken) {
+            LOGGER.debug("Getting token-info from: {}", tokenInfoURL);
+
+            final RequestEntity<Void> entity = RequestEntity.get(tokenInfoURL).accept(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, String.format(BEARER_TOKEN_TEMPLATE, accessToken)).build();
+            try {
+                return restTemplate.exchange(entity, TOKENINFO_MAP).getBody();
+            } catch (HttpStatusCodeException e) {
+                throw new ServiceTemporarilyUnavailableException("Unable to validate token", e);
+            } catch (Exception e) {
+                LOGGER.warn("Unable to get authorisation from tokeninfo", e);
+                return Collections.singletonMap("error", e.getMessage());
+            }
+        }
     }
 
 }


### PR DESCRIPTION
#  Differentiating tokenInfo endpoint problems from an invalid token. 

> Zalando ticket : https://github.bus.zalan.do/aruha/team-aruha/issues/82

## Description
The DefaultTokenInfoRequestExecutor treats not being able to validate a
token, probably because the tokenInfo endpoint is not working, as the
token not being valid. Adding NakadiTokenInfoRequestExecutor to
differentiate the problems with tokenInfo endpoint and throw a
ServiceTemporarilyUnavailableException exception when the tokenInfo is
not working.

