### PR TITLE
Add subscription id to the "no free slots" log

### DIFF
--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StartingState.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StartingState.java
@@ -85,7 +85,7 @@ public class StartingState extends State {
 
             if (autoBalanceSessionsCount >= autoSlotsCount) {
                 logStreamCloseReason("No streaming slots available");
-                throw new NoStreamingSlotsAvailable(partitions.length);
+                throw new NoStreamingSlotsAvailable(getContext().getSubscription().getId(), partitions.length);
             }
         }
 

--- a/core-common/src/main/java/org/zalando/nakadi/exceptions/runtime/NoStreamingSlotsAvailable.java
+++ b/core-common/src/main/java/org/zalando/nakadi/exceptions/runtime/NoStreamingSlotsAvailable.java
@@ -1,7 +1,8 @@
 package org.zalando.nakadi.exceptions.runtime;
 
 public class NoStreamingSlotsAvailable extends NakadiBaseException {
-    public NoStreamingSlotsAvailable(final int totalSlots) {
-        super("No free slots for streaming available. Total slots: " + totalSlots);
+    public NoStreamingSlotsAvailable(final String subscriptionId, final int totalSlots) {
+        super(String.format("No free slots for streaming available for subscription %s. Total slots: %d",
+                subscriptionId, totalSlots));
     }
 }


### PR DESCRIPTION
Sometimes it might be useful to know what subscription was it.