### PR TITLE
Fix typo: getLocalTokenInfoUrl()

### DIFF
--- a/app/src/main/java/org/zalando/nakadi/config/AuthenticationConfig.java
+++ b/app/src/main/java/org/zalando/nakadi/config/AuthenticationConfig.java
@@ -64,7 +64,7 @@ public class AuthenticationConfig {
                 securitySettings.getClientId(),
                 new DefaultAuthenticationExtractor(),
                 new DefaultUserRolesProvider(),
-                new NakadiTokenInfoRequestExecutor(securitySettings.getTokenInfoUrl(), restTemplate)
+                new NakadiTokenInfoRequestExecutor(securitySettings.getLocalTokenInfoUrl(), restTemplate)
         );
     }
 


### PR DESCRIPTION
Fix copy/paste problem in `AuthenticationConfig` class.
