### PR TITLE
Remove some stale code

### DIFF
--- a/api-metastore/src/test/java/org/zalando/nakadi/controller/PartitionsControllerTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/controller/PartitionsControllerTest.java
@@ -33,7 +33,6 @@ import org.zalando.nakadi.service.RepartitioningService;
 import org.zalando.nakadi.service.converter.CursorConverterImpl;
 import org.zalando.nakadi.service.timeline.TimelineService;
 import org.zalando.nakadi.utils.TestUtils;
-import org.zalando.nakadi.view.CursorLag;
 import org.zalando.nakadi.view.EventTypePartitionView;
 import org.zalando.problem.Problem;
 import org.zalando.problem.ThrowableProblem;
@@ -62,10 +61,10 @@ public class PartitionsControllerTest {
     private static final String UNKNOWN_PARTITION = "unknown-partition";
 
     private static final EventTypePartitionView TEST_TOPIC_PARTITION_0 =
-            new EventTypePartitionView(TEST_EVENT_TYPE, "0", "001-0000-000000000000000012",
+            new EventTypePartitionView("0", "001-0000-000000000000000012",
                     "001-0000-000000000000000067");
     private static final EventTypePartitionView TEST_TOPIC_PARTITION_1 =
-            new EventTypePartitionView(TEST_EVENT_TYPE, "1", "001-0000-000000000000000043",
+            new EventTypePartitionView("1", "001-0000-000000000000000043",
                     "001-0000-000000000000000098");
 
     private static final List<EventTypePartitionView> TEST_TOPIC_PARTITIONS = ImmutableList.of(
@@ -213,7 +212,7 @@ public class PartitionsControllerTest {
         mockMvc.perform(
                 get(String.format("/event-types/%s/partitions/%s?consumed_offset=1", TEST_EVENT_TYPE, TEST_PARTITION)))
                 .andExpect(status().isOk())
-                .andExpect(content().string(TestUtils.JSON_TEST_HELPER.matchesObject(new CursorLag(
+                .andExpect(content().string(TestUtils.JSON_TEST_HELPER.matchesObject(new EventTypePartitionView(
                         "0",
                         "001-0000-0",
                         "001-0000-1",

--- a/core-common/src/main/java/org/zalando/nakadi/view/EventTypePartitionView.java
+++ b/core-common/src/main/java/org/zalando/nakadi/view/EventTypePartitionView.java
@@ -1,33 +1,36 @@
 package org.zalando.nakadi.view;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 public class EventTypePartitionView {
-    @JsonIgnore
-    private String eventType;
     @JsonProperty("partition")
     private String partitionId;
     private String oldestAvailableOffset;
     private String newestAvailableOffset;
+    @JsonProperty("unconsumed_events")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Long unconsumedEvents;
+
 
     public EventTypePartitionView() {
     }
 
-    public EventTypePartitionView(final String eventType, final String partitionId, final String oldestAvailableOffset,
+    public EventTypePartitionView(final String partitionId, final String oldestAvailableOffset,
                                   final String newestAvailableOffset) {
-        this.eventType = eventType;
         this.partitionId = partitionId;
         this.oldestAvailableOffset = oldestAvailableOffset;
         this.newestAvailableOffset = newestAvailableOffset;
     }
 
-    public String getEventType() {
-        return eventType;
-    }
-
-    public void setEventType(final String eventType) {
-        this.eventType = eventType;
+    public EventTypePartitionView(final String partitionId, final String oldestAvailableOffset,
+                                  final String newestAvailableOffset, final Long unconsumedEvents) {
+        this.partitionId = partitionId;
+        this.oldestAvailableOffset = oldestAvailableOffset;
+        this.newestAvailableOffset = newestAvailableOffset;
+        this.unconsumedEvents = unconsumedEvents;
     }
 
     public String getPartitionId() {
@@ -54,6 +57,14 @@ public class EventTypePartitionView {
         this.newestAvailableOffset = newestAvailableOffset;
     }
 
+    public Long getUnconsumedEvents() {
+        return unconsumedEvents;
+    }
+
+    public void setUnconsumedEvents(final Long unconsumedEvents) {
+        this.unconsumedEvents = unconsumedEvents;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -66,40 +77,34 @@ public class EventTypePartitionView {
 
         final EventTypePartitionView that = (EventTypePartitionView) o;
 
-        if (eventType != null ? !eventType.equals(that.eventType) : that.eventType != null) {
+        if (!Objects.equals(partitionId, that.partitionId)) {
             return false;
         }
 
-        if (partitionId != null ? !partitionId.equals(that.partitionId) : that.partitionId != null) {
+        if (!Objects.equals(oldestAvailableOffset, that.oldestAvailableOffset)) {
             return false;
         }
 
-        if (oldestAvailableOffset != null ? !oldestAvailableOffset.equals(that.oldestAvailableOffset)
-                                          : that.oldestAvailableOffset != null) {
+        if (!Objects.equals(unconsumedEvents, that.unconsumedEvents)) {
             return false;
         }
 
-        return newestAvailableOffset != null ? newestAvailableOffset.equals(that.newestAvailableOffset)
-                                             : that.newestAvailableOffset == null;
+        return Objects.equals(newestAvailableOffset, that.newestAvailableOffset);
 
     }
 
     @Override
     public int hashCode() {
-        int result = eventType != null ? eventType.hashCode() : 0;
-        result = 31 * result + (partitionId != null ? partitionId.hashCode() : 0);
-        result = 31 * result + (oldestAvailableOffset != null ? oldestAvailableOffset.hashCode() : 0);
-        result = 31 * result + (newestAvailableOffset != null ? newestAvailableOffset.hashCode() : 0);
-        return result;
+        return Objects.hash(partitionId, oldestAvailableOffset, newestAvailableOffset, unconsumedEvents);
     }
 
     @Override
     public String toString() {
         return "EventTypePartitionView{" +
-                "eventType='" + eventType + '\'' +
-                ", partitionId='" + partitionId + '\'' +
+                "partitionId='" + partitionId + '\'' +
                 ", oldestAvailableOffset='" + oldestAvailableOffset + '\'' +
                 ", newestAvailableOffset='" + newestAvailableOffset + '\'' +
+                ", unconsumedEvents='" + unconsumedEvents + '\'' +
                 '}';
     }
 }


### PR DESCRIPTION
# One-line summary
Remove some outdated code (generation of response code, usage of incorrect DTO) in `event-types/{et}/partitions*` calls