### PR TITLE
Bugfix: Do not overwrite annotations and labels when missing.

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/EventTypeAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/EventTypeAT.java
@@ -1,6 +1,8 @@
 package org.zalando.nakadi.webservice;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.http.HttpStatus;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -542,11 +544,13 @@ public class EventTypeAT extends BaseAT {
 
     @Test
     public void whenPUTEventTypeWithoutAnnotationsAndLabelsThenOriginalValuesAreKept() throws JsonProcessingException {
+        final ObjectMapper objectMapper = MAPPER.copy();
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         final EventType eventType = buildDefaultEventType();
         eventType.getAnnotations().put("nakadi.io/annotation-key", "original-annotation");
         eventType.getLabels().put("nakadi.io/label-key", "original-label");
 
-        given().body(MAPPER.writer().writeValueAsString(eventType))
+        given().body(objectMapper.writer().writeValueAsString(eventType))
                 .header("accept", "application/json").contentType(JSON)
                 .when().post(ENDPOINT).then()
                 .body(equalTo("")).statusCode(HttpStatus.SC_CREATED);
@@ -561,7 +565,7 @@ public class EventTypeAT extends BaseAT {
         eventType.setAnnotations(null);
         eventType.setLabels(null);
 
-        given().body(MAPPER.writer().writeValueAsString(eventType))
+        given().body(objectMapper.writer().writeValueAsString(eventType))
                 .header("accept", "application/json")
                 .contentType(JSON).when().put(ENDPOINT + "/" + eventType.getName()).then()
                 .body(equalTo("")).statusCode(HttpStatus.SC_OK);
@@ -578,7 +582,7 @@ public class EventTypeAT extends BaseAT {
         eventType.setLabels(new ResourceLabels());
         eventType.getLabels().put("nakadi.io/label-key", "new-label");
 
-        given().body(MAPPER.writer().writeValueAsString(eventType))
+        given().body(objectMapper.writer().writeValueAsString(eventType))
                 .header("accept", "application/json")
                 .contentType(JSON).when().put(ENDPOINT + "/" + eventType.getName()).then()
                 .body(equalTo("")).statusCode(HttpStatus.SC_OK);

--- a/core-common/src/main/java/org/zalando/nakadi/domain/EventTypeBase.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/EventTypeBase.java
@@ -91,8 +91,6 @@ public class EventTypeBase implements EventTypeAuthz {
         this.options = new EventTypeOptions();
         this.compatibilityMode = CompatibilityMode.FORWARD;
         this.cleanupPolicy = CleanupPolicy.DELETE;
-        this.annotations = new ResourceAnnotations();
-        this.labels = new ResourceLabels();
     }
 
     public EventTypeBase(final String name,


### PR DESCRIPTION
# Bugfix: Do not overwrite annotations and labels when missing.

> Zalando ticket : team-aruha/issues/752

## Description
When annotations or labels is missing in the input, the existing value
should be preserved. This fix remove creation of empty annotation and
label objects when they are missing in the imput, thereby preserving the
existing values.