### PR TITLE
Be prepared for multiple calls to unregister session

### DIFF
--- a/api-consumption/src/test/java/org/zalando/nakadi/service/subscription/StreamingContextTest.java
+++ b/api-consumption/src/test/java/org/zalando/nakadi/service/subscription/StreamingContextTest.java
@@ -177,7 +177,7 @@ public class StreamingContextTest {
     }
 
     @Test
-    public void testSessionAlwaysCleaned() throws Exception {
+    public void testSessionAlwaysCleanedManyTimesOk() throws Exception {
 
         final ZkSubscriptionClient zkMock = mock(ZkSubscriptionClient.class);
         when(zkMock.isActiveSession(any())).thenReturn(true);
@@ -194,6 +194,9 @@ public class StreamingContextTest {
         assertThrows(NakadiRuntimeException.class, () -> context.registerSession());
 
         // CleanupState calls context.unregisterSession() in finally block
+        context.unregisterSession();
+
+        // It can also be called many times and should not result in exceptions
         context.unregisterSession();
 
         Mockito.verify(zkMock, Mockito.times(1)).unregisterSession(any());


### PR DESCRIPTION
# One-line summary
This restores the `sessionRegistered` flag, but makes sure to set it early and
to clean it before attempting to delete the node in ZooKeeper.

Zalando ticket : 788

## Review
- [ ] Tests
- [ ] Documentation
