### PR TITLE
use ByteArraySerializer for producer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ kafka-src
 scm-source.json
 
 *.code-workspace
+*.DS_Store

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -260,7 +260,7 @@ public class KafkaRepositoryAT extends BaseAT {
     }
 
     private Map<String, List<PartitionInfo>> getAllTopics() {
-        final KafkaConsumer<String, String> kafkaConsumer = kafkaHelper.createConsumer();
+        final KafkaConsumer<byte[], byte[]> kafkaConsumer = kafkaHelper.createConsumer();
         return kafkaConsumer.listTopics();
     }
 

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaTestHelper.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaTestHelper.java
@@ -12,6 +12,7 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.assertj.core.util.Lists;
 import org.zalando.nakadi.view.Cursor;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -30,29 +31,29 @@ public class KafkaTestHelper {
         this.kafkaUrl = kafkaUrl;
     }
 
-    public KafkaConsumer<String, String> createConsumer() {
+    public KafkaConsumer<byte[], byte[]> createConsumer() {
         return new KafkaConsumer<>(createKafkaProperties());
     }
 
-    public KafkaProducer<String, String> createProducer() {
+    public KafkaProducer<byte[], byte[]> createProducer() {
         return new KafkaProducer<>(createKafkaProperties());
     }
 
     protected static Properties createKafkaProperties() {
         final Properties props = new Properties();
         props.put("bootstrap.servers", "localhost:29092");
-        props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
-        props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
-        props.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
-        props.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+        props.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
+        props.put("key.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
+        props.put("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+        props.put("key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
         return props;
     }
 
     public void writeMessageToPartition(final String partition, final String topic, final String message)
             throws ExecutionException, InterruptedException {
         final String messageToSend = String.format("\"%s\"", message);
-        final ProducerRecord<String, String> producerRecord = new ProducerRecord<>(topic, Integer.parseInt(partition),
-                "someKey", messageToSend);
+        final ProducerRecord<byte[], byte[]> producerRecord = new ProducerRecord<>(topic, Integer.parseInt(partition),
+                "someKey".getBytes(StandardCharsets.UTF_8), messageToSend.getBytes(StandardCharsets.UTF_8));
         createProducer().send(producerRecord).get();
     }
 
@@ -82,7 +83,7 @@ public class KafkaTestHelper {
 
     public List<Cursor> getNextOffsets(final String topic) {
 
-        final KafkaConsumer<String, String> consumer = createConsumer();
+        final KafkaConsumer<byte[], byte[]> consumer = createConsumer();
         final List<TopicPartition> partitions = consumer
                 .partitionsFor(topic)
                 .stream()

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/EventTypeAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/EventTypeAT.java
@@ -31,6 +31,7 @@ import org.zalando.nakadi.webservice.utils.NakadiTestUtils;
 import org.zalando.problem.Problem;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -418,13 +419,13 @@ public class EventTypeAT extends BaseAT {
 
         // assert that key was correctly propagated to event key in kafka
         final KafkaTestHelper kafkaHelper = new KafkaTestHelper(KAFKA_URL);
-        final KafkaConsumer<String, String> consumer = kafkaHelper.createConsumer();
+        final KafkaConsumer<byte[], byte[]> consumer = kafkaHelper.createConsumer();
         final TopicPartition tp = new TopicPartition(topic, 0);
         consumer.assign(ImmutableList.of(tp));
         consumer.seek(tp, 0);
-        final ConsumerRecords<String, String> records = consumer.poll(5000);
-        final ConsumerRecord<String, String> record = records.iterator().next();
-        assertThat(record.key(), equalTo("abc"));
+        final ConsumerRecords<byte[], byte[]> records = consumer.poll(5000);
+        final ConsumerRecord<byte[], byte[]> record = records.iterator().next();
+        assertThat(record.key(), equalTo("abc".getBytes(StandardCharsets.UTF_8)));
 
         // publish event with missing compaction key and expect 422
         given().body("[{\"metadata\":{" +

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/PartitionsControllerAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/PartitionsControllerAT.java
@@ -18,6 +18,7 @@ import org.zalando.nakadi.view.Cursor;
 import org.zalando.nakadi.webservice.utils.NakadiTestUtils;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -192,9 +193,10 @@ public class PartitionsControllerAT extends BaseAT {
     }
 
     private void writeMessageToPartition(final int partition) throws InterruptedException, ExecutionException {
-        final KafkaProducer<String, String> producer = kafkaHelper.createProducer();
-        final ProducerRecord<String, String> producerRecord = new ProducerRecord<>(topicName, partition, "blahKey",
-                "blahValue");
+        final KafkaProducer<byte[], byte[]> producer = kafkaHelper.createProducer();
+        final ProducerRecord<byte[], byte[]> producerRecord = new ProducerRecord<>(topicName, partition,
+                "blahKey".getBytes(StandardCharsets.UTF_8),
+                "blahValue".getBytes(StandardCharsets.UTF_8));
         producer.send(producerRecord).get();
     }
 

--- a/core-common/src/main/java/org/zalando/nakadi/domain/BatchItem.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/BatchItem.java
@@ -138,6 +138,15 @@ public class BatchItem implements Resource<BatchItem> {
         return eventKey;
     }
 
+    @Nullable
+    public byte[] getEventKeyBytes() {
+        if (eventKey == null) {
+            return null;
+        }
+
+        return eventKey.getBytes(StandardCharsets.UTF_8);
+    }
+
     public void setEventKey(@Nullable final String key) {
         this.eventKey = key;
     }
@@ -243,6 +252,10 @@ public class BatchItem implements Resource<BatchItem> {
             appendWithSkip(sb, lastMainEventUsedPosition, rawEvent.length(), currentSkipPosition);
         }
         return sb.toString();
+    }
+
+    public byte[] dumpEventToBytes() {
+        return dumpEventToString().getBytes(StandardCharsets.UTF_8);
     }
 
     private int appendWithSkip(final StringBuilder sb, final int from, final int to, final int currentSkipPosition) {

--- a/core-common/src/main/java/org/zalando/nakadi/domain/EventOwnerHeader.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/EventOwnerHeader.java
@@ -24,7 +24,7 @@ public class EventOwnerHeader {
         this.value = value;
     }
 
-    public void serialize(final ProducerRecord<String, String> record) {
+    public void serialize(final ProducerRecord<byte[], byte[]> record) {
         record.headers().add(AUTH_PARAM_NAME, name.getBytes(Charsets.UTF_8));
         record.headers().add(AUTH_PARAM_VALUE, value.getBytes(Charsets.UTF_8));
     }

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -119,9 +119,9 @@ public class KafkaLocationManager {
     public Properties getKafkaProducerProperties() {
         final Properties producerProps = (Properties) kafkaProperties.clone();
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
-                "org.apache.kafka.common.serialization.StringSerializer");
+                "org.apache.kafka.common.serialization.ByteArraySerializer");
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-                "org.apache.kafka.common.serialization.StringSerializer");
+                "org.apache.kafka.common.serialization.ByteArraySerializer");
         producerProps.put(ProducerConfig.ACKS_CONFIG, "all");
         producerProps.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, kafkaSettings.getRequestTimeoutMs());
         producerProps.put(ProducerConfig.BUFFER_MEMORY_CONFIG, kafkaSettings.getBufferMemory());

--- a/core-common/src/test/java/org/zalando/nakadi/domain/EventOwnerHeaderTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/domain/EventOwnerHeaderTest.java
@@ -6,6 +6,8 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
+
 public class EventOwnerHeaderTest {
 
     private static final String NAME = "teams";
@@ -14,7 +16,9 @@ public class EventOwnerHeaderTest {
     @Test
     public void testEventOwnerHeaderSerialization() {
         final EventOwnerHeader eventOwnerHeader = new EventOwnerHeader(NAME, VALUE);
-        final ProducerRecord<String, String> record = new ProducerRecord<>("topic", "value");
+        final ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(
+                "topic",
+                "value".getBytes(StandardCharsets.UTF_8));
         eventOwnerHeader.serialize(record);
 
         Assert.assertEquals(NAME,

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaFactoryTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaFactoryTest.java
@@ -19,7 +19,7 @@ public class KafkaFactoryTest {
         }
 
         @Override
-        protected Producer<String, String> createProducerInstance() {
+        protected Producer<byte[], byte[]> createProducerInstance() {
             return Mockito.mock(Producer.class);
         }
     }
@@ -29,18 +29,18 @@ public class KafkaFactoryTest {
         Mockito.when(reg.counter(Mockito.anyString())).thenReturn(Mockito.mock(Counter.class));
         return new FakeKafkaFactory(reg);
     }
-
+ 
     @Test
     public void verifySameProducerUsed() {
         final KafkaFactory factory = createTestKafkaFactory();
-        final Producer<String, String> producer1 = factory.takeProducer();
+        final Producer<byte[], byte[]> producer1 = factory.takeProducer();
         try {
             Assert.assertNotNull(producer1);
         } finally {
             factory.releaseProducer(producer1);
         }
 
-        final Producer<String, String> producer2 = factory.takeProducer();
+        final Producer<byte[], byte[]> producer2 = factory.takeProducer();
         try {
             Assert.assertSame(producer1, producer2);
         } finally {
@@ -52,9 +52,9 @@ public class KafkaFactoryTest {
     public void verifyProducerIsClosedAtCorrectTime() {
         final KafkaFactory factory = createTestKafkaFactory();
 
-        final List<Producer<String, String>> producers1 = IntStream.range(0, 10)
+        final List<Producer<byte[], byte[]>> producers1 = IntStream.range(0, 10)
                 .mapToObj(ignore -> factory.takeProducer()).collect(Collectors.toList());
-        final Producer<String, String> producer = producers1.get(0);
+        final Producer<byte[], byte[]> producer = producers1.get(0);
         Assert.assertNotNull(producer);
         producers1.forEach(p -> Assert.assertSame(producer, p));
         producers1.forEach(factory::releaseProducer);
@@ -62,9 +62,9 @@ public class KafkaFactoryTest {
         Mockito.verify(producer, Mockito.times(0)).close();
 
 
-        final List<Producer<String, String>> producers2 = IntStream.range(0, 10)
+        final List<Producer<byte[], byte[]>> producers2 = IntStream.range(0, 10)
                 .mapToObj(ignore -> factory.takeProducer()).collect(Collectors.toList());
-        final Producer<String, String> additionalProducer = factory.takeProducer();
+        final Producer<byte[], byte[]> additionalProducer = factory.takeProducer();
 
         Assert.assertSame(producer, additionalProducer);
         producers2.forEach(p -> Assert.assertSame(producer, p));
@@ -82,13 +82,13 @@ public class KafkaFactoryTest {
     @Test
     public void verifyNewProducerCreatedAfterClose() {
         final KafkaFactory factory = createTestKafkaFactory();
-        final Producer<String, String> producer1 = factory.takeProducer();
+        final Producer<byte[], byte[]> producer1 = factory.takeProducer();
         Assert.assertNotNull(producer1);
         factory.terminateProducer(producer1);
         factory.releaseProducer(producer1);
         Mockito.verify(producer1, Mockito.times(1)).close();
 
-        final Producer<String, String> producer2 = factory.takeProducer();
+        final Producer<byte[], byte[]> producer2 = factory.takeProducer();
         Assert.assertNotNull(producer2);
         Assert.assertNotSame(producer1, producer2);
         factory.releaseProducer(producer2);

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -80,7 +80,7 @@ public class KafkaTopicRepositoryTest {
     private static final String KAFKA_CLIENT_ID = "application_name-topic_name";
 
     @Captor
-    private ArgumentCaptor<ProducerRecord<String, String>> producerRecordArgumentCaptor;
+    private ArgumentCaptor<ProducerRecord<byte[], byte[]>> producerRecordArgumentCaptor;
 
     @SuppressWarnings("unchecked")
     public static final ProducerRecord EXPECTED_PRODUCER_RECORD = new ProducerRecord(MY_TOPIC, 0, "0", "payload");
@@ -116,7 +116,7 @@ public class KafkaTopicRepositoryTest {
             cursor("5", "30"), cursor("9", "100"));
 
     private final KafkaTopicRepository kafkaTopicRepository;
-    private final KafkaProducer<String, String> kafkaProducer;
+    private final KafkaProducer<byte[], byte[]> kafkaProducer;
     private final KafkaFactory kafkaFactory;
 
     @SuppressWarnings("unchecked")
@@ -171,7 +171,7 @@ public class KafkaTopicRepositoryTest {
             kafkaTopicRepository.syncPostBatch(myTopic, batch, "random", false);
             fail();
         } catch (final EventPublishingException e) {
-            final ProducerRecord<String, String> recordSent = captureProducerRecordSent();
+            final ProducerRecord<byte[], byte[]> recordSent = captureProducerRecordSent();
             final Header nameHeader = recordSent.headers().headers(EventOwnerHeader.AUTH_PARAM_NAME)
                     .iterator().next();
             Assert.assertEquals(new String(nameHeader.value()), "retailer");
@@ -603,7 +603,7 @@ public class KafkaTopicRepositoryTest {
     }
 
     @SuppressWarnings("unchecked")
-    private ProducerRecord<String, String> captureProducerRecordSent() {
+    private ProducerRecord<byte[], byte[]> captureProducerRecordSent() {
         verify(kafkaProducer, atLeastOnce()).send(producerRecordArgumentCaptor.capture(), any());
         return producerRecordArgumentCaptor.getValue();
     }


### PR DESCRIPTION
Nakadi needs to use byte serializers in order to work with binary data, the change is tech refactoring as precondition for binary formats in Nakadi