### PR TITLE
Allow to change partitioning strategy to nakadi admins

### DIFF
--- a/api-metastore/src/main/java/org/zalando/nakadi/config/SchemaValidatorConfig.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/config/SchemaValidatorConfig.java
@@ -6,12 +6,9 @@ import com.google.common.io.Resources;
 import org.everit.json.schema.Schema;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONObject;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.zalando.nakadi.domain.SchemaChange;
-import org.zalando.nakadi.plugin.api.authz.AuthorizationService;
-import org.zalando.nakadi.service.AdminService;
 import org.zalando.nakadi.service.SchemaEvolutionService;
 import org.zalando.nakadi.validation.schema.CategoryChangeConstraint;
 import org.zalando.nakadi.validation.schema.CompatibilityModeChangeConstraint;
@@ -47,13 +44,14 @@ import static org.zalando.nakadi.domain.SchemaChange.Type.TYPE_NARROWED;
 @Configuration
 public class SchemaValidatorConfig {
 
-    private final AdminService adminService;
-    private final AuthorizationService authorizationService;
+    private final CompatibilityModeChangeConstraint compatibilityModeChangeConstraint;
+    private final PartitionStrategyConstraint partitionStrategyConstraint;
 
-    @Autowired
-    public SchemaValidatorConfig(final AdminService adminService, final AuthorizationService authorizationService) {
-        this.adminService = adminService;
-        this.authorizationService = authorizationService;
+    public SchemaValidatorConfig(
+            final CompatibilityModeChangeConstraint compatibilityModeChangeConstraint,
+            final PartitionStrategyConstraint partitionStrategyConstraint) {
+        this.compatibilityModeChangeConstraint = compatibilityModeChangeConstraint;
+        this.partitionStrategyConstraint = partitionStrategyConstraint;
     }
 
     @Bean
@@ -64,9 +62,9 @@ public class SchemaValidatorConfig {
 
         final List<SchemaEvolutionConstraint> schemaEvolutionConstraints = Lists.newArrayList(
                 new CategoryChangeConstraint(),
-                new CompatibilityModeChangeConstraint(adminService, authorizationService),
+                compatibilityModeChangeConstraint,
                 new PartitionKeyFieldsConstraint(),
-                new PartitionStrategyConstraint(),
+                partitionStrategyConstraint,
                 new EnrichmentStrategyConstraint()
         );
 

--- a/api-metastore/src/main/java/org/zalando/nakadi/validation/schema/CompatibilityModeChangeConstraint.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/validation/schema/CompatibilityModeChangeConstraint.java
@@ -2,6 +2,8 @@ package org.zalando.nakadi.validation.schema;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 import org.zalando.nakadi.domain.CompatibilityMode;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeBase;
@@ -12,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+@Service
 public class CompatibilityModeChangeConstraint implements SchemaEvolutionConstraint {
     final Map<CompatibilityMode, List<CompatibilityMode>> allowedChanges = ImmutableMap.of(
             CompatibilityMode.COMPATIBLE, Lists.newArrayList(CompatibilityMode.COMPATIBLE),
@@ -22,6 +25,7 @@ public class CompatibilityModeChangeConstraint implements SchemaEvolutionConstra
     private final AdminService adminService;
     private final AuthorizationService authorizationService;
 
+    @Autowired
     public CompatibilityModeChangeConstraint(final AdminService adminService,
                                              final AuthorizationService authorizationService) {
         this.adminService = adminService;

--- a/api-metastore/src/main/java/org/zalando/nakadi/validation/schema/PartitionStrategyConstraint.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/validation/schema/PartitionStrategyConstraint.java
@@ -1,14 +1,30 @@
 package org.zalando.nakadi.validation.schema;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeBase;
 import org.zalando.nakadi.partitioning.PartitionStrategy;
+import org.zalando.nakadi.plugin.api.authz.AuthorizationService;
+import org.zalando.nakadi.service.AdminService;
 
 import java.util.Optional;
 
+@Service
 public class PartitionStrategyConstraint implements SchemaEvolutionConstraint {
+    private final AdminService adminService;
+
+    @Autowired
+    public PartitionStrategyConstraint(final AdminService adminService) {
+        this.adminService = adminService;
+    }
+
     @Override
     public Optional<SchemaEvolutionIncompatibility> validate(final EventType original, final EventTypeBase eventType) {
+        if (adminService.isAdmin(AuthorizationService.Operation.WRITE)) {
+            // allow nakadi administrators to bypass the partitioning strategy check
+            return Optional.empty();
+        }
         if (!original.getPartitionStrategy().equals(PartitionStrategy.RANDOM_STRATEGY)
                 && !eventType.getPartitionStrategy().equals(original.getPartitionStrategy())) {
             return Optional.of(new SchemaEvolutionIncompatibility("changing partition_strategy " +

--- a/api-metastore/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTest.java
@@ -41,7 +41,6 @@ import org.zalando.nakadi.view.EventOwnerSelector;
 import org.zalando.problem.Problem;
 import org.zalando.problem.ThrowableProblem;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -78,7 +77,7 @@ import static org.zalando.problem.Status.UNPROCESSABLE_ENTITY;
 
 public class EventTypeControllerTest extends EventTypeControllerTestCase {
 
-    public EventTypeControllerTest() throws IOException {
+    public EventTypeControllerTest() {
     }
 
     @Test
@@ -610,7 +609,7 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
 
         deleteEventType(eventTypeName).andExpect(status().isInternalServerError())
                 .andExpect(content().contentType("application/problem+json")).andExpect(content()
-                .string(matchesProblem(expectedProblem)));
+                        .string(matchesProblem(expectedProblem)));
     }
 
     @Test
@@ -621,7 +620,7 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
 
         postEventType(TestUtils.buildDefaultEventType()).andExpect(status().isInternalServerError())
                 .andExpect(content().contentType("application/problem+json")).andExpect(
-                content().string(matchesProblem(expectedProblem)));
+                        content().string(matchesProblem(expectedProblem)));
     }
 
     @Test
@@ -648,7 +647,7 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
 
         postEventType(et).andExpect(status().isServiceUnavailable())
                 .andExpect(content().contentType("application/problem+json")).andExpect(content().string(
-                matchesProblem(expectedProblem)));
+                        matchesProblem(expectedProblem)));
 
         verify(eventTypeRepository, times(1)).saveEventType(any(EventTypeBase.class));
         verify(timelineService, times(1)).createDefaultTimeline(any(), anyInt());
@@ -667,8 +666,8 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
         putEventType(jsonObject.toString(), invalidEventType.getName()).andExpect(status().isUnprocessableEntity())
                 .andExpect(content().contentType(
                         "application/problem+json")).andExpect(
-                content().string(
-                        matchesProblem(expectedProblem)));
+                        content().string(
+                                matchesProblem(expectedProblem)));
     }
 
     @Test
@@ -684,7 +683,7 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
 
         putEventType(eventType, eventTypeName).andExpect(status().isUnprocessableEntity())
                 .andExpect(content().contentType("application/problem+json")).andExpect(
-                content().string(matchesProblem(expectedProblem)));
+                        content().string(matchesProblem(expectedProblem)));
     }
 
     @Test
@@ -711,7 +710,7 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
 
         mockMvc.perform(requestBuilder).andExpect(status().is(200))
                 .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON)).andExpect(content().json(
-                TestUtils.OBJECT_MAPPER.writeValueAsString(expectedEventType)));
+                        TestUtils.OBJECT_MAPPER.writeValueAsString(expectedEventType)));
 
     }
 
@@ -729,7 +728,7 @@ public class EventTypeControllerTest extends EventTypeControllerTestCase {
 
         mockMvc.perform(requestBuilder).andExpect(status().is(404))
                 .andExpect(content().contentTypeCompatibleWith("application/problem+json")).andExpect(content().string(
-                matchesProblem(expectedProblem)));
+                        matchesProblem(expectedProblem)));
 
     }
 

--- a/api-metastore/src/test/java/org/zalando/nakadi/validation/schema/PartitionStrategyConstraintTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/validation/schema/PartitionStrategyConstraintTest.java
@@ -1,0 +1,90 @@
+package org.zalando.nakadi.validation.schema;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.OngoingStubbing;
+import org.zalando.nakadi.domain.EventType;
+import org.zalando.nakadi.partitioning.PartitionStrategy;
+import org.zalando.nakadi.plugin.api.authz.AuthorizationService;
+import org.zalando.nakadi.service.AdminService;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PartitionStrategyConstraintTest {
+    @Mock
+    private AdminService adminService;
+
+    private PartitionStrategyConstraint constraint;
+
+    private static final String[] ALL_STRATEGIES = {
+            PartitionStrategy.HASH_STRATEGY,
+            PartitionStrategy.RANDOM_STRATEGY,
+            PartitionStrategy.USER_DEFINED_STRATEGY};
+
+    @Before
+    public void before() {
+        constraint = new PartitionStrategyConstraint(adminService);
+    }
+
+    @Test
+    public void migrationFromRandomToAnythingIsAllowed() {
+        when(adminService.isAdmin(eq(AuthorizationService.Operation.WRITE))).thenReturn(false);
+        final EventType original = new EventType();
+        original.setPartitionStrategy(PartitionStrategy.RANDOM_STRATEGY);
+
+        for (final String value : ALL_STRATEGIES) {
+            final EventType changed = new EventType();
+            changed.setPartitionStrategy(value);
+
+            final Optional<SchemaEvolutionIncompatibility> error = constraint.validate(original, changed);
+            Assert.assertFalse(error.isPresent());
+        }
+    }
+
+    @Test
+    public void migrationFromNonRandomToAnythingIsForbidden() {
+        when(adminService.isAdmin(eq(AuthorizationService.Operation.WRITE))).thenReturn(false);
+
+        for (final String o : new String[]{PartitionStrategy.HASH_STRATEGY, PartitionStrategy.USER_DEFINED_STRATEGY}) {
+            final EventType original = new EventType();
+            original.setPartitionStrategy(o);
+            for (final String t : ALL_STRATEGIES) {
+                if (Objects.equals(t, o)) {
+                    continue;
+                }
+                final EventType target = new EventType();
+                target.setPartitionStrategy(t);
+                final Optional<SchemaEvolutionIncompatibility> error = constraint.validate(original, target);
+                Assert.assertTrue(error.isPresent());
+            }
+        }
+
+    }
+
+    @Test
+    public void migrationFromAnythingToAnythingForAdminAllowed() {
+        OngoingStubbing<Boolean> stubbing = when(adminService.isAdmin(eq(AuthorizationService.Operation.WRITE)));
+        for (final String o : ALL_STRATEGIES) {
+            final EventType original = new EventType();
+            original.setPartitionStrategy(o);
+            for (final String t : ALL_STRATEGIES) {
+                final EventType target = new EventType();
+                target.setPartitionStrategy(t);
+
+                stubbing = stubbing.thenReturn(true);
+
+                final Optional<SchemaEvolutionIncompatibility> error = constraint.validate(original, target);
+                Assert.assertFalse(error.isPresent());
+            }
+        }
+    }
+}


### PR DESCRIPTION
# One-line summary

Right now nakadi admins are pretty limited in the actions that may be executed. 

This PR allows nakadi admins to change event type partitioning strategy to any value. 