### PR TITLE
Removed READ authorization check for some metadata endpoints

### DIFF
--- a/api-metastore/src/main/java/org/zalando/nakadi/controller/CursorOperationsController.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/controller/CursorOperationsController.java
@@ -59,7 +59,6 @@ public class CursorOperationsController {
 
         final EventType eventType = eventTypeCache.getEventType(eventTypeName);
         authorizationValidator.authorizeEventTypeView(eventType);
-        authorizationValidator.authorizeStreamRead(eventType);
 
         queries.getList().forEach(query -> {
             try {

--- a/api-metastore/src/main/java/org/zalando/nakadi/controller/PartitionsController.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/controller/PartitionsController.java
@@ -255,7 +255,6 @@ public class PartitionsController {
     private void checkAuthorization(final String eventTypeName) {
         final EventType eventType = eventTypeCache.getEventType(eventTypeName);
         authorizationValidator.authorizeEventTypeView(eventType);
-        authorizationValidator.authorizeStreamRead(eventType);
     }
 
     @RequestMapping(value = "/event-types/{name}/partitions/{partition}", method = RequestMethod.GET)

--- a/api-metastore/src/main/java/org/zalando/nakadi/controller/PartitionsController.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/controller/PartitionsController.java
@@ -118,7 +118,8 @@ public class PartitionsController {
         LOG.trace(
                 "Get partitions endpoint for event-type '{}' with cursorList `{}` is called",
                 eventTypeName, cursorsString);
-        checkAuthorization(eventTypeName);
+        final EventType eventType = eventTypeCache.getEventType(eventTypeName);
+        authorizationValidator.authorizeEventTypeView(eventType);
 
         final List<Timeline> timelines = timelineService.getActiveTimelinesOrdered(eventTypeName);
         final List<PartitionStatistics> firstStats =
@@ -252,9 +253,10 @@ public class PartitionsController {
         }
     }
 
-    private void checkAuthorization(final String eventTypeName) {
+    private void checkAuthorization(final String eventTypeName){
         final EventType eventType = eventTypeCache.getEventType(eventTypeName);
         authorizationValidator.authorizeEventTypeView(eventType);
+        authorizationValidator.authorizeStreamRead(eventType);
     }
 
     @RequestMapping(value = "/event-types/{name}/partitions/{partition}", method = RequestMethod.GET)

--- a/api-metastore/src/test/java/org/zalando/nakadi/controller/PartitionsControllerTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/controller/PartitionsControllerTest.java
@@ -196,28 +196,6 @@ public class PartitionsControllerTest {
     }
 
     @Test
-    public void whenUnauthorizedGetPartitionThenForbiddenStatusCode() throws Exception {
-        Mockito.when(eventTypeCacheMock.getEventType(TEST_EVENT_TYPE)).thenReturn(EVENT_TYPE);
-
-        Mockito.doThrow(TestUtils.mockAccessDeniedException()).when(authorizationValidator).authorizeStreamRead(any());
-
-        mockMvc.perform(
-                get(String.format("/event-types/%s/partitions/%s", TEST_EVENT_TYPE, TEST_PARTITION)))
-                .andExpect(status().isForbidden());
-    }
-
-    @Test
-    public void whenUnauthorizedGetPartitionsThenForbiddenStatusCode() throws Exception {
-        Mockito.when(eventTypeCacheMock.getEventType(TEST_EVENT_TYPE)).thenReturn(EVENT_TYPE);
-
-        Mockito.doThrow(TestUtils.mockAccessDeniedException()).when(authorizationValidator).authorizeStreamRead(any());
-
-        mockMvc.perform(
-                get(String.format("/event-types/%s/partitions", TEST_EVENT_TYPE)))
-                .andExpect(status().isForbidden());
-    }
-
-    @Test
     public void whenAllDataAccessGetPartitionsThenOk() throws Exception {
         Mockito.when(eventTypeCacheMock.getEventType(TEST_EVENT_TYPE)).thenReturn(EVENT_TYPE);
 
@@ -225,8 +203,6 @@ public class PartitionsControllerTest {
 
         mockMvc.perform(get(String.format("/event-types/%s/partitions", TEST_EVENT_TYPE)))
                 .andExpect(status().isOk());
-
-        Mockito.verify(authorizationValidator, Mockito.times(1)).authorizeStreamRead(any());
     }
 
     @Test
@@ -377,8 +353,6 @@ public class PartitionsControllerTest {
         mockMvc.perform(
                     get("/event-types/{0}/partitions?cursors={1}", TEST_EVENT_TYPE, cursorString))
                 .andExpect(content().string(TestUtils.JSON_TEST_HELPER.matchesObject(TEST_TOPIC_PARTITIONS_UE)));
-
-        Mockito.verify(authorizationValidator, Mockito.times(1)).authorizeStreamRead(any());
     }
 
     private List<NakadiCursorLag> getNakadiCursorLags() {


### PR DESCRIPTION
# Enabled viewing of some metadata for eventTypes

## Description
Removed auth checks for READ operation on 
- /event-types/{name}/partitions
- /event-types/{name}/cursor-distances

End point /subscriptions/{id}/stats is unchanged as it is using only View authorization already.

Authorization for View Operation are still done.