### PR TITLE
docs: Create does not update a subscription

### DIFF
--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -2624,7 +2624,7 @@ definitions:
       number of clients by managing consumed event offsets and distributing load between instances.
       The key properties that identify subscription are 'owning_application', 'event_types' and 'consumer_group'.
       It's not possible to have two different subscriptions with these properties being the same.
-      Trying to create a subscription with these keys matching an existing one will just return that one, and
+      Creating a subscription with the keys matching existing subscription will neither create a new or change the existing subscription ignoring the remaining fields (e.g. `read_from`, `authorization`, etc.).
       ignore the remaining fields (e.g. `read_from`, `authorization`, etc.).
     properties:
       id:

--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -2624,8 +2624,8 @@ definitions:
       number of clients by managing consumed event offsets and distributing load between instances.
       The key properties that identify subscription are 'owning_application', 'event_types' and 'consumer_group'.
       It's not possible to have two different subscriptions with these properties being the same.
-      Creating a subscription with the keys matching existing subscription will neither create a new or change the existing subscription ignoring the remaining fields (e.g. `read_from`, `authorization`, etc.).
-      ignore the remaining fields (e.g. `read_from`, `authorization`, etc.).
+      Creating a subscription with the keys matching an existing subscription will neither create a new one nor
+      change the existing subscription, ignoring the remaining fields (e.g. `read_from`, `authorization`, etc.).
     properties:
       id:
         type: string

--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -1076,7 +1076,7 @@ paths:
         The subscription is identified by its key parameters (owning_application, event_types, consumer_group). If
         this endpoint is invoked several times with the same key subscription properties in body (order of even_types is
         not important) - the subscription will be created only once and for all other calls it will just return
-        the subscription that was already created.
+        the subscription that was already created (ignoring the other parts of the body – the subscription will not be updated).
       parameters:
         - name: subscription
           in: body
@@ -2624,6 +2624,8 @@ definitions:
       number of clients by managing consumed event offsets and distributing load between instances.
       The key properties that identify subscription are 'owning_application', 'event_types' and 'consumer_group'.
       It's not possible to have two different subscriptions with these properties being the same.
+      Trying to create a subscription with these keys matching an existing one will just return that one, and
+      ignore the remaining fields (e.g. `read_from`, `authorization`, etc.).
     properties:
       id:
         type: string


### PR DESCRIPTION
# One-line summary

Docs only: make it clear that POST /subscriptions will not update an existing subscription

## Description

In an [internal discussion](https://chat.google.com/room/AAAALJjUd9k/7gM7kMlsUa8) some confusion was noticed about the behavior
of the `POST /subscriptions` endpoint when a subscription with the same keys
already exists (specifically about the cursors).

This change should make this a bit clearer, adding a bit of text to the endpoint
and the subscription object definition.


## Review
- [ ] Tests
- [ ] Documentation

## Deployment Notes

