### PR TITLE
Less noisy logging in StreamingState

### DIFF
--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -377,8 +377,7 @@ class StreamingState extends State {
 
             batchesSent++;
         } catch (final IOException e) {
-            getLog().warn("Failed to write data to output: {}", e.toString());
-            shutdownGracefully("Failed to write data to output");
+            shutdownGracefully("Failed to write data to output: " + e.toString());
         }
     }
 

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -377,7 +377,7 @@ class StreamingState extends State {
 
             batchesSent++;
         } catch (final IOException e) {
-            getLog().warn("Failed to write data to output: {}", e);
+            getLog().warn("Failed to write data to output: {}", e.toString());
             shutdownGracefully("Failed to write data to output");
         }
     }


### PR DESCRIPTION
The 'failed to write data to output' state is known to happen often, but it's
OK.  Don't log the full exception trace in this case.
