### PR TITLE
docs: POST /subscriptions doesn't update (part 2)

### DIFF
--- a/docs/_documentation/using_consuming-events-hila.md
+++ b/docs/_documentation/using_consuming-events-hila.md
@@ -66,6 +66,9 @@ Content-Type: application/json;charset=UTF-8
 }
 ```
 
+If there is already a subscription with same `owning_application`, `event_types` and `consumer_group`,
+it is just returned (and not updated, all other parts of the request body are then ignored).
+
 ### Consuming Events from a Subscription
 
 Consuming events is done by sending a GET request to the Subscriptions's event resource (`/subscriptions/{subscription-id}/events`): 


### PR DESCRIPTION
# One-line summary

Docs only: make it clear that POST /subscriptions will not update an existing subscription

## Description

It turns out that I missed this file in #1350.
(This is for https://nakadi.io/manual.html#creating-subscriptions)

## Review
- [ ] Documentation

## Deployment Notes
