### PR TITLE
Setting EventPublisher loglevel to Debug

### DIFF
--- a/app/src/main/resources/log4j.properties
+++ b/app/src/main/resources/log4j.properties
@@ -19,6 +19,7 @@ log4j.category.org.springframework.boot.actuate.autoconfigure.CrshAutoConfigurat
 log4j.category.org.springframework.boot.actuate.endpoint.jmx=WARN
 log4j.category.org.thymeleaf=WARN
 log4j.category.org.zalando.nakadi=DEBUG
+log4j.category.org.zalando.nakadi.service.publishing.EventPublisher=DEBUG
 log4j.category.org.zalando.nakadi.config=INFO
 log4j.category.org.apache.kafka=WARN
 log4j.category.org.zalando.nakadi.service.ClosedConnectionsCrutch=WARN


### PR DESCRIPTION
# One-line summary
Setting EventPublisher loglevel to Debug as it helps in viewing event publishing validation errors