### PR TITLE
[WiP] Use tracing ScopeManager to set the active span

### DIFF
--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/CleanupState.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/CleanupState.java
@@ -40,7 +40,6 @@ public class CleanupState extends State {
             } catch (final IOException e) {
                 getLog().error("Unexpected fail to release zk connection", e);
             }
-            getContext().getCurrentSpan().finish();
         }
     }
 }

--- a/api-consumption/src/test/java/org/zalando/nakadi/service/subscription/StreamingContextTest.java
+++ b/api-consumption/src/test/java/org/zalando/nakadi/service/subscription/StreamingContextTest.java
@@ -85,10 +85,7 @@ public class StreamingContextTest {
             }
         };
         final Thread t = new Thread(() -> {
-            try {
-                ctx.streamInternal(killerState);
-            } catch (final InterruptedException ignore) {
-            }
+            ctx.streamInternal(killerState);
         });
         t.start();
         t.join(1000);
@@ -156,14 +153,11 @@ public class StreamingContextTest {
     public void testOnNodeShutdown() throws Exception {
         final StreamingContext ctxSpy = Mockito.spy(createTestContext(null));
         final Thread t = new Thread(() -> {
-            try {
-                ctxSpy.streamInternal(new State() {
-                    @Override
-                    public void onEnter() {
-                    }
-                });
-            } catch (final InterruptedException ignore) {
-            }
+            ctxSpy.streamInternal(new State() {
+                @Override
+                public void onEnter() {
+                }
+            });
         });
         t.start();
         t.join(1000);


### PR DESCRIPTION
# One-line summary

This is the recommended way to enable discovery of the current active span
instead of passing the "parent" span explicitly everywhere.
