### PR TITLE
Fine-tune unregisterSession

### DIFF
--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -281,9 +281,9 @@ public class StreamingContext implements SubscriptionStreamer {
         } finally {
             this.sessionListSubscription = null;
             if (sessionRegistered) {
-                // This method can get called many times during cleanup, so we should avoid deleting the node again.
-                sessionRegistered = false;
                 zkClient.unregisterSession(session);
+                // It may get called more than one time during cleanup, so we should avoid deleting the node again.
+                sessionRegistered = false;
             }
         }
     }


### PR DESCRIPTION
# One-line summary

In case ZooKeeper client has a problem we might not actually delete the
session's node, so let it try another time if needed by not clearing the flag
just yet.

Zalando ticket : 788
