### PR TITLE
provide Kafka Client compression type via env var

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -57,6 +57,7 @@ public class KafkaRepositoryAT extends BaseAT {
     private static final int KAFKA_REQUEST_TIMEOUT = 30000;
     private static final int KAFKA_DELIVERY_TIMEOUT = 30000;
     private static final int KAFKA_MAX_BLOCK_TIMEOUT = 5000;
+    private static final String KAFKA_COMPRESSION_TYPE = "lz4";
     private static final int KAFKA_BATCH_SIZE = 1048576;
     private static final long KAFKA_BUFFER_MEMORY = KAFKA_BATCH_SIZE * 10L;
     private static final int KAFKA_LINGER_MS = 0;
@@ -107,7 +108,7 @@ public class KafkaRepositoryAT extends BaseAT {
 
         kafkaSettings = new KafkaSettings(KAFKA_REQUEST_TIMEOUT, KAFKA_BATCH_SIZE, KAFKA_BUFFER_MEMORY,
                 KAFKA_LINGER_MS, KAFKA_ENABLE_AUTO_COMMIT, KAFKA_MAX_REQUEST_SIZE,
-                KAFKA_DELIVERY_TIMEOUT, KAFKA_MAX_BLOCK_TIMEOUT, "");
+                KAFKA_DELIVERY_TIMEOUT, KAFKA_MAX_BLOCK_TIMEOUT, "", KAFKA_COMPRESSION_TYPE);
         zookeeperSettings = new ZookeeperSettings(ZK_SESSION_TIMEOUT, ZK_CONNECTION_TIMEOUT, ZK_MAX_IN_FLIGHT_REQUESTS);
         kafkaHelper = new KafkaTestHelper(KAFKA_URL);
         defaultTopicConfig = new NakadiTopicConfig(DEFAULT_PARTITION_COUNT, DEFAULT_CLEANUP_POLICY,

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -127,7 +127,7 @@ public class KafkaLocationManager {
         producerProps.put(ProducerConfig.BUFFER_MEMORY_CONFIG, kafkaSettings.getBufferMemory());
         producerProps.put(ProducerConfig.BATCH_SIZE_CONFIG, kafkaSettings.getBatchSize());
         producerProps.put(ProducerConfig.LINGER_MS_CONFIG, kafkaSettings.getLingerMs());
-        producerProps.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "lz4");
+        producerProps.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, kafkaSettings.getCompressionType());
         producerProps.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, kafkaSettings.getMaxRequestSize());
         producerProps.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, kafkaSettings.getDeliveryTimeoutMs());
         producerProps.put(ProducerConfig.RETRIES_CONFIG, 0);

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSettings.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSettings.java
@@ -22,6 +22,7 @@ public class KafkaSettings {
     private final int deliveryTimeoutMs;
     private final int maxBlockMs;
     private final String clientRack;
+    private final String compressionType;
 
     @Autowired
     public KafkaSettings(@Value("${nakadi.kafka.request.timeout.ms}") final int requestTimeoutMs,
@@ -32,7 +33,8 @@ public class KafkaSettings {
                          @Value("${nakadi.kafka.max.request.size}") final int maxRequestSize,
                          @Value("${nakadi.kafka.delivery.timeout.ms}") final int deliveryTimeoutMs,
                          @Value("${nakadi.kafka.max.block.ms}") final int maxBlockMs,
-                         @Value("${nakadi.kafka.client.rack:}") final String clientRack) {
+                         @Value("${nakadi.kafka.client.rack:}") final String clientRack,
+                         @Value("${nakadi.kafka.compression.type:lz4}") final String compressionType) {
         this.requestTimeoutMs = requestTimeoutMs;
         this.batchSize = batchSize;
         this.bufferMemory = bufferMemory;
@@ -42,6 +44,7 @@ public class KafkaSettings {
         this.deliveryTimeoutMs = deliveryTimeoutMs;
         this.maxBlockMs = maxBlockMs;
         this.clientRack = clientRack;
+        this.compressionType = compressionType;
     }
 
     public int getRequestTimeoutMs() {
@@ -78,5 +81,9 @@ public class KafkaSettings {
 
     public String getClientRack() {
         return clientRack;
+    }
+
+    public String getCompressionType() {
+        return compressionType;
     }
 }


### PR DESCRIPTION
at the moment it is not possible to set kafka client compression type using env var, it is hardcoded value of lz4