### PR TITLE
Leaderless partitions should not fail publishing

### DIFF
--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -351,7 +351,8 @@ public class KafkaTopicRepository implements TopicRepository {
             final Map<BatchItem, CompletableFuture<Exception>> sendFutures = new HashMap<>();
             for (final BatchItem item : batch) {
                 if (item.getBrokerId() == null) {
-                    item.updateStatusAndDetail(EventPublishingStatus.FAILED, String.format("No leader for partition."));
+                    item.updateStatusAndDetail(EventPublishingStatus.FAILED, String.format("No leader for partition: %s, topic: %s.", item.getPartition(), topicId));
+                    LOG.warn("Failed to publish. No leader fo partition [{}], topic [{topicId}].", item.getPartition(), topicId);
                     continue;
                 }
                 item.setStep(EventPublishingStep.PUBLISHING);

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -353,8 +353,8 @@ public class KafkaTopicRepository implements TopicRepository {
                 if (item.getBrokerId() == null) {
                     item.updateStatusAndDetail(EventPublishingStatus.FAILED,
                             String.format("No leader for partition: %s, topic: %s.", item.getPartition(), topicId));
-                    LOG.warn("Failed to publish to kafka. No leader for partition [{}], topic [{topicId}].",
-                            item.getPartition(), topicId);
+                    LOG.error("Failed to publish to kafka. No leader for ({}:{}).",
+                            topicId, item.getPartition());
                     continue;
                 }
                 item.setStep(EventPublishingStep.PUBLISHING);

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -351,8 +351,10 @@ public class KafkaTopicRepository implements TopicRepository {
             final Map<BatchItem, CompletableFuture<Exception>> sendFutures = new HashMap<>();
             for (final BatchItem item : batch) {
                 if (item.getBrokerId() == null) {
-                    item.updateStatusAndDetail(EventPublishingStatus.FAILED, String.format("No leader for partition: %s, topic: %s.", item.getPartition(), topicId));
-                    LOG.warn("Failed to publish. No leader fo partition [{}], topic [{topicId}].", item.getPartition(), topicId);
+                    item.updateStatusAndDetail(EventPublishingStatus.FAILED,
+                            String.format("No leader for partition: %s, topic: %s.", item.getPartition(), topicId));
+                    LOG.warn("Failed to publish to kafka. No leader for partition [{}], topic [{topicId}].",
+                            item.getPartition(), topicId);
                     continue;
                 }
                 item.setStep(EventPublishingStep.PUBLISHING);

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -50,9 +50,7 @@ import java.util.stream.Collectors;
 import static com.google.common.collect.Sets.newHashSet;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.anyString;
@@ -341,7 +339,7 @@ public class KafkaTopicRepositoryTest {
         });
 
         assertThat(firstItem.getResponse().getPublishingStatus(), equalTo(EventPublishingStatus.FAILED));
-        assertThat(firstItem.getResponse().getDetail(), equalTo("No leader for partition."));
+        assertThat(firstItem.getResponse().getDetail(), containsString("No leader for partition"));
 
         assertThat(secondItem.getResponse().getPublishingStatus(), equalTo(EventPublishingStatus.SUBMITTED));
     }

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -50,8 +50,12 @@ import java.util.stream.Collectors;
 import static com.google.common.collect.Sets.newHashSet;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.anyVararg;
@@ -334,7 +338,7 @@ public class KafkaTopicRepositoryTest {
             return null;
         });
 
-        assertThrows(EventPublishingException.class, () -> {
+        Assert.assertThrows(EventPublishingException.class, () -> {
             kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(), batch, "random", false);
         });
 

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -53,8 +53,7 @@ import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.anyVararg;
@@ -305,6 +304,46 @@ public class KafkaTopicRepositoryTest {
             assertThat(item.getResponse().getPublishingStatus(), equalTo(EventPublishingStatus.FAILED));
             assertThat(item.getResponse().getDetail(), equalTo("timed out"));
         }
+    }
+
+    @Test
+    public void whenPartitionLeaderNotFoundTheRestOfTheBatchOk() {
+        final BatchItem firstItem = new BatchItem(
+                "{}",
+                BatchItem.EmptyInjectionConfiguration.build(1, true),
+                new BatchItem.InjectionConfiguration[BatchItem.Injection.values().length],
+                Collections.emptyList());
+        firstItem.setPartition("1");
+
+        final BatchItem secondItem = new BatchItem(
+                "{}",
+                BatchItem.EmptyInjectionConfiguration.build(1, true),
+                new BatchItem.InjectionConfiguration[BatchItem.Injection.values().length],
+                Collections.emptyList());
+        secondItem.setPartition("2");
+
+        final List<BatchItem> batch = new ArrayList<>();
+        batch.add(firstItem);
+        batch.add(secondItem);
+
+        when(kafkaProducer.partitionsFor(EXPECTED_PRODUCER_RECORD.topic())).thenReturn(ImmutableList.of(
+                new PartitionInfo(EXPECTED_PRODUCER_RECORD.topic(), 1, null, null, null),
+                new PartitionInfo(EXPECTED_PRODUCER_RECORD.topic(), 2, NODE, null, null)));
+
+        when(kafkaProducer.send(any(), any())).thenAnswer(invocation -> {
+            final Callback callback = (Callback) invocation.getArguments()[1];
+            callback.onCompletion(null, null);
+            return null;
+        });
+
+        assertThrows(EventPublishingException.class, () -> {
+            kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(), batch, "random", false);
+        });
+
+        assertThat(firstItem.getResponse().getPublishingStatus(), equalTo(EventPublishingStatus.FAILED));
+        assertThat(firstItem.getResponse().getDetail(), equalTo("No leader for partition."));
+
+        assertThat(secondItem.getResponse().getPublishingStatus(), equalTo(EventPublishingStatus.SUBMITTED));
     }
 
     @Test


### PR DESCRIPTION
# One-line summary

> Zalando ticket : 764

## Description
At the time when Nakadi requests partition information from Kafka Producer, it can happen that a partition can have no broker as a leader. In this case, chances are that the event will not get published by Kafka Producer.

Currently, Nakadi throws a null pointer exception that fails the entire batch.

## Review
- [X] Tests
- [ ] Documentation
