### PR TITLE
Removing core-publishing module from settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,6 @@ rootProject.name = 'nakadi'
 include 'app'
 
 include 'core-common'
-include 'core-publishing'
 include 'core-services'
 include 'core-metastore'
 


### PR DESCRIPTION
# Removing core-publishing module from settings.gradle

## Description
The `core-publishing` module is no present in the Nakadi codebase now.
The `core-publishing` entry in the settings.gradle is simply creating
empty directory that is not committed to the repo and generating an
empty Jar file as well. Removing this entry to cleanup the
`settings.gradle`.
