### PR TITLE
Safety check in unregister session method

### DIFF
--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -81,7 +81,6 @@ public class StreamingContext implements SubscriptionStreamer {
     private State currentState = new DummyState();
     private ZkSubscription<List<String>> sessionListSubscription;
     private Closeable authorizationCheckSubscription;
-    private boolean sessionRegistered;
     private boolean zkClientClosed;
 
     private final Logger log;
@@ -252,7 +251,6 @@ public class StreamingContext implements SubscriptionStreamer {
     public void registerSession() throws NakadiRuntimeException {
         log.info("Registering session {}", session);
         zkClient.registerSession(session);
-        sessionRegistered = true;
     }
 
     public void closeZkClient() throws IOException {
@@ -278,7 +276,6 @@ public class StreamingContext implements SubscriptionStreamer {
         } finally {
             this.sessionListSubscription = null;
             // It's safe to unregister session, even if the original call to register it has failed.
-            sessionRegistered = false;
             zkClient.unregisterSession(session);
         }
     }

--- a/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/AbstractZkSubscriptionClient.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/AbstractZkSubscriptionClient.java
@@ -173,6 +173,8 @@ public abstract class AbstractZkSubscriptionClient implements ZkSubscriptionClie
     public final void unregisterSession(final Session session) {
         try {
             getCurator().delete().guaranteed().forPath(getSubscriptionPath("/sessions/" + session.getId()));
+        } catch (final KeeperException.NoNodeException ke) {
+            // It's OK that the session node was not there: all we want is to make sure it's deleted.
         } catch (final Exception e) {
             throw new NakadiRuntimeException(e);
         }

--- a/core-common/src/test/java/org/zalando/nakadi/service/subscription/zk/NewZkSubscriptionClientTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/service/subscription/zk/NewZkSubscriptionClientTest.java
@@ -2,8 +2,11 @@ package org.zalando.nakadi.service.subscription.zk;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.BackgroundPathAndBytesable;
+import org.apache.curator.framework.api.ChildrenDeletable;
+import org.apache.curator.framework.api.DeleteBuilder;
 import org.apache.curator.framework.api.GetDataBuilder;
 import org.apache.curator.framework.api.SetDataBuilder;
 import org.apache.curator.framework.api.WatchPathable;
@@ -15,6 +18,7 @@ import org.zalando.nakadi.domain.EventTypePartition;
 import org.zalando.nakadi.repository.zookeeper.CuratorFrameworkRotator;
 import org.zalando.nakadi.repository.zookeeper.ZooKeeperHolder;
 import org.zalando.nakadi.service.subscription.model.Partition;
+import org.zalando.nakadi.service.subscription.model.Session;
 
 import java.util.Collections;
 
@@ -26,6 +30,9 @@ public class NewZkSubscriptionClientTest {
     private final SetDataBuilder setDataBuilder = Mockito.mock(SetDataBuilder.class);
     private final BackgroundPathAndBytesable bytesable = Mockito.mock(BackgroundPathAndBytesable.class);
     private final WatchPathable watchPathable = Mockito.mock(WatchPathable.class);
+    private final DeleteBuilder deleteBuilder = Mockito.mock(DeleteBuilder.class);
+    private final ChildrenDeletable childrenDeletable = Mockito.mock(ChildrenDeletable.class);
+
     private final ObjectMapper objectMapper = new ObjectMapper();
     private NewZkSubscriptionClient client;
     private byte[] topology;
@@ -37,6 +44,9 @@ public class NewZkSubscriptionClientTest {
         Mockito.when(curator.setData()).thenReturn(setDataBuilder);
         Mockito.when(setDataBuilder.withVersion(Mockito.anyInt())).thenReturn(bytesable);
         Mockito.when(getDataBuilder.storingStatIn(Mockito.any())).thenReturn(watchPathable);
+        Mockito.when(curator.delete()).thenReturn(deleteBuilder);
+        Mockito.when(deleteBuilder.guaranteed()).thenReturn(childrenDeletable);
+
         topology = objectMapper.writeValueAsBytes(new ZkSubscriptionClient.Topology(
                 new Partition[]{new Partition(
                         "test-event-type", "0", "session-id-xxx", null, Partition.State.REASSIGNING)},
@@ -86,5 +96,17 @@ public class NewZkSubscriptionClientTest {
                 new EventTypePartition("test-event-type", "0")));
         Mockito.verify(bytesable, Mockito.times(0)).forPath(Mockito.anyString(), Mockito.any());
         Mockito.reset(bytesable);
+    }
+
+    @Test
+    public void whenUnregisterSessionMissingNodeThenOk() throws Exception {
+
+        Mockito.when(curator.delete().guaranteed().forPath(Mockito.any()))
+            .thenThrow(KeeperException.NoNodeException.class);
+
+        final Session session = Session.generate(1, ImmutableList.of());
+
+        // It should not throw.
+        client.unregisterSession(session);
     }
 }


### PR DESCRIPTION
It should not throw exception if the node was already gone (or wasn't there in
the first place).  Otherwise our cleanup procedure will handle the exception
and try to unregister again and again.

Follow-up on #1299 

## Review
- [ ] Tests
- [ ] Documentation
