### PR TITLE
Stop relying on Curator's guarantees

### DIFF
--- a/app/src/main/java/org/zalando/nakadi/service/job/ExclusiveJobWrapper.java
+++ b/app/src/main/java/org/zalando/nakadi/service/job/ExclusiveJobWrapper.java
@@ -68,7 +68,6 @@ public class ExclusiveJobWrapper {
         try {
             zkHolder.get()
                     .delete()
-                    .guaranteed()
                     .forPath(zkPath + "/lock");
         } catch (final Exception e) {
             log.error("Zookeeper error when deleting job lock-node", e);

--- a/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/AbstractZkSubscriptionClient.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/AbstractZkSubscriptionClient.java
@@ -87,7 +87,7 @@ public abstract class AbstractZkSubscriptionClient implements ZkSubscriptionClie
     @Override
     public final void deleteSubscription() {
         try {
-            getCurator().delete().guaranteed()
+            getCurator().delete()
                     .deletingChildrenIfNeeded()
                     .forPath(getSubscriptionPath(""));
         } catch (final KeeperException.NoNodeException nne) {
@@ -172,7 +172,7 @@ public abstract class AbstractZkSubscriptionClient implements ZkSubscriptionClie
     @Override
     public final void unregisterSession(final Session session) {
         try {
-            getCurator().delete().guaranteed().forPath(getSubscriptionPath("/sessions/" + session.getId()));
+            getCurator().delete().forPath(getSubscriptionPath("/sessions/" + session.getId()));
         } catch (final KeeperException.NoNodeException ke) {
             // It's OK that the session node was not there: all we want is to make sure it's deleted.
         } catch (final Exception e) {
@@ -346,7 +346,7 @@ public abstract class AbstractZkSubscriptionClient implements ZkSubscriptionClie
 
             try {
                 if (!resetWasAlreadyInitiated) {
-                    getCurator().delete().guaranteed().forPath(closeSubscriptionStream);
+                    getCurator().delete().forPath(closeSubscriptionStream);
                 }
             } catch (final Exception e) {
                 getLog().error(e.getMessage(), e);

--- a/core-common/src/test/java/org/zalando/nakadi/service/subscription/zk/NewZkSubscriptionClientTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/service/subscription/zk/NewZkSubscriptionClientTest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.BackgroundPathAndBytesable;
-import org.apache.curator.framework.api.ChildrenDeletable;
 import org.apache.curator.framework.api.DeleteBuilder;
 import org.apache.curator.framework.api.GetDataBuilder;
 import org.apache.curator.framework.api.SetDataBuilder;
@@ -31,7 +30,6 @@ public class NewZkSubscriptionClientTest {
     private final BackgroundPathAndBytesable bytesable = Mockito.mock(BackgroundPathAndBytesable.class);
     private final WatchPathable watchPathable = Mockito.mock(WatchPathable.class);
     private final DeleteBuilder deleteBuilder = Mockito.mock(DeleteBuilder.class);
-    private final ChildrenDeletable childrenDeletable = Mockito.mock(ChildrenDeletable.class);
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private NewZkSubscriptionClient client;
@@ -45,7 +43,6 @@ public class NewZkSubscriptionClientTest {
         Mockito.when(setDataBuilder.withVersion(Mockito.anyInt())).thenReturn(bytesable);
         Mockito.when(getDataBuilder.storingStatIn(Mockito.any())).thenReturn(watchPathable);
         Mockito.when(curator.delete()).thenReturn(deleteBuilder);
-        Mockito.when(deleteBuilder.guaranteed()).thenReturn(childrenDeletable);
 
         topology = objectMapper.writeValueAsBytes(new ZkSubscriptionClient.Topology(
                 new Partition[]{new Partition(
@@ -101,7 +98,7 @@ public class NewZkSubscriptionClientTest {
     @Test
     public void whenUnregisterSessionMissingNodeThenOk() throws Exception {
 
-        Mockito.when(curator.delete().guaranteed().forPath(Mockito.any()))
+        Mockito.when(curator.delete().forPath(Mockito.any()))
             .thenThrow(KeeperException.NoNodeException.class);
 
         final Session session = Session.generate(1, ImmutableList.of());


### PR DESCRIPTION
The background attempts to retry the delete operations were causing more harm
than good.

We do not rely on the deletes to always work as the nodes are ephemeral and
will be removed eventually within the next ZooKeeper client rotation interval.

## Review
- [ ] Tests
- [ ] Documentation
