### PR TITLE
[README Documentation] Resolved the ambiguity of whether two tasks have different scopes of work

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ The gradle setup is fairly standard, the main tasks are:
 Some other useful tasks are:
 
 - `./gradlew startNakadi`: build Nakadi and start docker-compose services: nakadi, postgresql, zookeeper and kafka
-- `./gradlew stopNakadi`: shutdown docker-compose services
+- `./gradlew stopNakadi`: shutdown all docker-compose services (current implementation is same as that of `./gradlew stopStorages`)
 - `./gradlew startStorages`: start docker-compose services: postgres, zookeeper and kafka (useful for development purposes)
-- `./gradlew stopStorages`: shutdown docker-compose services
+- `./gradlew stopStorages`: shutdown all docker-compose services (current implementation is same as that of `./gradlew stopNakadi`)
 - `./gradlew fullAcceptanceTest`: start Nakadi configured for acceptance tests and run acceptance tests
 
 For working with an IDE, the `eclipse` IDE task is available and you'll be able to import the `build.gradle` into Intellij IDEA directly.


### PR DESCRIPTION
# One-line summary
In README file, for the sake of clarity, specified that the two tasks 'gradlew stopNakadi' and 'gradlew stopStorages' have common scope of work and code. For https://github.com/zalando/nakadi/issues/1334

## Description
The Building section of README.md file reads:
Some other useful tasks are:
./gradlew startNakadi: build Nakadi and start docker-compose services: nakadi, postgresql, zookeeper and kafka
./gradlew stopNakadi: shutdown docker-compose services
./gradlew startStorages: start docker-compose services: postgres, zookeeper and kafka (useful for development purposes)
./gradlew stopStorages: shutdown docker-compose services
./gradlew fullAcceptanceTest: start Nakadi configured for acceptance tests and run acceptance tests

Here the descriptions of two tasks are identical. For some readers, these may appear to be ambiguous of not misleading, like over the question of what services in all are shut down by stopNakadi and what services are shut down by stopStorages.

I have updated the documentation (2 lines) to resolve the question of ambiguity.
I hope that the contribution from me adds value.

## Review
- [ ] Tests
- [ ] Documentation

## Deployment Notes
NA