### PR TITLE
Avro Schema Registry Poc

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/db/EventTypeDbRepositoryTest.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/db/EventTypeDbRepositoryTest.java
@@ -1,6 +1,5 @@
 package org.zalando.nakadi.repository.db;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.junit.Before;

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/db/EventTypeDbRepositoryTest.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/db/EventTypeDbRepositoryTest.java
@@ -164,7 +164,7 @@ public class EventTypeDbRepositoryTest extends AbstractDbRepositoryTest {
 
         repository.saveEventType(eventType);
 
-        eventType.getSchema().setVersion(new JsonVersion("1.1.0"));
+        eventType.getSchema().setVersion("1.1.0");
 
         repository.update(eventType);
 

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/db/EventTypeDbRepositoryTest.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/db/EventTypeDbRepositoryTest.java
@@ -10,7 +10,6 @@ import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeSchema;
 import org.zalando.nakadi.domain.ResourceAuthorization;
 import org.zalando.nakadi.domain.ResourceAuthorizationAttribute;
-import org.zalando.nakadi.domain.JsonVersion;
 import org.zalando.nakadi.exceptions.runtime.DuplicatedEventTypeNameException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchEventTypeException;
 import org.zalando.nakadi.utils.TestUtils;

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/db/EventTypeDbRepositoryTest.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/db/EventTypeDbRepositoryTest.java
@@ -1,5 +1,6 @@
 package org.zalando.nakadi.repository.db;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.junit.Before;
@@ -10,7 +11,7 @@ import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeSchema;
 import org.zalando.nakadi.domain.ResourceAuthorization;
 import org.zalando.nakadi.domain.ResourceAuthorizationAttribute;
-import org.zalando.nakadi.domain.Version;
+import org.zalando.nakadi.domain.JsonVersion;
 import org.zalando.nakadi.exceptions.runtime.DuplicatedEventTypeNameException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchEventTypeException;
 import org.zalando.nakadi.utils.TestUtils;
@@ -164,7 +165,7 @@ public class EventTypeDbRepositoryTest extends AbstractDbRepositoryTest {
 
         repository.saveEventType(eventType);
 
-        eventType.getSchema().setVersion(new Version("1.1.0"));
+        eventType.getSchema().setVersion(new JsonVersion("1.1.0"));
 
         repository.update(eventType);
 

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/db/SchemaRepositoryTest.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/db/SchemaRepositoryTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeSchema;
 import org.zalando.nakadi.domain.EventTypeSchemaBase;
-import org.zalando.nakadi.domain.Version;
+import org.zalando.nakadi.domain.JsonVersion;
 import org.zalando.nakadi.utils.EventTypeTestBuilder;
 import org.zalando.nakadi.utils.TestUtils;
 
@@ -33,9 +33,9 @@ public class SchemaRepositoryTest extends AbstractDbRepositoryTest {
 
         final List<EventTypeSchema> schemas = repository.getSchemas(name, 0, 3);
         Assert.assertEquals(3, schemas.size());
-        Assert.assertEquals(new Version("10.0.0"), schemas.get(0).getVersion());
-        Assert.assertEquals(new Version("2.10.3"), schemas.get(1).getVersion());
-        Assert.assertEquals(new Version("1.0.2"), schemas.get(2).getVersion());
+        Assert.assertEquals(new JsonVersion("10.0.0"), schemas.get(0).getVersion());
+        Assert.assertEquals(new JsonVersion("2.10.3"), schemas.get(1).getVersion());
+        Assert.assertEquals(new JsonVersion("1.0.2"), schemas.get(2).getVersion());
 
         final int count = repository.getSchemasCount(name);
         Assert.assertEquals(3, count);

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/db/SchemaRepositoryTest.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/db/SchemaRepositoryTest.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeSchema;
 import org.zalando.nakadi.domain.EventTypeSchemaBase;
-import org.zalando.nakadi.domain.JsonVersion;
 import org.zalando.nakadi.utils.EventTypeTestBuilder;
 import org.zalando.nakadi.utils.TestUtils;
 

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/db/SchemaRepositoryTest.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/db/SchemaRepositoryTest.java
@@ -33,9 +33,9 @@ public class SchemaRepositoryTest extends AbstractDbRepositoryTest {
 
         final List<EventTypeSchema> schemas = repository.getSchemas(name, 0, 3);
         Assert.assertEquals(3, schemas.size());
-        Assert.assertEquals(new JsonVersion("10.0.0"), schemas.get(0).getVersion());
-        Assert.assertEquals(new JsonVersion("2.10.3"), schemas.get(1).getVersion());
-        Assert.assertEquals(new JsonVersion("1.0.2"), schemas.get(2).getVersion());
+        Assert.assertEquals("10.0.0", schemas.get(0).getVersion());
+        Assert.assertEquals("2.10.3", schemas.get(1).getVersion());
+        Assert.assertEquals("1.0.2", schemas.get(2).getVersion());
 
         final int count = repository.getSchemasCount(name);
         Assert.assertEquals(3, count);
@@ -46,7 +46,7 @@ public class SchemaRepositoryTest extends AbstractDbRepositoryTest {
         final String name = randomUUID();
         buildEventWithMultipleSchemas(name);
         final EventTypeSchema schema = repository.getSchemaVersion(name, "10.0.0");
-        Assert.assertEquals("10.0.0", schema.getVersion().toString());
+        Assert.assertEquals("10.0.0", schema.getVersion());
         Assert.assertEquals("schema", schema.getSchema());
     }
 
@@ -55,7 +55,7 @@ public class SchemaRepositoryTest extends AbstractDbRepositoryTest {
         final String name = randomUUID();
         buildEventWithMultipleSchemas(name);
         final EventTypeSchema schema = repository.getSchemaVersion(name, "1.0.2");
-        Assert.assertEquals("1.0.2", schema.getVersion().toString());
+        Assert.assertEquals("1.0.2", schema.getVersion());
         Assert.assertEquals("schema", schema.getSchema());
     }
 

--- a/api-metastore/src/main/java/org/zalando/nakadi/config/SchemaValidatorConfig.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/config/SchemaValidatorConfig.java
@@ -9,7 +9,6 @@ import org.json.JSONObject;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.zalando.nakadi.domain.SchemaChange;
-import org.zalando.nakadi.repository.db.SchemaRepository;
 import org.zalando.nakadi.service.AvroSchemaCompatibility;
 import org.zalando.nakadi.service.SchemaEvolutionService;
 import org.zalando.nakadi.validation.schema.CategoryChangeConstraint;
@@ -50,17 +49,14 @@ public class SchemaValidatorConfig {
     private final CompatibilityModeChangeConstraint compatibilityModeChangeConstraint;
     private final PartitionStrategyConstraint partitionStrategyConstraint;
     private final AvroSchemaCompatibility avroSchemaCompatibility;
-    private final SchemaRepository schemaRepository;
 
     public SchemaValidatorConfig(
             final CompatibilityModeChangeConstraint compatibilityModeChangeConstraint,
             final PartitionStrategyConstraint partitionStrategyConstraint,
-            final AvroSchemaCompatibility avroSchemaCompatibility,
-            final SchemaRepository schemaRepository ) {
+            final AvroSchemaCompatibility avroSchemaCompatibility) {
         this.compatibilityModeChangeConstraint = compatibilityModeChangeConstraint;
         this.partitionStrategyConstraint = partitionStrategyConstraint;
         this.avroSchemaCompatibility = avroSchemaCompatibility;
-        this.schemaRepository = schemaRepository;
     }
 
     @Bean
@@ -100,6 +96,6 @@ public class SchemaValidatorConfig {
         final SchemaDiff diff = new SchemaDiff();
 
         return new SchemaEvolutionService(metaSchema, schemaEvolutionConstraints, diff, errorMessage,
-                avroSchemaCompatibility, schemaRepository);
+                avroSchemaCompatibility);
     }
 }

--- a/api-metastore/src/main/java/org/zalando/nakadi/config/SchemaValidatorConfig.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/config/SchemaValidatorConfig.java
@@ -6,7 +6,6 @@ import com.google.common.io.Resources;
 import org.everit.json.schema.Schema;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONObject;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.zalando.nakadi.domain.SchemaChange;
@@ -100,6 +99,7 @@ public class SchemaValidatorConfig {
 
         final SchemaDiff diff = new SchemaDiff();
 
-        return new SchemaEvolutionService(metaSchema, schemaEvolutionConstraints, diff, errorMessage, avroSchemaCompatibility, schemaRepository);
+        return new SchemaEvolutionService(metaSchema, schemaEvolutionConstraints, diff, errorMessage,
+                avroSchemaCompatibility, schemaRepository);
     }
 }

--- a/api-metastore/src/main/java/org/zalando/nakadi/controller/SchemaController.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/controller/SchemaController.java
@@ -55,18 +55,20 @@ public class SchemaController {
         return status(HttpStatus.OK).build();
     }
 
-    @RequestMapping(value = "/event-types/{name}/schemas/{version}", method = RequestMethod.PUT)
+    @RequestMapping(value = "/event-types/{name}/schemas/{version}/compatibility-check", method = RequestMethod.POST)
     public ResponseEntity<?> checkCompatibility(@PathVariable("name") final String name,
                                                 @PathVariable("version") final String version,
-                                    @Valid @RequestBody final EventTypeSchemaBase schema,
-                                    final Errors errors) {
+                                                @Valid @RequestBody final EventTypeSchemaBase schema,
+                                                final Errors errors) {
         if (errors.hasErrors()) {
             throw new ValidationException(errors);
         }
 
         final EventType eventType = eventTypeService.get(name);
         if(!schema.getType().equals(eventType.getSchema().getType())){
-            throw new SchemaValidationException("schema type cannot be different");
+            throw new SchemaValidationException(String.format("schema type cannot be " +
+                            "different: expected `%s`, but was `%s`"
+                    , eventType.getSchema().getType(), schema.getType()));
         }
 
         final var toCompareEventTypeSchema = version.equals("latest")?

--- a/api-metastore/src/main/java/org/zalando/nakadi/controller/SchemaController.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/controller/SchemaController.java
@@ -24,6 +24,7 @@ import org.zalando.nakadi.exceptions.runtime.NoSuchEventTypeException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchSchemaException;
 import org.zalando.nakadi.exceptions.runtime.ValidationException;
 import org.zalando.nakadi.model.CompatibilityResponse;
+import org.zalando.nakadi.model.CompatibilitySchemaRequest;
 import org.zalando.nakadi.service.EventTypeService;
 import org.zalando.nakadi.service.SchemaService;
 
@@ -59,7 +60,7 @@ public class SchemaController {
     @RequestMapping(value = "/event-types/{name}/schemas/{version}/compatibility-check", method = RequestMethod.POST)
     public ResponseEntity<?> checkCompatibility(@PathVariable("name") final String name,
                                                 @PathVariable("version") final String version,
-                                                @Valid @RequestBody final EventTypeSchemaBase schema,
+                                                @Valid @RequestBody final CompatibilitySchemaRequest schema,
                                                 final Errors errors) {
         if (errors.hasErrors()) {
             throw new ValidationException(errors);
@@ -71,7 +72,8 @@ public class SchemaController {
         eventType.setSchema(toCompareEventTypeSchema);
 
         final var newEventTypeBase = new EventTypeBase(eventType);
-        newEventTypeBase.setSchema(schema);
+        newEventTypeBase.setSchema(
+                new EventTypeSchemaBase(eventType.getSchema().getType(), schema.getSchema()));
 
         return compatibilityResponse(eventType, newEventTypeBase);
     }

--- a/api-metastore/src/main/java/org/zalando/nakadi/controller/SchemaController.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/controller/SchemaController.java
@@ -25,12 +25,10 @@ import org.zalando.nakadi.exceptions.runtime.NoSuchSchemaException;
 import org.zalando.nakadi.exceptions.runtime.ValidationException;
 import org.zalando.nakadi.service.EventTypeService;
 import org.zalando.nakadi.service.SchemaService;
-import org.zalando.problem.Problem;
 
 import javax.validation.Valid;
 
 import static org.springframework.http.ResponseEntity.status;
-import static org.zalando.problem.Status.UNPROCESSABLE_ENTITY;
 
 @RestController
 public class SchemaController {

--- a/api-metastore/src/main/java/org/zalando/nakadi/controller/SchemaController.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/controller/SchemaController.java
@@ -65,8 +65,9 @@ public class SchemaController {
         }
 
         final EventType eventType = eventTypeService.get(name);
-        if(!schema.getType().equals(eventType.getSchema().getType()))
+        if(!schema.getType().equals(eventType.getSchema().getType())){
             throw new SchemaValidationException("schema type cannot be different");
+        }
 
         final var toCompareEventTypeSchema = version.equals("latest")?
                 eventType.getSchema(): schemaService.getSchemaVersion(name, version);

--- a/api-metastore/src/main/java/org/zalando/nakadi/controller/SchemaController.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/controller/SchemaController.java
@@ -26,8 +26,6 @@ import org.zalando.nakadi.exceptions.runtime.ValidationException;
 import org.zalando.nakadi.model.CompatibilityResponse;
 import org.zalando.nakadi.service.EventTypeService;
 import org.zalando.nakadi.service.SchemaService;
-import org.zalando.problem.Problem;
-import org.zalando.problem.Status;
 
 import javax.validation.Valid;
 
@@ -68,16 +66,6 @@ public class SchemaController {
         }
 
         final EventType eventType = eventTypeService.get(name);
-
-        if(!schema.getType().equals(eventType.getSchema().getType())){
-            final var detail = String.format("schema type cannot be " +
-                            "different: expected `%s`, but was `%s`"
-                    , eventType.getSchema().getType(), schema.getType());
-
-            return status(HttpStatus.CONFLICT).
-                    body(Problem.valueOf(Status.CONFLICT, detail));
-        }
-
         final var toCompareEventTypeSchema = version.equals("latest")?
                 eventType.getSchema(): schemaService.getSchemaVersion(name, version);
         eventType.setSchema(toCompareEventTypeSchema);

--- a/api-metastore/src/main/java/org/zalando/nakadi/controller/SchemaController.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/controller/SchemaController.java
@@ -70,8 +70,13 @@ public class SchemaController {
         if(!schema.getType().equals(eventType.getSchema().getType()))
             throw new SchemaValidationException("schema type cannot be different");
 
+        final var toCompareEventTypeSchema = version.equals("latest")?
+                eventType.getSchema(): schemaService.getSchemaVersion(name, version);
+        eventType.setSchema(toCompareEventTypeSchema);
+
         final var newEventTypeBase = new EventTypeBase(eventType);
         newEventTypeBase.setSchema(schema);
+
         schemaService.getValidEvolvedEventType(eventType, newEventTypeBase);
 
         return ResponseEntity.status(HttpStatus.OK).build();

--- a/api-metastore/src/main/java/org/zalando/nakadi/model/CompatibilityResponse.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/model/CompatibilityResponse.java
@@ -1,0 +1,69 @@
+package org.zalando.nakadi.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.zalando.nakadi.domain.CompatibilityMode;
+
+import java.util.Objects;
+
+public class CompatibilityResponse {
+    private boolean compatible;
+    private CompatibilityMode compatibilityMode;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String error;
+    private String validatedAgainstVersion;
+
+    public CompatibilityResponse(final boolean compatible, final CompatibilityMode compatibilityMode,
+                                 final String error,
+                                 final String validatedAgainstVersion) {
+        this.compatible = compatible;
+        this.compatibilityMode = compatibilityMode;
+        this.error = error;
+        this.validatedAgainstVersion = validatedAgainstVersion;
+    }
+
+    public boolean isCompatible() {
+        return compatible;
+    }
+
+    public CompatibilityMode getCompatibilityMode() {
+        return compatibilityMode;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public String getValidatedAgainstVersion() {
+        return validatedAgainstVersion;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o){
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()){
+            return false;
+        }
+        final CompatibilityResponse that = (CompatibilityResponse) o;
+        return compatible == that.compatible && compatibilityMode == that.compatibilityMode
+                && Objects.equals(error, that.error)
+                && Objects.equals(validatedAgainstVersion, that.validatedAgainstVersion);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(compatible, compatibilityMode, error, validatedAgainstVersion);
+    }
+
+    @Override
+    public String toString() {
+        return "CompatibilityResponse{" +
+                "compatible=" + compatible +
+                ", compatibilityMode=" + compatibilityMode +
+                ", error='" + error + '\'' +
+                ", validatedAgainstVersion='" + validatedAgainstVersion + '\'' +
+                '}';
+    }
+}

--- a/api-metastore/src/main/java/org/zalando/nakadi/model/CompatibilitySchemaRequest.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/model/CompatibilitySchemaRequest.java
@@ -1,0 +1,48 @@
+package org.zalando.nakadi.model;
+
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
+
+public class CompatibilitySchemaRequest {
+    @NotNull
+    private String schema;
+
+    public CompatibilitySchemaRequest() {
+    }
+
+    public CompatibilitySchemaRequest(final String schema) {
+        this.schema = schema;
+    }
+
+    public String getSchema() {
+        return schema;
+    }
+
+    public void setSchema(final String schema) {
+        this.schema = schema;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()){
+            return false;
+        }
+        final CompatibilitySchemaRequest that = (CompatibilitySchemaRequest) o;
+        return Objects.equals(schema, that.schema);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schema);
+    }
+
+    @Override
+    public String toString() {
+        return "CompatibilitySchemaRequest{" +
+                "schema='" + schema + '\'' +
+                '}';
+    }
+}

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/AvroSchemaCompatibility.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/AvroSchemaCompatibility.java
@@ -65,9 +65,13 @@ public class AvroSchemaCompatibility {
                 return flatMapToIncompat.apply(
                         fullyCompatibleFn.apply(newSchema, getLastSchema.get()).stream()
                 );
-            default:
+            case NONE:
                 return Collections.emptyList();
+            default:
+                throw new UnsupportedOperationException("Unsupported compatibility mode "+ compatibilityMode
+                        + " supplied for avro compatibility validation");
         }
+
     }
 
     private List<AvroIncompatibility> toAvroIncompatibility(final SchemaPairCompatibility schemaPairCompatibility) {

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/AvroSchemaCompatibility.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/AvroSchemaCompatibility.java
@@ -69,22 +69,6 @@ public class AvroSchemaCompatibility {
                 return flatMapToIncompat.apply(
                         fullyCompatibleFn.apply(newSchema, getLastSchema.get()).stream()
                 );
-
-            case FORWARD_TRANSITIVE:
-                return flatMapToIncompat.apply(
-                        original.stream().map(prevSchema -> forwardCompatibleFn.apply(newSchema, prevSchema))
-                );
-
-            case BACKWARD_TRANSITIVE:
-                return flatMapToIncompat.apply(
-                        original.stream().map(prevSchema -> backwardCompatibleFn.apply(newSchema, prevSchema))
-                );
-
-            case COMPATIBLE_TRANSITIVE:
-                return flatMapToIncompat.apply(
-                        original.stream().map(prevSchema -> fullyCompatibleFn.apply(newSchema, prevSchema)).
-                                flatMap(Collection::stream)
-                );
             default:
                 return Collections.emptyList();
         }

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/AvroSchemaCompatibility.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/AvroSchemaCompatibility.java
@@ -1,0 +1,144 @@
+package org.zalando.nakadi.service;
+
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaCompatibility;
+import org.apache.avro.SchemaCompatibility.Incompatibility;
+import org.apache.avro.SchemaCompatibility.SchemaPairCompatibility;
+import org.springframework.stereotype.Component;
+import org.zalando.nakadi.domain.CompatibilityMode;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Component
+public class AvroSchemaCompatibility {
+
+    private static BiFunction<Schema, Schema, SchemaPairCompatibility> backwardCompatibleFn = (reader, writer) ->
+            SchemaCompatibility.checkReaderWriterCompatibility(reader, writer);
+
+    private static BiFunction<Schema, Schema, SchemaPairCompatibility> forwardCompatibleFn = (reader, writer) ->
+            SchemaCompatibility.checkReaderWriterCompatibility(writer, reader);
+
+    private static BiFunction<Schema, Schema, List<SchemaPairCompatibility>> fullyCompatibleFn = (reader, writer) ->
+            List.of(backwardCompatibleFn.apply(reader, writer), forwardCompatibleFn.apply(reader, writer));
+
+
+    /**
+     * Evaluate schema evolution for a given list of Schemas and a new Schema provided a CompatibilityMode.
+     *
+     * @param original
+     * @param newSchema
+     * @param compatibilityMode
+     * @return List of Incompatibilities
+     */
+    public List<AvroIncompatibility> validateSchema(final List<Schema> original, final Schema newSchema,
+                                                    final CompatibilityMode compatibilityMode) throws AvroRuntimeException {
+        if (original == null || original.isEmpty())
+            throw new RuntimeException("previous schema cannot be empty");
+        if (newSchema == null)
+            throw new RuntimeException("new schema cannot be null");
+
+        Supplier<Schema> getLastSchema = () -> original.get(original.size() - 1);
+
+        Function<Stream<SchemaPairCompatibility>, List<AvroIncompatibility>> flatMapToIncompat =
+                inputStream -> inputStream.
+                        map(AvroSchemaCompatibility::toAvroIncompatibility).
+                        flatMap(Collection::stream).collect(Collectors.toList());
+
+        switch (compatibilityMode) {
+            case FORWARD:
+                return forwardCompatibleFn.andThen(AvroSchemaCompatibility::toAvroIncompatibility).
+                        apply(newSchema, getLastSchema.get());
+
+            case BACKWARD:
+                return backwardCompatibleFn.andThen(AvroSchemaCompatibility::toAvroIncompatibility).
+                        apply(newSchema, getLastSchema.get());
+
+            case COMPATIBLE:
+                return flatMapToIncompat.apply(
+                        fullyCompatibleFn.apply(newSchema, getLastSchema.get()).stream()
+                );
+
+            case FORWARD_TRANSITIVE:
+                return flatMapToIncompat.apply(
+                        original.stream().map(prevSchema -> forwardCompatibleFn.apply(newSchema, prevSchema))
+                );
+
+            case BACKWARD_TRANSITIVE:
+                return flatMapToIncompat.apply(
+                        original.stream().map(prevSchema -> backwardCompatibleFn.apply(newSchema, prevSchema))
+                );
+
+            case COMPATIBLE_TRANSITIVE:
+                return flatMapToIncompat.apply(
+                        original.stream().map(prevSchema -> fullyCompatibleFn.apply(newSchema, prevSchema)).
+                                flatMap(Collection::stream)
+                );
+            default:
+                return Collections.emptyList();
+        }
+    }
+
+    private static List<AvroIncompatibility> toAvroIncompatibility(final SchemaPairCompatibility schemaPairCompatibility) {
+        Function<Incompatibility, AvroIncompatibility> mapperFn = (incompat) ->
+                new AvroIncompatibility(incompat.getLocation(), incompat.getMessage(), incompat.getType());
+
+        return schemaPairCompatibility.getResult().getIncompatibilities().stream().
+                map(mapperFn).collect(Collectors.toList());
+    }
+
+    public static class AvroIncompatibility {
+        private final String location;
+        private final String message;
+        private final SchemaCompatibility.SchemaIncompatibilityType mType;
+
+        public AvroIncompatibility(String location, String message, SchemaCompatibility.SchemaIncompatibilityType mType) {
+            this.location = location;
+            this.message = message;
+            this.mType = mType;
+        }
+
+        public String getLocation() {
+            return location;
+        }
+
+        public SchemaCompatibility.SchemaIncompatibilityType getmType() {
+            return mType;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            AvroIncompatibility that = (AvroIncompatibility) o;
+            return Objects.equals(location, that.location) && Objects.equals(message, that.message) && mType == that.mType;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(location, message, mType);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("{ type:%s, location:%s, message:%s }", mType,
+                    location, message);
+        }
+
+
+    }
+}
+
+

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/AvroSchemaCompatibility.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/AvroSchemaCompatibility.java
@@ -61,10 +61,6 @@ public class AvroSchemaCompatibility {
                 return forwardCompatibleFn.andThen(this::toAvroIncompatibility).
                         apply(newSchema, getLastSchema.get());
 
-            case BACKWARD:
-                return backwardCompatibleFn.andThen(this::toAvroIncompatibility).
-                        apply(newSchema, getLastSchema.get());
-
             case COMPATIBLE:
                 return flatMapToIncompat.apply(
                         fullyCompatibleFn.apply(newSchema, getLastSchema.get()).stream()
@@ -85,21 +81,21 @@ public class AvroSchemaCompatibility {
     public static class AvroIncompatibility {
         private final String location;
         private final String message;
-        private final SchemaCompatibility.SchemaIncompatibilityType mType;
+        private final SchemaCompatibility.SchemaIncompatibilityType incompatibilityType;
 
         public AvroIncompatibility(final String location, final String message,
                                    final SchemaCompatibility.SchemaIncompatibilityType mType) {
             this.location = location;
             this.message = message;
-            this.mType = mType;
+            this.incompatibilityType = mType;
         }
 
         public String getLocation() {
             return location;
         }
 
-        public SchemaCompatibility.SchemaIncompatibilityType getmType() {
-            return mType;
+        public SchemaCompatibility.SchemaIncompatibilityType getIncompatibilityType() {
+            return incompatibilityType;
         }
 
         public String getMessage() {
@@ -116,17 +112,17 @@ public class AvroSchemaCompatibility {
             }
             final AvroIncompatibility that = (AvroIncompatibility) o;
             return Objects.equals(location, that.location) &&
-                    Objects.equals(message, that.message) && mType == that.mType;
+                    Objects.equals(message, that.message) && incompatibilityType == that.incompatibilityType;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(location, message, mType);
+            return Objects.hash(location, message, incompatibilityType);
         }
 
         @Override
         public String toString() {
-            return String.format("{ type:%s, location:%s, message:%s }", mType,
+            return String.format("{ type:%s, location:%s, message:%s }", incompatibilityType,
                     location, message);
         }
 

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaEvolutionService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaEvolutionService.java
@@ -117,7 +117,8 @@ public class SchemaEvolutionService {
         }
     }
 
-    private EventType evolveAvroSchema(final EventType original, final EventTypeBase eventType) {
+    private EventType evolveAvroSchema(final EventType original, final EventTypeBase eventType)
+            throws SchemaEvolutionException {
         final var compatibilityMode = eventType.getCompatibilityMode();
             validateAvroSchema(Collections.singletonList(original.getSchema()),
                     eventType.getSchema(), compatibilityMode);
@@ -129,7 +130,8 @@ public class SchemaEvolutionService {
     }
 
     private void validateAvroSchema(final List<? extends EventTypeSchema> original,
-                                    final EventTypeSchemaBase eventType, final CompatibilityMode compatibilityMode) {
+                                    final EventTypeSchemaBase eventType, final CompatibilityMode compatibilityMode)
+            throws SchemaEvolutionException {
         try {
             final var prevSchema =
                     original.stream().map(schema -> AvroUtils.getParsedSchema(schema.getSchema())).

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaEvolutionService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaEvolutionService.java
@@ -3,7 +3,6 @@ package org.zalando.nakadi.service;
 
 import com.google.common.collect.Lists;
 import org.apache.avro.AvroRuntimeException;
-import org.apache.avro.SchemaCompatibility;
 import org.everit.json.schema.Schema;
 import org.everit.json.schema.ValidationException;
 import org.everit.json.schema.loader.SchemaLoader;
@@ -126,13 +125,13 @@ public class SchemaEvolutionService {
     }
 
     private EventType evolveAvroSchema(final EventType original, final EventTypeBase eventType) {
-
-        if (TRANSITIVE_MODES.contains(original.getCompatibilityMode())) {
+        final var compatibilityMode = eventType.getCompatibilityMode();
+        if (TRANSITIVE_MODES.contains(compatibilityMode)) {
             final var version = original.getSchema().getVersion().toString();
             final var schemaList = schemaRepository.listSchemas(original.getName(), version);
-            validateAvroSchema(schemaList, eventType.getSchema(), original.getCompatibilityMode());
+            validateAvroSchema(schemaList, eventType.getSchema(), compatibilityMode);
         } else {
-            validateAvroSchema(Collections.singletonList(original.getSchema()), eventType.getSchema(), original.getCompatibilityMode());
+            validateAvroSchema(Collections.singletonList(original.getSchema()), eventType.getSchema(), compatibilityMode);
         }
 
         final var level = getParsedAvroSchema(original.getSchema().getSchema()).

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaEvolutionService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaEvolutionService.java
@@ -21,7 +21,6 @@ import org.zalando.nakadi.domain.Version;
 import org.zalando.nakadi.exception.SchemaEvolutionException;
 import org.zalando.nakadi.exceptions.runtime.InvalidEventTypeException;
 import org.zalando.nakadi.util.AvroUtils;
-import org.zalando.nakadi.repository.db.SchemaRepository;
 import org.zalando.nakadi.validation.SchemaIncompatibility;
 import org.zalando.nakadi.validation.schema.ForbiddenAttributeIncompatibility;
 import org.zalando.nakadi.validation.schema.SchemaEvolutionConstraint;
@@ -33,7 +32,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
@@ -47,10 +45,6 @@ import static org.zalando.nakadi.domain.SchemaChange.Type.TITLE_CHANGED;
 import static org.zalando.nakadi.domain.Version.Level.MAJOR;
 import static org.zalando.nakadi.domain.Version.Level.NO_CHANGES;
 import static org.zalando.nakadi.domain.Version.Level.PATCH;
-import static org.zalando.nakadi.domain.CompatibilityMode.BACKWARD_TRANSITIVE;
-import static org.zalando.nakadi.domain.CompatibilityMode.FORWARD_TRANSITIVE;
-import static org.zalando.nakadi.domain.CompatibilityMode.COMPATIBLE_TRANSITIVE;
-
 
 public class SchemaEvolutionService {
 
@@ -63,34 +57,28 @@ public class SchemaEvolutionService {
             ADDITIONAL_PROPERTIES_CHANGED, ADDITIONAL_ITEMS_CHANGED);
     private final BiFunction<SchemaChange.Type, CompatibilityMode, Version.Level> levelResolver;
     private final AvroSchemaCompatibility avroSchemaCompatibility;
-    private final SchemaRepository schemaRepository;
-    private static final Set<CompatibilityMode> TRANSITIVE_MODES =
-            Set.of(BACKWARD_TRANSITIVE, FORWARD_TRANSITIVE, COMPATIBLE_TRANSITIVE);
 
     public SchemaEvolutionService(final Schema metaSchema,
                                   final List<SchemaEvolutionConstraint> schemaEvolutionConstraints,
                                   final SchemaDiff schemaDiff,
                                   final BiFunction<SchemaChange.Type, CompatibilityMode, Version.Level> levelResolver,
                                   final Map<SchemaChange.Type, String> errorMessages,
-                                  final AvroSchemaCompatibility avroSchemaCompatibility,
-                                  final SchemaRepository schemaRepository) {
+                                  final AvroSchemaCompatibility avroSchemaCompatibility) {
         this.metaSchema = metaSchema;
         this.schemaEvolutionConstraints = schemaEvolutionConstraints;
         this.schemaDiff = schemaDiff;
         this.levelResolver = levelResolver;
         this.errorMessages = errorMessages;
         this.avroSchemaCompatibility = avroSchemaCompatibility;
-        this.schemaRepository = schemaRepository;
     }
 
     public SchemaEvolutionService(final Schema metaSchema,
                                   final List<SchemaEvolutionConstraint> schemaEvolutionConstraints,
                                   final SchemaDiff schemaDiff,
                                   final Map<SchemaChange.Type, String> errorMessages,
-                                  final AvroSchemaCompatibility avroSchemaCompatibility,
-                                  final SchemaRepository schemaRepository) {
+                                  final AvroSchemaCompatibility avroSchemaCompatibility) {
         this(metaSchema, schemaEvolutionConstraints, schemaDiff, SchemaChange.Type::getLevel, errorMessages,
-                avroSchemaCompatibility, schemaRepository);
+                avroSchemaCompatibility);
     }
 
     public List<SchemaIncompatibility> collectIncompatibilities(final JSONObject schemaJson) {
@@ -131,14 +119,8 @@ public class SchemaEvolutionService {
 
     private EventType evolveAvroSchema(final EventType original, final EventTypeBase eventType) {
         final var compatibilityMode = eventType.getCompatibilityMode();
-        if (TRANSITIVE_MODES.contains(compatibilityMode)) {
-            final var version = original.getSchema().getVersion().toString();
-            final var schemaList = schemaRepository.listSchemas(original.getName(), version);
-            validateAvroSchema(schemaList, eventType.getSchema(), compatibilityMode);
-        } else {
             validateAvroSchema(Collections.singletonList(original.getSchema()),
                     eventType.getSchema(), compatibilityMode);
-        }
 
         final var level = AvroUtils.getParsedSchema(original.getSchema().getSchema()).
                 equals(AvroUtils.getParsedSchema(eventType.getSchema().getSchema()))? NO_CHANGES : MAJOR;

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaEvolutionService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaEvolutionService.java
@@ -135,10 +135,10 @@ public class SchemaEvolutionService {
             validateAvroSchema(Collections.singletonList(original.getSchema()), eventType.getSchema(), original.getCompatibilityMode());
         }
 
-        final String newVersion = original.getSchema().getVersion().bump(MAJOR).toString();
-        final DateTime now = new DateTime(DateTimeZone.UTC);
-        return new EventType(eventType, original.getCreatedAt(), now,
-                new EventTypeSchema(eventType.getSchema(), newVersion, now));
+        final var level = getParsedAvroSchema(original.getSchema().getSchema()).
+                equals(getParsedAvroSchema(eventType.getSchema().getSchema()))? NO_CHANGES : MAJOR;
+
+        return bumpVersion(original, eventType, level);
     }
 
     private void validateAvroSchema(final List<? extends EventTypeSchema> original,

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaService.java
@@ -1,5 +1,7 @@
 package org.zalando.nakadi.service;
 
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.SchemaParseException;
 import org.everit.json.schema.Schema;
 import org.everit.json.schema.SchemaException;
 import org.everit.json.schema.loader.SchemaClient;
@@ -109,10 +111,8 @@ public class SchemaService {
 
             final EventTypeBase updatedEventType = new EventTypeBase(originalEventType);
             updatedEventType.setSchema(newSchema);
-            validateSchema(updatedEventType);
 
-            final EventType eventType = schemaEvolutionService.evolve(originalEventType, updatedEventType);
-
+            final EventType eventType = getValidEvolvedEventType(originalEventType, updatedEventType);
             eventTypeRepository.update(eventType);
 
             eventTypeCache.invalidate(eventType.getName());
@@ -146,6 +146,11 @@ public class SchemaService {
         }
     }
 
+    public EventType getValidEvolvedEventType(EventType originalEventType, EventTypeBase updatedEventType) {
+        validateSchema(updatedEventType);
+        return schemaEvolutionService.evolve(originalEventType, updatedEventType);
+    }
+
     public PaginationWrapper getSchemas(final String name, final int offset, final int limit)
             throws InvalidLimitException {
         if (limit < 1 || limit > 1000) {
@@ -164,10 +169,6 @@ public class SchemaService {
 
     public EventTypeSchema getSchemaVersion(final String name, final String version)
             throws NoSuchSchemaException, InvalidVersionNumberException {
-        final Matcher versionMatcher = VERSION_PATTERN.matcher(version);
-        if (!versionMatcher.matches()) {
-            throw new InvalidVersionNumberException("Invalid version number");
-        }
         final EventTypeSchema schema = schemaRepository.getSchemaVersion(name, version);
         return schema;
     }
@@ -176,40 +177,17 @@ public class SchemaService {
         try {
             final String eventTypeSchema = eventType.getSchema().getSchema();
 
-            isStrictlyValidJson(eventTypeSchema);
 
-            final JSONObject schemaAsJson = new JSONObject(eventTypeSchema);
-
-            if (schemaAsJson.has("type") && !Objects.equals("object", schemaAsJson.getString("type"))) {
-                throw new SchemaValidationException("\"type\" of root element in schema can only be \"object\"");
+            final EventTypeSchemaBase.Type schemaType = eventType.getSchema().getType();
+            if(schemaType.equals(EventTypeSchemaBase.Type.JSON_SCHEMA)) {
+                isStrictlyValidJson(eventTypeSchema);
+                validateJsonTypeSchema(eventType, eventTypeSchema);
             }
-
-            final Schema schema = SchemaLoader
-                    .builder()
-                    .httpClient(new BlockedHttpClient())
-                    .schemaJson(schemaAsJson)
-                    .build()
-                    .load()
-                    .build();
-
-            if (eventType.getCategory() == EventCategory.BUSINESS && schema.definesProperty("#/metadata")) {
-                throw new SchemaValidationException("\"metadata\" property is reserved");
+            else if (schemaType.equals(EventTypeSchemaBase.Type.AVRO_SCHEMA)){
+                validateAvroTypeSchema(eventTypeSchema);
             }
+            else throw new RuntimeException("undefined schema type");
 
-            final List<String> orderingInstanceIds = eventType.getOrderingInstanceIds();
-            final List<String> orderingKeyFields = eventType.getOrderingKeyFields();
-            if (!orderingInstanceIds.isEmpty() && orderingKeyFields.isEmpty()) {
-                throw new SchemaValidationException(
-                        "`ordering_instance_ids` field can not be defined without defining `ordering_key_fields`");
-            }
-            final JSONObject effectiveSchemaAsJson = jsonSchemaEnrichment.effectiveSchema(eventType);
-            final Schema effectiveSchema = SchemaLoader.load(effectiveSchemaAsJson);
-            validateFieldsInSchema("ordering_key_fields", orderingKeyFields, effectiveSchema);
-            validateFieldsInSchema("ordering_instance_ids", orderingInstanceIds, effectiveSchema);
-
-            if (eventType.getCompatibilityMode() == CompatibilityMode.COMPATIBLE) {
-                validateJsonSchemaConstraints(schemaAsJson);
-            }
         } catch (final com.google.re2j.PatternSyntaxException e) {
             throw new SchemaValidationException("invalid regex pattern in the schema: "
                     + e.getDescription() + " \"" + e.getPattern() + "\"");
@@ -217,6 +195,53 @@ public class SchemaService {
             throw new SchemaValidationException("schema must be a valid json");
         } catch (final SchemaException e) {
             throw new SchemaValidationException("schema must be a valid json-schema");
+        }
+    }
+
+    /**
+     * @param eventTypeSchema - Avro Payload Schema
+     */
+    private void validateAvroTypeSchema(final String eventTypeSchema) {
+        final var avroSchemaParser = new org.apache.avro.Schema.Parser();
+        try {
+            avroSchemaParser.parse(eventTypeSchema);
+        } catch (AvroRuntimeException e) {
+            throw new SchemaValidationException("failed to parse avro schema " + e.getMessage());
+        }
+    }
+
+    private void validateJsonTypeSchema(EventTypeBase eventType, String eventTypeSchema) {
+        final JSONObject schemaAsJson = new JSONObject(eventTypeSchema);
+
+        if (schemaAsJson.has("type") && !Objects.equals("object", schemaAsJson.getString("type"))) {
+            throw new SchemaValidationException("\"type\" of root element in schema can only be \"object\"");
+        }
+
+        final Schema schema = SchemaLoader
+                .builder()
+                .httpClient(new BlockedHttpClient())
+                .schemaJson(schemaAsJson)
+                .build()
+                .load()
+                .build();
+
+        if (eventType.getCategory() == EventCategory.BUSINESS && schema.definesProperty("#/metadata")) {
+            throw new SchemaValidationException("\"metadata\" property is reserved");
+        }
+
+        final List<String> orderingInstanceIds = eventType.getOrderingInstanceIds();
+        final List<String> orderingKeyFields = eventType.getOrderingKeyFields();
+        if (!orderingInstanceIds.isEmpty() && orderingKeyFields.isEmpty()) {
+            throw new SchemaValidationException(
+                    "`ordering_instance_ids` field can not be defined without defining `ordering_key_fields`");
+        }
+        final JSONObject effectiveSchemaAsJson = jsonSchemaEnrichment.effectiveSchema(eventType);
+        final Schema effectiveSchema = SchemaLoader.load(effectiveSchemaAsJson);
+        validateFieldsInSchema("ordering_key_fields", orderingKeyFields, effectiveSchema);
+        validateFieldsInSchema("ordering_instance_ids", orderingInstanceIds, effectiveSchema);
+
+        if (eventType.getCompatibilityMode() == CompatibilityMode.COMPATIBLE) {
+            validateJsonSchemaConstraints(schemaAsJson);
         }
     }
 

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaService.java
@@ -1,7 +1,6 @@
 package org.zalando.nakadi.service;
 
 import org.apache.avro.AvroRuntimeException;
-import org.apache.avro.SchemaParseException;
 import org.everit.json.schema.Schema;
 import org.everit.json.schema.SchemaException;
 import org.everit.json.schema.loader.SchemaClient;
@@ -45,7 +44,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -146,7 +144,7 @@ public class SchemaService {
         }
     }
 
-    public EventType getValidEvolvedEventType(EventType originalEventType, EventTypeBase updatedEventType) {
+    public EventType getValidEvolvedEventType(final EventType originalEventType, final EventTypeBase updatedEventType) {
         validateSchema(updatedEventType);
         return schemaEvolutionService.evolve(originalEventType, updatedEventType);
     }
@@ -186,7 +184,9 @@ public class SchemaService {
             else if (schemaType.equals(EventTypeSchemaBase.Type.AVRO_SCHEMA)){
                 validateAvroTypeSchema(eventTypeSchema);
             }
-            else throw new RuntimeException("undefined schema type");
+            else {
+                throw new IllegalArgumentException("undefined schema type");
+            }
 
         } catch (final com.google.re2j.PatternSyntaxException e) {
             throw new SchemaValidationException("invalid regex pattern in the schema: "
@@ -210,7 +210,7 @@ public class SchemaService {
         }
     }
 
-    private void validateJsonTypeSchema(EventTypeBase eventType, String eventTypeSchema) {
+    private void validateJsonTypeSchema(final EventTypeBase eventType, final String eventTypeSchema) {
         final JSONObject schemaAsJson = new JSONObject(eventTypeSchema);
 
         if (schemaAsJson.has("type") && !Objects.equals("object", schemaAsJson.getString("type"))) {

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/SchemaService.java
@@ -28,6 +28,7 @@ import org.zalando.nakadi.exceptions.runtime.InvalidEventTypeException;
 import org.zalando.nakadi.exceptions.runtime.InvalidLimitException;
 import org.zalando.nakadi.exceptions.runtime.InvalidVersionNumberException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchSchemaException;
+import org.zalando.nakadi.util.AvroUtils;
 import org.zalando.nakadi.plugin.api.authz.AuthorizationService;
 import org.zalando.nakadi.repository.db.EventTypeRepository;
 import org.zalando.nakadi.repository.db.SchemaRepository;
@@ -198,13 +199,9 @@ public class SchemaService {
         }
     }
 
-    /**
-     * @param eventTypeSchema - Avro Payload Schema
-     */
     private void validateAvroTypeSchema(final String eventTypeSchema) {
-        final var avroSchemaParser = new org.apache.avro.Schema.Parser();
         try {
-            avroSchemaParser.parse(eventTypeSchema);
+            AvroUtils.getParsedSchema(eventTypeSchema);
         } catch (AvroRuntimeException e) {
             throw new SchemaValidationException("failed to parse avro schema " + e.getMessage());
         }

--- a/api-metastore/src/main/java/org/zalando/nakadi/validation/schema/CompatibilityModeChangeConstraint.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/validation/schema/CompatibilityModeChangeConstraint.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 import org.zalando.nakadi.domain.CompatibilityMode;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeBase;
-import org.zalando.nakadi.domain.EventTypeSchemaBase;
 import org.zalando.nakadi.plugin.api.authz.AuthorizationService;
 import org.zalando.nakadi.service.AdminService;
 
@@ -17,7 +16,7 @@ import java.util.Optional;
 
 @Service
 public class CompatibilityModeChangeConstraint implements SchemaEvolutionConstraint {
-    final Map<CompatibilityMode, List<CompatibilityMode>> allowedChangesJson = ImmutableMap.of(
+    final Map<CompatibilityMode, List<CompatibilityMode>> allowedChanges = ImmutableMap.of(
             CompatibilityMode.COMPATIBLE, Lists.newArrayList(CompatibilityMode.COMPATIBLE),
             CompatibilityMode.FORWARD, Lists.newArrayList(CompatibilityMode.FORWARD, CompatibilityMode.COMPATIBLE),
             CompatibilityMode.NONE, Lists.newArrayList(CompatibilityMode.NONE, CompatibilityMode.FORWARD)
@@ -38,8 +37,7 @@ public class CompatibilityModeChangeConstraint implements SchemaEvolutionConstra
         final boolean isNakadiAdmin = adminService.isAdmin(AuthorizationService.Operation.WRITE);
         final boolean isEventTypeAdmin = authorizationService
                 .isAuthorized(AuthorizationService.Operation.ADMIN, original.asResource());
-        final boolean isChangeValid = original.getSchema().getType() == EventTypeSchemaBase.Type.AVRO_SCHEMA ||
-                allowedChangesJson.get(original.getCompatibilityMode())
+        final boolean isChangeValid = allowedChanges.get(original.getCompatibilityMode())
                 .contains(eventType.getCompatibilityMode());
         if (isEventTypeAdmin || isNakadiAdmin || isChangeValid) {
             return Optional.empty();

--- a/api-metastore/src/main/java/org/zalando/nakadi/validation/schema/SchemaTypeChangeConstraint.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/validation/schema/SchemaTypeChangeConstraint.java
@@ -1,0 +1,17 @@
+package org.zalando.nakadi.validation.schema;
+
+import org.zalando.nakadi.domain.EventType;
+import org.zalando.nakadi.domain.EventTypeBase;
+
+import java.util.Optional;
+
+public class SchemaTypeChangeConstraint implements SchemaEvolutionConstraint{
+
+    @Override
+    public Optional<SchemaEvolutionIncompatibility> validate(EventType original, EventTypeBase eventType) {
+        if(!original.getSchema().getType().equals(eventType.getSchema().getType()))
+            return Optional.of(new SchemaEvolutionIncompatibility("changing schema_type is not allowed"));
+
+        return Optional.empty();
+    }
+}

--- a/api-metastore/src/main/java/org/zalando/nakadi/validation/schema/SchemaTypeChangeConstraint.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/validation/schema/SchemaTypeChangeConstraint.java
@@ -8,9 +8,10 @@ import java.util.Optional;
 public class SchemaTypeChangeConstraint implements SchemaEvolutionConstraint{
 
     @Override
-    public Optional<SchemaEvolutionIncompatibility> validate(EventType original, EventTypeBase eventType) {
-        if(!original.getSchema().getType().equals(eventType.getSchema().getType()))
+    public Optional<SchemaEvolutionIncompatibility> validate(final EventType original, final EventTypeBase eventType) {
+        if(!original.getSchema().getType().equals(eventType.getSchema().getType())){
             return Optional.of(new SchemaEvolutionIncompatibility("changing schema_type is not allowed"));
+        }
 
         return Optional.empty();
     }

--- a/api-metastore/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
@@ -123,7 +123,7 @@ public class EventTypeControllerTestCase {
         final SchemaEvolutionService ses = new SchemaValidatorConfig(
                 new CompatibilityModeChangeConstraint(adminService, authorizationService),
                 new PartitionStrategyConstraint(adminService),
-                avroSchemaCompatibility, schemaRepository
+                avroSchemaCompatibility
         ).schemaEvolutionService();
 
         final EventTypeOptionsValidator eventTypeOptionsValidator =

--- a/api-metastore/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
@@ -2,6 +2,7 @@ package org.zalando.nakadi.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.Before;
+import org.mockito.Mockito;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -23,6 +24,7 @@ import org.zalando.nakadi.plugin.api.ApplicationService;
 import org.zalando.nakadi.plugin.api.authz.AuthorizationService;
 import org.zalando.nakadi.repository.TopicRepository;
 import org.zalando.nakadi.repository.db.EventTypeRepository;
+import org.zalando.nakadi.repository.db.SchemaRepository;
 import org.zalando.nakadi.repository.db.SubscriptionDbRepository;
 import org.zalando.nakadi.repository.db.SubscriptionTokenLister;
 import org.zalando.nakadi.repository.kafka.KafkaConfig;
@@ -30,6 +32,7 @@ import org.zalando.nakadi.repository.kafka.PartitionsCalculator;
 import org.zalando.nakadi.security.ClientResolver;
 import org.zalando.nakadi.service.AdminService;
 import org.zalando.nakadi.service.AuthorizationValidator;
+import org.zalando.nakadi.service.AvroSchemaCompatibility;
 import org.zalando.nakadi.service.EventTypeService;
 import org.zalando.nakadi.service.FeatureToggleService;
 import org.zalando.nakadi.service.SchemaEvolutionService;
@@ -92,6 +95,8 @@ public class EventTypeControllerTestCase {
     protected final NakadiAuditLogPublisher nakadiAuditLogPublisher = mock(NakadiAuditLogPublisher.class);
     protected final SubscriptionTokenLister subscriptionTokenLister = mock(SubscriptionTokenLister.class);
     private final SchemaService schemaService = mock(SchemaService.class);
+    private final AvroSchemaCompatibility avroSchemaCompatibility = Mockito.mock(AvroSchemaCompatibility.class);
+    private final SchemaRepository schemaRepository = Mockito.mock(SchemaRepository.class);
     protected MockMvc mockMvc;
 
     public EventTypeControllerTestCase() {
@@ -117,7 +122,8 @@ public class EventTypeControllerTestCase {
 
         final SchemaEvolutionService ses = new SchemaValidatorConfig(
                 new CompatibilityModeChangeConstraint(adminService, authorizationService),
-                new PartitionStrategyConstraint(adminService)
+                new PartitionStrategyConstraint(adminService),
+                avroSchemaCompatibility, schemaRepository
         ).schemaEvolutionService();
 
         final EventTypeOptionsValidator eventTypeOptionsValidator =

--- a/api-metastore/src/test/java/org/zalando/nakadi/controller/SchemaControllerTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/controller/SchemaControllerTest.java
@@ -156,29 +156,4 @@ public class SchemaControllerTest {
         Assert.assertEquals(expected, resp);
     }
 
-    @Test
-    public void testCheckCompatibilityForMismatchTypeEvolution() throws IOException {
-        final EventType eventTypeOriginal = buildDefaultEventType();
-        final EventType eventTypeNew = buildDefaultEventType();
-
-        final var schemeBase = new EventTypeSchemaBase(EventTypeSchemaBase.Type.AVRO_SCHEMA, "");
-        eventTypeNew.setSchema(new EventTypeSchema(schemeBase, "1", DateTime.now()));
-
-        Mockito.when(eventTypeService.get(eventTypeOriginal.getName())).
-                thenReturn(eventTypeOriginal);
-        Mockito.when(schemaService.
-                        getValidEvolvedEventType(eventTypeOriginal, eventTypeNew)).
-                thenReturn(eventTypeNew);
-
-        final ResponseEntity<?> result =
-                new SchemaController(schemaService, eventTypeService).
-                        checkCompatibility(
-                                eventTypeOriginal.getName(),
-                                "latest",
-                                eventTypeNew.getSchema(),
-                                new MapBindingResult(new HashMap<>(), "name"));
-
-        Assert.assertEquals(HttpStatus.CONFLICT, result.getStatusCode());
-    }
-
 }

--- a/api-metastore/src/test/java/org/zalando/nakadi/controller/SchemaControllerTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/controller/SchemaControllerTest.java
@@ -126,7 +126,6 @@ public class SchemaControllerTest {
                                 eventTypeNew.getSchema(),
                                 new MapBindingResult(new HashMap<>(), "name"));
 
-        Assert.assertEquals(HttpStatus.OK, result.getStatusCode());
     }
 
 }

--- a/api-metastore/src/test/java/org/zalando/nakadi/controller/SchemaControllerTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/controller/SchemaControllerTest.java
@@ -16,6 +16,7 @@ import org.zalando.nakadi.domain.EventTypeSchemaBase;
 import org.zalando.nakadi.exception.SchemaEvolutionException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchEventTypeException;
 import org.zalando.nakadi.model.CompatibilityResponse;
+import org.zalando.nakadi.model.CompatibilitySchemaRequest;
 import org.zalando.nakadi.service.EventTypeService;
 import org.zalando.nakadi.service.SchemaService;
 import org.zalando.nakadi.utils.EventTypeTestBuilder;
@@ -101,7 +102,7 @@ public class SchemaControllerTest {
                         checkCompatibility(
                                 eventTypeOriginal.getName(),
                                 "latest",
-                                eventTypeNew.getSchema(),
+                                new CompatibilitySchemaRequest(eventTypeNew.getSchema().getSchema()),
                                 new MapBindingResult(new HashMap<>(), "name"));
 
         Assert.assertEquals(HttpStatus.OK, result.getStatusCode());
@@ -147,7 +148,7 @@ public class SchemaControllerTest {
                         checkCompatibility(
                                 eventTypeOriginal.getName(),
                                 "latest",
-                                eventTypeNew.getSchema(),
+                                new CompatibilitySchemaRequest(eventTypeNew.getSchema().getSchema()),
                                 new MapBindingResult(new HashMap<>(), "name"));
 
         Assert.assertEquals(HttpStatus.OK, result.getStatusCode());

--- a/api-metastore/src/test/java/org/zalando/nakadi/controller/SchemaControllerTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/controller/SchemaControllerTest.java
@@ -9,15 +9,18 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.MapBindingResult;
 import org.springframework.web.context.request.NativeWebRequest;
+import org.zalando.nakadi.domain.CompatibilityMode;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeSchema;
 import org.zalando.nakadi.domain.EventTypeSchemaBase;
-import org.zalando.nakadi.exception.SchemaValidationException;
+import org.zalando.nakadi.exception.SchemaEvolutionException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchEventTypeException;
+import org.zalando.nakadi.model.CompatibilityResponse;
 import org.zalando.nakadi.service.EventTypeService;
 import org.zalando.nakadi.service.SchemaService;
 import org.zalando.nakadi.utils.EventTypeTestBuilder;
 
+import java.io.IOException;
 import java.util.HashMap;
 
 import static org.zalando.nakadi.utils.TestUtils.buildDefaultEventType;
@@ -79,7 +82,7 @@ public class SchemaControllerTest {
     }
 
     @Test
-    public void testCheckCompatibilityForValidEvolution() {
+    public void testCheckCompatibilityForValidEvolution() throws IOException {
         final EventType eventTypeOriginal = buildDefaultEventType();
         final EventType eventTypeNew = buildDefaultEventType();
 
@@ -97,15 +100,64 @@ public class SchemaControllerTest {
                 new SchemaController(schemaService, eventTypeService).
                         checkCompatibility(
                                 eventTypeOriginal.getName(),
-                                eventTypeOriginal.getSchema().getVersion().toString(),
+                                "latest",
                                 eventTypeNew.getSchema(),
                                 new MapBindingResult(new HashMap<>(), "name"));
 
         Assert.assertEquals(HttpStatus.OK, result.getStatusCode());
+        final var resp = (CompatibilityResponse) result.getBody();
+        final var expected = new CompatibilityResponse(true, CompatibilityMode.COMPATIBLE, null, "1.0.0");
+        Assert.assertEquals(expected, resp);
+
     }
 
-    @Test(expected = SchemaValidationException.class)
-    public void testCheckCompatibilityForMismatchTypeEvolution() {
+    @Test
+    public void testCheckCompatibilityForIncompatibleEvolution() throws IOException {
+        final var origSchema = "[{\"type\":\"record\",\"name\":\"NAME_PLACE_HOLDER\"," +
+                "\"fields\":[{\"name\":\"foo\",\"type\":\"string\"},{\"name\":\"bar\",\"type\":\"string\"}," +
+                "{\"name\":\"baz\",\"type\":\"int\"}]";
+        final var etSchema = new EventTypeSchema(
+                new EventTypeSchemaBase(EventTypeSchemaBase.Type.AVRO_SCHEMA, origSchema), "1", DateTime.now()
+        );
+        final EventType eventTypeOriginal =
+                EventTypeTestBuilder.builder().
+                compatibilityMode(CompatibilityMode.FORWARD).
+                        schema(etSchema).build();
+
+        final var newSchema = "[{\"type\":\"record\",\"name\":\"NAME_PLACE_HOLDER\"," +
+                "\"fields\":[{\"name\":\"foo\",\"type\":\"string\"},{\"name\":\"bar\",\"type\":\"string\"}]";
+        final var newEtSchema = new EventTypeSchema(
+                new EventTypeSchemaBase(EventTypeSchemaBase.Type.AVRO_SCHEMA, newSchema), "2", DateTime.now()
+        );
+
+        final EventType eventTypeNew =
+                EventTypeTestBuilder.builder().
+                        schema(newEtSchema).build();
+
+        Mockito.when(eventTypeService.get(eventTypeOriginal.getName())).
+                thenReturn(eventTypeOriginal);
+        final var errorMsg = "Failed to evolve avro schema due to " +
+                "[{ type:READER_FIELD_MISSING_DEFAULT_VALUE, location:/fields/2, message:baz }]";
+        Mockito.when(schemaService.
+                        getValidEvolvedEventType(Mockito.eq(eventTypeOriginal), Mockito.any())).
+                thenThrow(new SchemaEvolutionException(errorMsg));
+
+        final ResponseEntity<?> result =
+                new SchemaController(schemaService, eventTypeService).
+                        checkCompatibility(
+                                eventTypeOriginal.getName(),
+                                "latest",
+                                eventTypeNew.getSchema(),
+                                new MapBindingResult(new HashMap<>(), "name"));
+
+        Assert.assertEquals(HttpStatus.OK, result.getStatusCode());
+        final var resp = (CompatibilityResponse) result.getBody();
+        final var expected = new CompatibilityResponse(false, CompatibilityMode.FORWARD, errorMsg, "1");
+        Assert.assertEquals(expected, resp);
+    }
+
+    @Test
+    public void testCheckCompatibilityForMismatchTypeEvolution() throws IOException {
         final EventType eventTypeOriginal = buildDefaultEventType();
         final EventType eventTypeNew = buildDefaultEventType();
 
@@ -122,10 +174,11 @@ public class SchemaControllerTest {
                 new SchemaController(schemaService, eventTypeService).
                         checkCompatibility(
                                 eventTypeOriginal.getName(),
-                                eventTypeOriginal.getSchema().getVersion().toString(),
+                                "latest",
                                 eventTypeNew.getSchema(),
                                 new MapBindingResult(new HashMap<>(), "name"));
 
+        Assert.assertEquals(HttpStatus.CONFLICT, result.getStatusCode());
     }
 
 }

--- a/api-metastore/src/test/java/org/zalando/nakadi/service/AvroSchemaCompatibilityTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/service/AvroSchemaCompatibilityTest.java
@@ -1,0 +1,244 @@
+package org.zalando.nakadi.service;
+
+import org.apache.avro.SchemaBuilder;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.springframework.util.Assert;
+import org.zalando.nakadi.domain.CompatibilityMode;
+import org.zalando.nakadi.util.AvroUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.avro.SchemaCompatibility.SchemaIncompatibilityType.NAME_MISMATCH;
+import static org.apache.avro.SchemaCompatibility.SchemaIncompatibilityType.READER_FIELD_MISSING_DEFAULT_VALUE;
+import static org.apache.avro.SchemaCompatibility.SchemaIncompatibilityType.TYPE_MISMATCH;
+
+
+public class AvroSchemaCompatibilityTest {
+
+    private AvroSchemaCompatibility avroSchemaCompatibility;
+    private static final String BASE_RECORD_JSON =  getBaseRecordJson();
+
+    @Before
+    public void setUp() throws Exception {
+        this.avroSchemaCompatibility = new AvroSchemaCompatibility();
+    }
+
+    @Test
+    public void testRemoveFieldIsBackwardCompatibleChange(){
+        final var original = List.of(AvroUtils.getParsedSchema(BASE_RECORD_JSON));
+        final var newSchema = AvroUtils.getParsedSchema(removeAndGetJson("baz", BASE_RECORD_JSON));
+        final var incompatibilities =
+                avroSchemaCompatibility.validateSchema(original, newSchema, CompatibilityMode.BACKWARD);
+        Assert.isTrue(incompatibilities.isEmpty(), "no incompatibilities should exist");
+    }
+
+    @Test
+    public void testAddFieldIsNotBackwardCompatibleChange(){
+        final var original = List.of(AvroUtils.getParsedSchema(BASE_RECORD_JSON));
+        final var newSchema = AvroUtils.getParsedSchema(
+                putAndGetJson(new JSONObject("{\"type\":\"string\",\"name\":\"saz\"}"), BASE_RECORD_JSON)
+        );
+        final var incompatibilities =
+                avroSchemaCompatibility.validateSchema(original, newSchema, CompatibilityMode.BACKWARD);
+        final var expected = new AvroSchemaCompatibility.
+                AvroIncompatibility("/fields/4", "saz", READER_FIELD_MISSING_DEFAULT_VALUE);
+
+        Assert.notEmpty(incompatibilities, "should not be empty");
+        Assertions.assertEquals(List.of(expected), incompatibilities);
+    }
+
+    @Test
+    public void testAddFieldWithDefaultIsBackwardCompatibleChange(){
+        final var original = List.of(AvroUtils.getParsedSchema(BASE_RECORD_JSON));
+        final var newSchema = AvroUtils.getParsedSchema(
+                putAndGetJson(
+                        new JSONObject("{\"type\":\"string\",\"name\":\"saz\",\"default\":\"value\"}"),
+                        BASE_RECORD_JSON)
+        );
+        final var incompatibilities =
+                avroSchemaCompatibility.validateSchema(original, newSchema, CompatibilityMode.BACKWARD);
+
+        Assert.isTrue(incompatibilities.isEmpty(), "should be empty");
+    }
+
+    @Test
+    public void testAddFieldIsForwardCompatibleChange(){
+        final var original = List.of(AvroUtils.getParsedSchema(BASE_RECORD_JSON));
+        final var newSchema = AvroUtils.getParsedSchema(
+                putAndGetJson(
+                        new JSONObject("{\"type\":\"string\",\"name\":\"saz\"}"),
+                        BASE_RECORD_JSON)
+        );
+        final var incompatibilities =
+                avroSchemaCompatibility.validateSchema(original, newSchema, CompatibilityMode.FORWARD);
+
+        Assert.isTrue(incompatibilities.isEmpty(), "no incompatibilities should exist");
+    }
+
+    @Test
+    public void testRemoveFieldIsNotForwardCompatibleChange(){
+        final var original = List.of(AvroUtils.getParsedSchema(BASE_RECORD_JSON));
+        final var newSchema = AvroUtils.getParsedSchema(
+                removeAndGetJson("baz", BASE_RECORD_JSON)
+        );
+        final var incompatibilities =
+                avroSchemaCompatibility.validateSchema(original, newSchema, CompatibilityMode.FORWARD);
+        final var expected = new AvroSchemaCompatibility.
+                AvroIncompatibility("/fields/2", "baz", READER_FIELD_MISSING_DEFAULT_VALUE);
+
+        Assert.notEmpty(incompatibilities, "should not be empty");
+        Assertions.assertEquals(List.of(expected), incompatibilities);
+    }
+
+    @Test
+    public void testRemoveOptionalFieldIsForwardCompatibleChange(){
+        final var json = "{\"type\":[\"null\",\"string\"],\"name\":\"saz\",\"default\": null}";
+        final var newBase = putAndGetJson(new JSONObject(json), BASE_RECORD_JSON);
+
+        final var original = List.of(AvroUtils.getParsedSchema(newBase));
+        final var newSchema = AvroUtils.getParsedSchema(
+                removeAndGetJson("saz", newBase)
+        );
+
+        final var incompatibilities =
+                avroSchemaCompatibility.validateSchema(original, newSchema, CompatibilityMode.FORWARD);
+
+        Assert.isTrue(incompatibilities.isEmpty(), "should be empty");
+    }
+
+    @Test
+    public void testAddOptionalFieldIsCompatibleChange(){
+
+        final var original = List.of(AvroUtils.getParsedSchema(BASE_RECORD_JSON));
+
+        final var json = "{\"type\":[\"null\",\"string\"],\"name\":\"saz\",\"default\": null}";
+        final var newSchemaJson = putAndGetJson(new JSONObject(json), BASE_RECORD_JSON);
+        final var newSchema = AvroUtils.getParsedSchema(newSchemaJson);
+
+        final var incompatibilities =
+                avroSchemaCompatibility.validateSchema(original, newSchema, CompatibilityMode.COMPATIBLE);
+
+        Assert.isTrue(incompatibilities.isEmpty(), "should be empty");
+    }
+
+    @Test
+    public void testRemoveOptionalFieldIsCompatibleChange(){
+        final var json = "{\"type\":[\"null\",\"string\"],\"name\":\"saz\",\"default\": null}";
+        final var newBase = putAndGetJson(new JSONObject(json), BASE_RECORD_JSON);
+
+        final var original = List.of(AvroUtils.getParsedSchema(newBase));
+        final var newSchema = AvroUtils.getParsedSchema(removeAndGetJson("saz", newBase));
+
+        final var incompatibilities =
+                avroSchemaCompatibility.validateSchema(original, newSchema, CompatibilityMode.COMPATIBLE);
+
+        Assert.isTrue(incompatibilities.isEmpty(), "should be empty");
+    }
+
+
+    @Test
+    public void testOrderOfFieldChangeIsAllowed(){
+        final var original = List.of(AvroUtils.getParsedSchema(BASE_RECORD_JSON));
+
+        final var orderChangedJson = putAndGetJson(
+                new JSONObject("{\"type\":\"string\",\"name\":\"foo\"}"),
+                removeAndGetJson("foo", BASE_RECORD_JSON)
+        ); // now foo is at the end in new schema
+
+        final var newSchema = AvroUtils.getParsedSchema(orderChangedJson);
+
+        final var incompatibilities =
+                Stream.of(CompatibilityMode.BACKWARD, CompatibilityMode.FORWARD, CompatibilityMode.COMPATIBLE).
+                map(mode -> avroSchemaCompatibility.validateSchema(original, newSchema, mode)).
+                flatMap(List::stream).collect(Collectors.toList());
+
+        Assert.isTrue(incompatibilities.isEmpty(), "should be empty");
+    }
+
+    @Test
+    public void testTypeChangeIsNotAllowed(){
+        final var original = List.of(AvroUtils.getParsedSchema(BASE_RECORD_JSON));
+        final var typeChangedJson = putAndGetJson(
+                new JSONObject("{\"type\":\"string\",\"name\":\"baz\"}"),
+                removeAndGetJson("baz", BASE_RECORD_JSON)
+        ); // now baz went from int -> string
+        final var newSchema = AvroUtils.getParsedSchema(typeChangedJson);
+
+        final var incompatibilities =
+                Stream.of(CompatibilityMode.BACKWARD, CompatibilityMode.FORWARD, CompatibilityMode.COMPATIBLE).
+                map(mode -> avroSchemaCompatibility.validateSchema(original, newSchema, mode)).
+                flatMap(List::stream).collect(Collectors.toList());
+
+        Assert.notEmpty(incompatibilities, "should not be empty");
+
+        final var incompatType =
+                incompatibilities.stream().
+                map(incompat -> incompat.getmType()).collect(Collectors.toSet());
+
+        Assert.isTrue(incompatType.size() == 1);
+        Assert.isTrue(incompatType.contains(TYPE_MISMATCH));
+    }
+
+    @Test
+    public void testSchemaNameChangedNotAllowed(){
+        final var original = List.of(AvroUtils.getParsedSchema(BASE_RECORD_JSON));
+        final var typeChangedJson =
+                BASE_RECORD_JSON.replace("NESTED_RECORD_SCHEMA_NAME", "NESTED_RECORD_SCHEMA_NAME_NEW");
+
+        final var newSchema = AvroUtils.getParsedSchema(typeChangedJson);
+
+        final var incompatibilities =
+                Stream.of(CompatibilityMode.BACKWARD, CompatibilityMode.FORWARD, CompatibilityMode.COMPATIBLE).
+                map(mode -> avroSchemaCompatibility.validateSchema(original, newSchema, mode)).
+                flatMap(List::stream).collect(Collectors.toList());
+
+        Assert.notEmpty(incompatibilities, "should not be empty");
+
+        final var incompatType =
+                incompatibilities.stream().
+                        map(incompat -> incompat.getmType()).collect(Collectors.toSet());
+        Assert.isTrue(incompatType.size() == 1);
+        Assert.isTrue(incompatType.contains(NAME_MISMATCH));
+
+    }
+
+    private String removeAndGetJson(final String elementName, final String schemaJson){
+        final var baseSchema = new JSONObject(schemaJson);
+        final var fields = baseSchema.getJSONArray("fields");
+
+        for(int idx = 0; idx < fields.length(); idx++){
+            final boolean found = fields.getJSONObject(idx).getString("name").equals(elementName);
+            if(found){
+                fields.remove(idx);
+                break;
+            }
+        }
+        return baseSchema.toString();
+    }
+
+    private String putAndGetJson(final JSONObject jsonObject, final String schemaJson){
+        final JSONObject baseSchema = new JSONObject(schemaJson);
+        baseSchema.getJSONArray("fields").put(jsonObject);
+        return baseSchema.toString();
+    }
+
+    private static String getBaseRecordJson(){
+        final var nestedRecordSchema = SchemaBuilder.record("NESTED_RECORD_SCHEMA_NAME").fields().
+                name("foo").type().stringType().noDefault().
+                name("bar").type().intType().noDefault().
+                endRecord();
+
+        return SchemaBuilder.
+                        record("NAME_PLACE_HOLDER").fields().
+                        name("foo").type().stringType().noDefault().
+                        name("bar").type().stringType().noDefault().
+                        name("baz").type().intType().noDefault().
+                        name("NESTED_RECORD_NAME").type(nestedRecordSchema).noDefault().
+                        endRecord().toString(true);
+    }
+}

--- a/api-metastore/src/test/java/org/zalando/nakadi/service/AvroSchemaCompatibilityTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/service/AvroSchemaCompatibilityTest.java
@@ -28,43 +28,6 @@ public class AvroSchemaCompatibilityTest {
         this.avroSchemaCompatibility = new AvroSchemaCompatibility();
     }
 
-    @Test
-    public void testRemoveFieldIsBackwardCompatibleChange(){
-        final var original = List.of(AvroUtils.getParsedSchema(BASE_RECORD_JSON));
-        final var newSchema = AvroUtils.getParsedSchema(removeAndGetJson("baz", BASE_RECORD_JSON));
-        final var incompatibilities =
-                avroSchemaCompatibility.validateSchema(original, newSchema, CompatibilityMode.BACKWARD);
-        Assert.isTrue(incompatibilities.isEmpty(), "no incompatibilities should exist");
-    }
-
-    @Test
-    public void testAddFieldIsNotBackwardCompatibleChange(){
-        final var original = List.of(AvroUtils.getParsedSchema(BASE_RECORD_JSON));
-        final var newSchema = AvroUtils.getParsedSchema(
-                putAndGetJson(new JSONObject("{\"type\":\"string\",\"name\":\"saz\"}"), BASE_RECORD_JSON)
-        );
-        final var incompatibilities =
-                avroSchemaCompatibility.validateSchema(original, newSchema, CompatibilityMode.BACKWARD);
-        final var expected = new AvroSchemaCompatibility.
-                AvroIncompatibility("/fields/4", "saz", READER_FIELD_MISSING_DEFAULT_VALUE);
-
-        Assert.notEmpty(incompatibilities, "should not be empty");
-        Assertions.assertEquals(List.of(expected), incompatibilities);
-    }
-
-    @Test
-    public void testAddFieldWithDefaultIsBackwardCompatibleChange(){
-        final var original = List.of(AvroUtils.getParsedSchema(BASE_RECORD_JSON));
-        final var newSchema = AvroUtils.getParsedSchema(
-                putAndGetJson(
-                        new JSONObject("{\"type\":\"string\",\"name\":\"saz\",\"default\":\"value\"}"),
-                        BASE_RECORD_JSON)
-        );
-        final var incompatibilities =
-                avroSchemaCompatibility.validateSchema(original, newSchema, CompatibilityMode.BACKWARD);
-
-        Assert.isTrue(incompatibilities.isEmpty(), "should be empty");
-    }
 
     @Test
     public void testAddFieldIsForwardCompatibleChange(){
@@ -153,7 +116,7 @@ public class AvroSchemaCompatibilityTest {
         final var newSchema = AvroUtils.getParsedSchema(orderChangedJson);
 
         final var incompatibilities =
-                Stream.of(CompatibilityMode.BACKWARD, CompatibilityMode.FORWARD, CompatibilityMode.COMPATIBLE).
+                Stream.of(CompatibilityMode.FORWARD, CompatibilityMode.COMPATIBLE).
                 map(mode -> avroSchemaCompatibility.validateSchema(original, newSchema, mode)).
                 flatMap(List::stream).collect(Collectors.toList());
 
@@ -170,7 +133,7 @@ public class AvroSchemaCompatibilityTest {
         final var newSchema = AvroUtils.getParsedSchema(typeChangedJson);
 
         final var incompatibilities =
-                Stream.of(CompatibilityMode.BACKWARD, CompatibilityMode.FORWARD, CompatibilityMode.COMPATIBLE).
+                Stream.of(CompatibilityMode.FORWARD, CompatibilityMode.COMPATIBLE).
                 map(mode -> avroSchemaCompatibility.validateSchema(original, newSchema, mode)).
                 flatMap(List::stream).collect(Collectors.toList());
 
@@ -178,7 +141,7 @@ public class AvroSchemaCompatibilityTest {
 
         final var incompatType =
                 incompatibilities.stream().
-                map(incompat -> incompat.getmType()).collect(Collectors.toSet());
+                map(incompat -> incompat.getIncompatibilityType()).collect(Collectors.toSet());
 
         Assert.isTrue(incompatType.size() == 1);
         Assert.isTrue(incompatType.contains(TYPE_MISMATCH));
@@ -193,7 +156,7 @@ public class AvroSchemaCompatibilityTest {
         final var newSchema = AvroUtils.getParsedSchema(typeChangedJson);
 
         final var incompatibilities =
-                Stream.of(CompatibilityMode.BACKWARD, CompatibilityMode.FORWARD, CompatibilityMode.COMPATIBLE).
+                Stream.of(CompatibilityMode.FORWARD, CompatibilityMode.COMPATIBLE).
                 map(mode -> avroSchemaCompatibility.validateSchema(original, newSchema, mode)).
                 flatMap(List::stream).collect(Collectors.toList());
 
@@ -201,7 +164,7 @@ public class AvroSchemaCompatibilityTest {
 
         final var incompatType =
                 incompatibilities.stream().
-                        map(incompat -> incompat.getmType()).collect(Collectors.toSet());
+                        map(incompat -> incompat.getIncompatibilityType()).collect(Collectors.toSet());
         Assert.isTrue(incompatType.size() == 1);
         Assert.isTrue(incompatType.contains(NAME_MISMATCH));
 

--- a/api-metastore/src/test/java/org/zalando/nakadi/service/AvroSchemaCompatibilityTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/service/AvroSchemaCompatibilityTest.java
@@ -9,6 +9,7 @@ import org.springframework.util.Assert;
 import org.zalando.nakadi.domain.CompatibilityMode;
 import org.zalando.nakadi.util.AvroUtils;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -168,6 +169,20 @@ public class AvroSchemaCompatibilityTest {
         Assert.isTrue(incompatType.size() == 1);
         Assert.isTrue(incompatType.contains(NAME_MISMATCH));
 
+    }
+
+    @Test
+    public void testAllCompatibilityModesAreSupported() {
+        final var json = "{\"type\":[\"null\",\"string\"],\"name\":\"saz\",\"default\": null}";
+        final var newBase = putAndGetJson(new JSONObject(json), BASE_RECORD_JSON);
+
+        final var original = List.of(AvroUtils.getParsedSchema(newBase));
+        final var newSchema = AvroUtils.getParsedSchema(removeAndGetJson("saz", newBase));
+
+        //No exception is throw when below function is executed
+        final var incompatibilities =
+                Arrays.stream(CompatibilityMode.values()).
+                map(mode -> avroSchemaCompatibility.validateSchema(original, newSchema, mode));
     }
 
     private String removeAndGetJson(final String elementName, final String schemaJson){

--- a/api-metastore/src/test/java/org/zalando/nakadi/service/SchemaServiceTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/service/SchemaServiceTest.java
@@ -11,6 +11,7 @@ import org.zalando.nakadi.cache.EventTypeCache;
 import org.zalando.nakadi.config.NakadiSettings;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeSchema;
+import org.zalando.nakadi.domain.JsonVersion;
 import org.zalando.nakadi.domain.PaginationWrapper;
 import org.zalando.nakadi.domain.Version;
 import org.zalando.nakadi.exception.SchemaEvolutionException;
@@ -102,11 +103,11 @@ public class SchemaServiceTest {
 
     @Test(expected = NoSuchSchemaException.class)
     public void testNonExistingVersionNumber() throws Exception {
-        Mockito.when(schemaRepository.getSchemaVersion(eventType.getName(),
-                eventType.getSchema().getVersion().bump(Version.Level.MINOR).toString()))
+        final var newVersion =
+                new JsonVersion(eventType.getSchema().getVersion()).bump(Version.Level.MINOR).toString();
+        Mockito.when(schemaRepository.getSchemaVersion(eventType.getName(), newVersion))
                 .thenThrow(NoSuchSchemaException.class);
-        schemaService.getSchemaVersion(eventType.getName(),
-                eventType.getSchema().getVersion().bump(Version.Level.MINOR).toString());
+        schemaService.getSchemaVersion(eventType.getName(), newVersion);
     }
 
     @Test

--- a/api-metastore/src/test/java/org/zalando/nakadi/validation/SchemaEvolutionServiceTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/validation/SchemaEvolutionServiceTest.java
@@ -14,7 +14,7 @@ import org.mockito.Mockito;
 import org.zalando.nakadi.domain.CompatibilityMode;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.SchemaChange;
-import org.zalando.nakadi.domain.JsonVersion;
+import org.zalando.nakadi.domain.Version;
 import org.zalando.nakadi.exception.SchemaEvolutionException;
 import org.zalando.nakadi.service.AvroSchemaCompatibility;
 import org.zalando.nakadi.service.SchemaEvolutionService;
@@ -63,7 +63,7 @@ public class SchemaEvolutionServiceTest {
     private SchemaEvolutionService service;
     private final SchemaEvolutionConstraint evolutionConstraint = Mockito.mock(SchemaEvolutionConstraint.class);
     private final Map<SchemaChange.Type, String> errorMessages = Mockito.mock(HashMap.class);
-    private final BiFunction<SchemaChange.Type, CompatibilityMode, JsonVersion.Level> levelResolver =
+    private final BiFunction<SchemaChange.Type, CompatibilityMode, Version.Level> levelResolver =
             Mockito.mock(BiFunction.class);
     private final SchemaDiff schemaDiff = Mockito.mock(SchemaDiff.class);
     private final AvroSchemaCompatibility avroSchemaCompatibility = Mockito.mock(AvroSchemaCompatibility.class);
@@ -103,7 +103,7 @@ public class SchemaEvolutionServiceTest {
 
         final EventType eventType = service.evolve(oldEventType, newEventType);
 
-        Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo(new JsonVersion("1.0.0"))));
+        Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo("1.0.0")));
 
         Mockito.verify(evolutionConstraint).validate(oldEventType, newEventType);
     }
@@ -118,7 +118,7 @@ public class SchemaEvolutionServiceTest {
 
         final EventType eventType = service.evolve(oldEventType, newEventType);
 
-        Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo(new JsonVersion("1.0.1"))));
+        Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo("1.0.1")));
 
         Mockito.verify(evolutionConstraint).validate(oldEventType, newEventType);
     }
@@ -147,7 +147,7 @@ public class SchemaEvolutionServiceTest {
 
         final EventType eventType = service.evolve(oldEventType, newEventType);
 
-        Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo(new JsonVersion("1.0.1"))));
+        Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo("1.0.1")));
 
         Mockito.verify(evolutionConstraint).validate(oldEventType, newEventType);
     }
@@ -165,7 +165,7 @@ public class SchemaEvolutionServiceTest {
 
         final EventType eventType = service.evolve(oldEventType, newEventType);
 
-        Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo(new JsonVersion("1.1.0"))));
+        Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo("1.1.0")));
 
         Mockito.verify(evolutionConstraint).validate(oldEventType, newEventType);
     }
@@ -197,7 +197,7 @@ public class SchemaEvolutionServiceTest {
 
         final EventType eventType = service.evolve(oldEventType, newEventType);
 
-        Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo(new JsonVersion("2.0.0"))));
+        Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo("2.0.0")));
 
         Mockito.verify(evolutionConstraint).validate(oldEventType, newEventType);
     }
@@ -242,7 +242,7 @@ public class SchemaEvolutionServiceTest {
             final EventType eventType;
             try {
                 eventType = service.evolve(oldEventType, newEventType);
-                Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo(new JsonVersion("1.1.0"))));
+                Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo("1.1.0")));
             } catch (final SchemaEvolutionException e) {
                 Assert.fail();
             }

--- a/api-metastore/src/test/java/org/zalando/nakadi/validation/SchemaEvolutionServiceTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/validation/SchemaEvolutionServiceTest.java
@@ -16,7 +16,6 @@ import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.SchemaChange;
 import org.zalando.nakadi.domain.JsonVersion;
 import org.zalando.nakadi.exception.SchemaEvolutionException;
-import org.zalando.nakadi.repository.db.SchemaRepository;
 import org.zalando.nakadi.service.AvroSchemaCompatibility;
 import org.zalando.nakadi.service.SchemaEvolutionService;
 import org.zalando.nakadi.utils.EventTypeTestBuilder;
@@ -68,7 +67,6 @@ public class SchemaEvolutionServiceTest {
             Mockito.mock(BiFunction.class);
     private final SchemaDiff schemaDiff = Mockito.mock(SchemaDiff.class);
     private final AvroSchemaCompatibility avroSchemaCompatibility = Mockito.mock(AvroSchemaCompatibility.class);
-    private final SchemaRepository schemaRepository = Mockito.mock(SchemaRepository.class);
 
     @Before
     public void setUp() throws IOException {
@@ -77,7 +75,7 @@ public class SchemaEvolutionServiceTest {
                 Charsets.UTF_8));
         final Schema metaSchema = SchemaLoader.load(metaSchemaJson);
         this.service = new SchemaEvolutionService(metaSchema, evolutionConstraints, schemaDiff, levelResolver,
-                errorMessages, avroSchemaCompatibility, schemaRepository);
+                errorMessages, avroSchemaCompatibility);
 
         Mockito.doReturn("error").when(errorMessages).get(any());
     }

--- a/api-metastore/src/test/java/org/zalando/nakadi/validation/SchemaEvolutionServiceTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/validation/SchemaEvolutionServiceTest.java
@@ -14,8 +14,10 @@ import org.mockito.Mockito;
 import org.zalando.nakadi.domain.CompatibilityMode;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.SchemaChange;
-import org.zalando.nakadi.domain.Version;
+import org.zalando.nakadi.domain.JsonVersion;
 import org.zalando.nakadi.exception.SchemaEvolutionException;
+import org.zalando.nakadi.repository.db.SchemaRepository;
+import org.zalando.nakadi.service.AvroSchemaCompatibility;
 import org.zalando.nakadi.service.SchemaEvolutionService;
 import org.zalando.nakadi.utils.EventTypeTestBuilder;
 import org.zalando.nakadi.utils.TestUtils;
@@ -62,9 +64,11 @@ public class SchemaEvolutionServiceTest {
     private SchemaEvolutionService service;
     private final SchemaEvolutionConstraint evolutionConstraint = Mockito.mock(SchemaEvolutionConstraint.class);
     private final Map<SchemaChange.Type, String> errorMessages = Mockito.mock(HashMap.class);
-    private final BiFunction<SchemaChange.Type, CompatibilityMode, Version.Level> levelResolver =
+    private final BiFunction<SchemaChange.Type, CompatibilityMode, JsonVersion.Level> levelResolver =
             Mockito.mock(BiFunction.class);
     private final SchemaDiff schemaDiff = Mockito.mock(SchemaDiff.class);
+    private final AvroSchemaCompatibility avroSchemaCompatibility = Mockito.mock(AvroSchemaCompatibility.class);
+    private final SchemaRepository schemaRepository = Mockito.mock(SchemaRepository.class);
 
     @Before
     public void setUp() throws IOException {
@@ -73,7 +77,7 @@ public class SchemaEvolutionServiceTest {
                 Charsets.UTF_8));
         final Schema metaSchema = SchemaLoader.load(metaSchemaJson);
         this.service = new SchemaEvolutionService(metaSchema, evolutionConstraints, schemaDiff, levelResolver,
-                errorMessages);
+                errorMessages, avroSchemaCompatibility, schemaRepository);
 
         Mockito.doReturn("error").when(errorMessages).get(any());
     }
@@ -101,7 +105,7 @@ public class SchemaEvolutionServiceTest {
 
         final EventType eventType = service.evolve(oldEventType, newEventType);
 
-        Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo(new Version("1.0.0"))));
+        Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo(new JsonVersion("1.0.0"))));
 
         Mockito.verify(evolutionConstraint).validate(oldEventType, newEventType);
     }
@@ -116,7 +120,7 @@ public class SchemaEvolutionServiceTest {
 
         final EventType eventType = service.evolve(oldEventType, newEventType);
 
-        Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo(new Version("1.0.1"))));
+        Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo(new JsonVersion("1.0.1"))));
 
         Mockito.verify(evolutionConstraint).validate(oldEventType, newEventType);
     }
@@ -145,7 +149,7 @@ public class SchemaEvolutionServiceTest {
 
         final EventType eventType = service.evolve(oldEventType, newEventType);
 
-        Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo(new Version("1.0.1"))));
+        Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo(new JsonVersion("1.0.1"))));
 
         Mockito.verify(evolutionConstraint).validate(oldEventType, newEventType);
     }
@@ -163,7 +167,7 @@ public class SchemaEvolutionServiceTest {
 
         final EventType eventType = service.evolve(oldEventType, newEventType);
 
-        Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo(new Version("1.1.0"))));
+        Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo(new JsonVersion("1.1.0"))));
 
         Mockito.verify(evolutionConstraint).validate(oldEventType, newEventType);
     }
@@ -195,7 +199,7 @@ public class SchemaEvolutionServiceTest {
 
         final EventType eventType = service.evolve(oldEventType, newEventType);
 
-        Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo(new Version("2.0.0"))));
+        Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo(new JsonVersion("2.0.0"))));
 
         Mockito.verify(evolutionConstraint).validate(oldEventType, newEventType);
     }
@@ -240,7 +244,7 @@ public class SchemaEvolutionServiceTest {
             final EventType eventType;
             try {
                 eventType = service.evolve(oldEventType, newEventType);
-                Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo(new Version("1.1.0"))));
+                Assert.assertThat(eventType.getSchema().getVersion(), is(equalTo(new JsonVersion("1.1.0"))));
             } catch (final SchemaEvolutionException e) {
                 Assert.fail();
             }

--- a/core-common/src/main/java/org/zalando/nakadi/domain/AvroVersion.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/AvroVersion.java
@@ -15,10 +15,14 @@ public class AvroVersion implements Version {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        AvroVersion that = (AvroVersion) o;
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()){
+            return false;
+        }
+        final AvroVersion that = (AvroVersion) o;
         return version == that.version;
     }
 
@@ -34,9 +38,10 @@ public class AvroVersion implements Version {
     }
 
     @Override
-    public Version bump(Level level) {
-        if(level == Level.MAJOR)
+    public Version bump(final Level level) {
+        if(level != Level.NO_CHANGES){
             return new AvroVersion(Short.toString((short) (this.version + 1)));
+        }
 
         return new AvroVersion(Short.toString((this.version)));
     }

--- a/core-common/src/main/java/org/zalando/nakadi/domain/AvroVersion.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/AvroVersion.java
@@ -1,0 +1,40 @@
+package org.zalando.nakadi.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Objects;
+
+public class AvroVersion implements Version {
+
+    private final short version;
+
+    @JsonCreator
+    public AvroVersion(final String version){
+        this.version = Short.parseShort(version);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AvroVersion that = (AvroVersion) o;
+        return version == that.version;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(version);
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return Short.toString(version);
+    }
+
+    @Override
+    public Version bump(Level level) { // ignores level
+        return new AvroVersion(Short.toString((short) (this.version + 1)));
+    }
+}

--- a/core-common/src/main/java/org/zalando/nakadi/domain/AvroVersion.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/AvroVersion.java
@@ -9,6 +9,10 @@ public class AvroVersion implements Version {
 
     private final short version;
 
+    public AvroVersion(){
+        version = 1;
+    }
+
     @JsonCreator
     public AvroVersion(final String version){
         this.version = Short.parseShort(version);

--- a/core-common/src/main/java/org/zalando/nakadi/domain/AvroVersion.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/AvroVersion.java
@@ -34,7 +34,10 @@ public class AvroVersion implements Version {
     }
 
     @Override
-    public Version bump(Level level) { // ignores level
-        return new AvroVersion(Short.toString((short) (this.version + 1)));
+    public Version bump(Level level) {
+        if(level == Level.MAJOR)
+            return new AvroVersion(Short.toString((short) (this.version + 1)));
+
+        return new AvroVersion(Short.toString((this.version)));
     }
 }

--- a/core-common/src/main/java/org/zalando/nakadi/domain/CompatibilityMode.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/CompatibilityMode.java
@@ -1,5 +1,5 @@
 package org.zalando.nakadi.domain;
 
 public enum CompatibilityMode {
-    FORWARD, COMPATIBLE, NONE, BACKWARD
+    FORWARD, COMPATIBLE, NONE
 }

--- a/core-common/src/main/java/org/zalando/nakadi/domain/CompatibilityMode.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/CompatibilityMode.java
@@ -1,7 +1,5 @@
 package org.zalando.nakadi.domain;
 
 public enum CompatibilityMode {
-    FORWARD, COMPATIBLE, NONE,
-    BACKWARD, BACKWARD_TRANSITIVE,
-    FORWARD_TRANSITIVE, COMPATIBLE_TRANSITIVE
+    FORWARD, COMPATIBLE, NONE, BACKWARD
 }

--- a/core-common/src/main/java/org/zalando/nakadi/domain/CompatibilityMode.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/CompatibilityMode.java
@@ -1,5 +1,7 @@
 package org.zalando.nakadi.domain;
 
 public enum CompatibilityMode {
-    FORWARD, COMPATIBLE, NONE;
+    FORWARD, COMPATIBLE, NONE,
+    BACKWARD, BACKWARD_TRANSITIVE,
+    FORWARD_TRANSITIVE, COMPATIBLE_TRANSITIVE
 }

--- a/core-common/src/main/java/org/zalando/nakadi/domain/EventTypeSchema.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/EventTypeSchema.java
@@ -1,19 +1,10 @@
 package org.zalando.nakadi.domain;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.As;
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-
 import org.joda.time.DateTime;
 
 public class EventTypeSchema extends EventTypeSchemaBase {
-    @JsonTypeInfo(use = Id.NAME, property = "type", include = As.EXTERNAL_PROPERTY)
-    @JsonSubTypes(value = {
-            @JsonSubTypes.Type(value = JsonVersion.class, name = "JSON_SCHEMA"),
-            @JsonSubTypes.Type(value = AvroVersion.class, name = "AVRO_SCHEMA")
-    })
-    private Version version;
+
+    private String version;
 
     private DateTime createdAt;
 
@@ -23,11 +14,11 @@ public class EventTypeSchema extends EventTypeSchemaBase {
 
     public EventTypeSchema(final EventTypeSchemaBase schemaBase, final String version, final DateTime createdAt) {
         super(schemaBase);
-        this.version = this.getType().equals(Type.JSON_SCHEMA)? new JsonVersion(version) : new AvroVersion(version);
+        this.version = version;
         this.createdAt = createdAt;
     }
 
-    public Version getVersion() {
+    public String getVersion() {
         return version;
     }
 
@@ -35,7 +26,7 @@ public class EventTypeSchema extends EventTypeSchemaBase {
         return createdAt;
     }
 
-    public void setVersion(final Version version) {
+    public void setVersion(final String version) {
         this.version = version;
     }
 

--- a/core-common/src/main/java/org/zalando/nakadi/domain/EventTypeSchema.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/EventTypeSchema.java
@@ -10,8 +10,8 @@ import org.joda.time.DateTime;
 public class EventTypeSchema extends EventTypeSchemaBase {
     @JsonTypeInfo(use = Id.NAME, property = "type", include = As.EXTERNAL_PROPERTY)
     @JsonSubTypes(value = {
-            @JsonSubTypes.Type(value = JsonVersion.class, name = "json_schema"),
-            @JsonSubTypes.Type(value = AvroVersion.class, name = "avro_schema")
+            @JsonSubTypes.Type(value = JsonVersion.class, name = "JSON_SCHEMA"),
+            @JsonSubTypes.Type(value = AvroVersion.class, name = "AVRO_SCHEMA")
     })
     private Version version;
 

--- a/core-common/src/main/java/org/zalando/nakadi/domain/EventTypeSchema.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/EventTypeSchema.java
@@ -1,9 +1,20 @@
 package org.zalando.nakadi.domain;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+
 import org.joda.time.DateTime;
 
 public class EventTypeSchema extends EventTypeSchemaBase {
+    @JsonTypeInfo(use = Id.NAME, property = "type", include = As.EXTERNAL_PROPERTY)
+    @JsonSubTypes(value = {
+            @JsonSubTypes.Type(value = JsonVersion.class, name = "json_schema"),
+            @JsonSubTypes.Type(value = AvroVersion.class, name = "avro_schema")
+    })
     private Version version;
+
     private DateTime createdAt;
 
     public EventTypeSchema() {
@@ -12,7 +23,7 @@ public class EventTypeSchema extends EventTypeSchemaBase {
 
     public EventTypeSchema(final EventTypeSchemaBase schemaBase, final String version, final DateTime createdAt) {
         super(schemaBase);
-        this.version = new Version(version);
+        this.version = this.getType().equals(Type.JSON_SCHEMA)? new JsonVersion(version) : new AvroVersion(version);
         this.createdAt = createdAt;
     }
 

--- a/core-common/src/main/java/org/zalando/nakadi/domain/EventTypeSchemaBase.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/EventTypeSchemaBase.java
@@ -17,7 +17,7 @@ public class EventTypeSchemaBase {
     }
 
     public enum Type {
-        JSON_SCHEMA
+        JSON_SCHEMA, AVRO_SCHEMA
     }
 
     @NotNull

--- a/core-common/src/main/java/org/zalando/nakadi/domain/EventTypeSchemaBase.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/EventTypeSchemaBase.java
@@ -17,7 +17,17 @@ public class EventTypeSchemaBase {
     }
 
     public enum Type {
-        JSON_SCHEMA, AVRO_SCHEMA
+        JSON_SCHEMA("1.0.0"), AVRO_SCHEMA("1");
+
+        private String startVersion;
+
+        Type(final String startVersion){
+            this.startVersion = startVersion;
+        }
+
+        public String getStartVersion(){
+            return startVersion;
+        }
     }
 
     @NotNull

--- a/core-common/src/main/java/org/zalando/nakadi/domain/EventTypeSchemaBase.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/EventTypeSchemaBase.java
@@ -17,17 +17,7 @@ public class EventTypeSchemaBase {
     }
 
     public enum Type {
-        JSON_SCHEMA("1.0.0"), AVRO_SCHEMA("1");
-
-        private String startVersion;
-
-        Type(final String startVersion){
-            this.startVersion = startVersion;
-        }
-
-        public String getStartVersion(){
-            return startVersion;
-        }
+        JSON_SCHEMA, AVRO_SCHEMA
     }
 
     @NotNull

--- a/core-common/src/main/java/org/zalando/nakadi/domain/JsonVersion.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/JsonVersion.java
@@ -1,0 +1,68 @@
+package org.zalando.nakadi.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public class JsonVersion implements Version {
+
+    private final int major;
+    private final int minor;
+    private final int patch;
+
+    public JsonVersion(final int major, final int minor, final int patch) {
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+    }
+
+    @JsonCreator
+    public JsonVersion(final String versionString) {
+        final String[] versionStringParts = versionString.split("\\.");
+        this.major = Integer.valueOf(versionStringParts[0]);
+        this.minor = Integer.valueOf(versionStringParts[1]);
+        this.patch = Integer.valueOf(versionStringParts[2]);
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return major + "." + minor + "." + patch;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final JsonVersion version = (JsonVersion) o;
+
+        if (major != version.major) {
+            return false;
+        }
+        if (minor != version.minor) {
+            return false;
+        }
+        return patch == version.patch;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = major;
+        result = 31 * result + minor;
+        result = 31 * result + patch;
+        return result;
+    }
+
+    public Version bump(final Version.Level level) {
+        switch (level) {
+            case MAJOR: return new JsonVersion(this.major + 1, 0, 0);
+            case MINOR: return new JsonVersion(this.major, this.minor + 1, 0);
+            case PATCH: return new JsonVersion(this.major, this.minor, this.patch + 1);
+            default: return new JsonVersion(this.major, this.minor, this.patch);
+        }
+    }
+}

--- a/core-common/src/main/java/org/zalando/nakadi/domain/JsonVersion.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/JsonVersion.java
@@ -9,6 +9,12 @@ public class JsonVersion implements Version {
     private final int minor;
     private final int patch;
 
+    public JsonVersion() {
+        this.major = 1;
+        this.minor = 0;
+        this.patch = 0;
+    }
+
     public JsonVersion(final int major, final int minor, final int patch) {
         this.major = major;
         this.minor = minor;

--- a/core-common/src/main/java/org/zalando/nakadi/domain/Version.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/Version.java
@@ -3,6 +3,6 @@ package org.zalando.nakadi.domain;
 public interface Version {
     enum Level { MAJOR, MINOR, PATCH, NO_CHANGES }
 
-    Version bump(final Version.Level level);
+    Version bump(Version.Level level);
 
 }

--- a/core-common/src/main/java/org/zalando/nakadi/domain/Version.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/Version.java
@@ -1,69 +1,8 @@
 package org.zalando.nakadi.domain;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+public interface Version {
+    enum Level { MAJOR, MINOR, PATCH, NO_CHANGES }
 
-public class Version {
-    public enum Level { MAJOR, MINOR, PATCH, NO_CHANGES }
+    Version bump(final Version.Level level);
 
-    private final int major;
-    private final int minor;
-    private final int patch;
-
-    public Version(final int major, final int minor, final int patch) {
-        this.major = major;
-        this.minor = minor;
-        this.patch = patch;
-    }
-
-    @JsonCreator
-    public Version(final String versionString) {
-        final String[] versionStringParts = versionString.split("\\.");
-        this.major = Integer.valueOf(versionStringParts[0]);
-        this.minor = Integer.valueOf(versionStringParts[1]);
-        this.patch = Integer.valueOf(versionStringParts[2]);
-    }
-
-    @Override
-    @JsonValue
-    public String toString() {
-        return major + "." + minor + "." + patch;
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        final Version version = (Version) o;
-
-        if (major != version.major) {
-            return false;
-        }
-        if (minor != version.minor) {
-            return false;
-        }
-        return patch == version.patch;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = major;
-        result = 31 * result + minor;
-        result = 31 * result + patch;
-        return result;
-    }
-
-    public Version bump(final Version.Level level) {
-        switch (level) {
-            case MAJOR: return new Version(this.major + 1, 0, 0);
-            case MINOR: return new Version(this.major, this.minor + 1, 0);
-            case PATCH: return new Version(this.major, this.minor, this.patch + 1);
-            default: return new Version(this.major, this.minor, this.patch);
-        }
-    }
 }

--- a/core-common/src/main/java/org/zalando/nakadi/service/AvroSchema.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/AvroSchema.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
+import org.zalando.nakadi.util.AvroUtils;
 
 import java.io.IOException;
 
@@ -31,8 +32,8 @@ public class AvroSchema {
             throws IOException {
         this.avroMapper = avroMapper;
         this.objectMapper = objectMapper;
-        this.metadataSchema = new Schema.Parser().parse(metadataRes.getInputStream());
-        this.nakadiAccessLogSchema = new Schema.Parser().parse(nakadiAccessLogRes.getInputStream());
+        this.metadataSchema = AvroUtils.getParsedSchema(metadataRes.getInputStream());
+        this.nakadiAccessLogSchema = AvroUtils.getParsedSchema(nakadiAccessLogRes.getInputStream());
     }
 
     public Schema getNakadiAccessLogSchema() {

--- a/core-common/src/main/java/org/zalando/nakadi/util/AvroUtils.java
+++ b/core-common/src/main/java/org/zalando/nakadi/util/AvroUtils.java
@@ -1,0 +1,19 @@
+package org.zalando.nakadi.util;
+
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.Schema;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class AvroUtils {
+
+    public static Schema getParsedSchema(final String schema) throws AvroRuntimeException {
+        return new Schema.Parser().parse(schema);
+    }
+
+    public static Schema getParsedSchema(final InputStream schema) throws AvroRuntimeException, IOException {
+        return new Schema.Parser().parse(schema);
+    }
+
+}

--- a/core-common/src/test/java/org/zalando/nakadi/domain/VersionTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/domain/VersionTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.assertThat;
 public class VersionTest {
     @Test
     public void bumpShouldZeroSmallerVersionNumber() throws Exception {
-        assertThat(new Version("1.1.0").bump(Version.Level.MAJOR), equalTo(new Version("2.0.0")));
-        assertThat(new Version("1.1.1").bump(Version.Level.MINOR), equalTo(new Version("1.2.0")));
+        assertThat(new JsonVersion("1.1.0").bump(JsonVersion.Level.MAJOR), equalTo(new JsonVersion("2.0.0")));
+        assertThat(new JsonVersion("1.1.1").bump(JsonVersion.Level.MINOR), equalTo(new JsonVersion("1.2.0")));
     }
 }

--- a/core-common/src/test/resources/org/zalando/nakadi/domain/event-type.with.annotations-and-labels.json
+++ b/core-common/src/test/resources/org/zalando/nakadi/domain/event-type.with.annotations-and-labels.json
@@ -14,7 +14,8 @@
     "name"
   ],
   "schema": {
-    "type": "JSON_SCHEMA",
-    "schema": "{ \"Article\": { \"properties\": { \"name\": { \"type\": \"string\" } } } }"
+    "type": "json_schema",
+    "schema": "{ \"Article\": { \"properties\": { \"name\": { \"type\": \"string\" } } } }",
+    "version" : "1.0.0"
   }
 }

--- a/core-common/src/test/resources/org/zalando/nakadi/domain/event-type.with.annotations-and-labels.json
+++ b/core-common/src/test/resources/org/zalando/nakadi/domain/event-type.with.annotations-and-labels.json
@@ -14,7 +14,7 @@
     "name"
   ],
   "schema": {
-    "type": "json_schema",
+    "type": "JSON_SCHEMA",
     "schema": "{ \"Article\": { \"properties\": { \"name\": { \"type\": \"string\" } } } }",
     "version" : "1.0.0"
   }

--- a/core-common/src/test/resources/org/zalando/nakadi/domain/event-type.with.partition-key-fields.json
+++ b/core-common/src/test/resources/org/zalando/nakadi/domain/event-type.with.partition-key-fields.json
@@ -6,7 +6,7 @@
     "sku", "name"
   ],
   "schema": {
-    "type": "json_schema",
+    "type": "JSON_SCHEMA",
     "schema": "{ \"Article\": { \"properties\": { \"sku\": { \"type\": \"string\" }, \"name\": { \"type\": \"string\" }, \"color\": { \"type\": \"string\" } \"price\": { \"type\": \"number\" }} } }",
     "version" : "1.0.0"
 

--- a/core-common/src/test/resources/org/zalando/nakadi/domain/event-type.with.partition-key-fields.json
+++ b/core-common/src/test/resources/org/zalando/nakadi/domain/event-type.with.partition-key-fields.json
@@ -6,7 +6,9 @@
     "sku", "name"
   ],
   "schema": {
-    "type": "JSON_SCHEMA",
-    "schema": "{ \"Article\": { \"properties\": { \"sku\": { \"type\": \"string\" }, \"name\": { \"type\": \"string\" }, \"color\": { \"type\": \"string\" } \"price\": { \"type\": \"number\" }} } }"
+    "type": "json_schema",
+    "schema": "{ \"Article\": { \"properties\": { \"sku\": { \"type\": \"string\" }, \"name\": { \"type\": \"string\" }, \"color\": { \"type\": \"string\" } \"price\": { \"type\": \"number\" }} } }",
+    "version" : "1.0.0"
+
   }
 }

--- a/core-common/src/test/resources/org/zalando/nakadi/domain/event-type.without.partition-key-fields.json
+++ b/core-common/src/test/resources/org/zalando/nakadi/domain/event-type.without.partition-key-fields.json
@@ -3,7 +3,8 @@
   "owning_application": "article-producer",
   "category": "data",
   "schema": {
-    "type": "JSON_SCHEMA",
-    "schema": "{ \"Article\": { \"properties\": { \"sku\": { \"type\": \"string\" }, \"name\": { \"type\": \"string\" }, \"color\": { \"type\": \"string\" } \"price\": { \"type\": \"number\" }} } }"
+    "type": "json_schema",
+    "schema": "{ \"Article\": { \"properties\": { \"sku\": { \"type\": \"string\" }, \"name\": { \"type\": \"string\" }, \"color\": { \"type\": \"string\" } \"price\": { \"type\": \"number\" }} } }",
+    "version": "1.0.0"
   }
 }

--- a/core-common/src/test/resources/org/zalando/nakadi/domain/event-type.without.partition-key-fields.json
+++ b/core-common/src/test/resources/org/zalando/nakadi/domain/event-type.without.partition-key-fields.json
@@ -3,7 +3,7 @@
   "owning_application": "article-producer",
   "category": "data",
   "schema": {
-    "type": "json_schema",
+    "type": "JSON_SCHEMA",
     "schema": "{ \"Article\": { \"properties\": { \"sku\": { \"type\": \"string\" }, \"name\": { \"type\": \"string\" }, \"color\": { \"type\": \"string\" } \"price\": { \"type\": \"number\" }} } }",
     "version": "1.0.0"
   }

--- a/core-metastore/src/main/java/org/zalando/nakadi/repository/db/EventTypeRepository.java
+++ b/core-metastore/src/main/java/org/zalando/nakadi/repository/db/EventTypeRepository.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 import org.zalando.nakadi.annotations.DB;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeBase;
+import org.zalando.nakadi.domain.EventTypeSchemaBase;
 import org.zalando.nakadi.exceptions.runtime.DuplicatedEventTypeNameException;
 import org.zalando.nakadi.exceptions.runtime.InternalNakadiException;
 import org.zalando.nakadi.exceptions.runtime.NoSuchEventTypeException;
@@ -39,7 +40,8 @@ public class EventTypeRepository extends AbstractDbRepository {
             DuplicatedEventTypeNameException {
         try {
             final DateTime now = new DateTime(DateTimeZone.UTC);
-            final EventType eventType = new EventType(eventTypeBase, "1.0.0", now, now);
+            final var version = eventTypeBase.getSchema().getType() == EventTypeSchemaBase.Type.JSON_SCHEMA? "1.0.0": "1";
+            final EventType eventType = new EventType(eventTypeBase, version, now, now);
             jdbcTemplate.update(
                     "INSERT INTO zn_data.event_type (et_name, et_event_type_object) VALUES (?, ?::jsonb)",
                     eventTypeBase.getName(),

--- a/core-metastore/src/main/java/org/zalando/nakadi/repository/db/EventTypeRepository.java
+++ b/core-metastore/src/main/java/org/zalando/nakadi/repository/db/EventTypeRepository.java
@@ -40,7 +40,7 @@ public class EventTypeRepository extends AbstractDbRepository {
             DuplicatedEventTypeNameException {
         try {
             final DateTime now = new DateTime(DateTimeZone.UTC);
-            final var version = eventTypeBase.getSchema().getType() == EventTypeSchemaBase.Type.JSON_SCHEMA? "1.0.0": "1";
+            final var version = constructVersionString(eventTypeBase);
             final EventType eventType = new EventType(eventTypeBase, version, now, now);
             jdbcTemplate.update(
                     "INSERT INTO zn_data.event_type (et_name, et_event_type_object) VALUES (?, ?::jsonb)",
@@ -53,6 +53,11 @@ public class EventTypeRepository extends AbstractDbRepository {
         } catch (final DataIntegrityViolationException e) {
             throw new DuplicatedEventTypeNameException("EventType " + eventTypeBase.getName() + " already exists.", e);
         }
+    }
+
+    private String constructVersionString(final EventTypeBase eventTypeBase) {
+        return eventTypeBase.getSchema().getType() == EventTypeSchemaBase.Type.JSON_SCHEMA?
+                "1.0.0": "1";
     }
 
     public EventType findByName(final String name) throws NoSuchEventTypeException {

--- a/core-metastore/src/main/java/org/zalando/nakadi/repository/db/SchemaRepository.java
+++ b/core-metastore/src/main/java/org/zalando/nakadi/repository/db/SchemaRepository.java
@@ -30,10 +30,11 @@ public class SchemaRepository extends AbstractDbRepository {
                 new SchemaRowMapper());
     }
 
-    public List<EventTypeSchema> listSchemas(final String name, String version) {
+    public List<EventTypeSchema> listSchemas(final String name, final String version) {
         return jdbcTemplate.query(
                 "SELECT ets_schema_object FROM zn_data.event_type_schema " +
-                        "WHERE ets_event_type_name = ? AND ets_schema_object->>'version' <= ? ORDER BY ets_schema_object->>'created_at' DESC",
+                        "WHERE ets_event_type_name = ? AND ets_schema_object->>'version' <= ? " +
+                        "ORDER BY ets_schema_object->>'created_at' DESC",
                 new Object[]{name, version},
                 new SchemaRowMapper());
     }

--- a/core-metastore/src/main/java/org/zalando/nakadi/repository/db/SchemaRepository.java
+++ b/core-metastore/src/main/java/org/zalando/nakadi/repository/db/SchemaRepository.java
@@ -30,15 +30,6 @@ public class SchemaRepository extends AbstractDbRepository {
                 new SchemaRowMapper());
     }
 
-    public List<EventTypeSchema> listSchemas(final String name, final String version) {
-        return jdbcTemplate.query(
-                "SELECT ets_schema_object FROM zn_data.event_type_schema " +
-                        "WHERE ets_event_type_name = ? AND ets_schema_object->>'version' <= ? " +
-                        "ORDER BY ets_schema_object->>'created_at' DESC",
-                new Object[]{name, version},
-                new SchemaRowMapper());
-    }
-
     public EventTypeSchema getSchemaVersion(final String name, final String version)
             throws NoSuchSchemaException {
         final String sql = "SELECT ets_schema_object FROM zn_data.event_type_schema " +

--- a/core-metastore/src/main/java/org/zalando/nakadi/repository/db/SchemaRepository.java
+++ b/core-metastore/src/main/java/org/zalando/nakadi/repository/db/SchemaRepository.java
@@ -30,6 +30,14 @@ public class SchemaRepository extends AbstractDbRepository {
                 new SchemaRowMapper());
     }
 
+    public List<EventTypeSchema> listSchemas(final String name, String version) {
+        return jdbcTemplate.query(
+                "SELECT ets_schema_object FROM zn_data.event_type_schema " +
+                        "WHERE ets_event_type_name = ? AND ets_schema_object->>'version' <= ? ORDER BY ets_schema_object->>'created_at' DESC",
+                new Object[]{name, version},
+                new SchemaRowMapper());
+    }
+
     public EventTypeSchema getSchemaVersion(final String name, final String version)
             throws NoSuchSchemaException {
         final String sql = "SELECT ets_schema_object FROM zn_data.event_type_schema " +

--- a/core-services/src/main/java/org/zalando/nakadi/cache/EventTypeCache.java
+++ b/core-services/src/main/java/org/zalando/nakadi/cache/EventTypeCache.java
@@ -4,7 +4,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +19,6 @@ import org.zalando.nakadi.repository.db.TimelineDbRepository;
 import org.zalando.nakadi.service.timeline.TimelineSync;
 import org.zalando.nakadi.validation.EventTypeValidator;
 import org.zalando.nakadi.validation.EventValidatorBuilder;
-import org.zalando.nakadi.validation.ValidationError;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -34,7 +32,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -307,7 +304,8 @@ public class EventTypeCache {
 
         final CachedValue result = new CachedValue(
                 eventType,
-                schemaType == EventTypeSchemaBase.Type.JSON_SCHEMA? eventValidatorBuilder.build(eventType) : noopValidator,
+                schemaType == EventTypeSchemaBase.Type.JSON_SCHEMA?
+                        eventValidatorBuilder.build(eventType) : noopValidator,
                 timelines
         );
         LOG.info("Successfully load event type {}, took: {} ms", eventTypeName, System.currentTimeMillis() - start);

--- a/core-services/src/test/java/org/zalando/nakadi/cache/EventTypeCacheTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/cache/EventTypeCacheTest.java
@@ -1,6 +1,7 @@
 package org.zalando.nakadi.cache;
 
 import org.echocat.jomon.runtime.concurrent.RetryForSpecifiedTimeStrategy;
+import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -9,6 +10,8 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.zalando.nakadi.domain.EventType;
+import org.zalando.nakadi.domain.EventTypeSchema;
+import org.zalando.nakadi.domain.EventTypeSchemaBase;
 import org.zalando.nakadi.domain.Timeline;
 import org.zalando.nakadi.exceptions.runtime.NoSuchEventTypeException;
 import org.zalando.nakadi.repository.db.EventTypeRepository;
@@ -154,6 +157,11 @@ public class EventTypeCacheTest {
         final EventTypeValidator validator2 = mock(EventTypeValidator.class);
         final List<Timeline> expectedTimelines2 = mock(List.class);
 
+        final var etSchema = new EventTypeSchema(new EventTypeSchemaBase(
+                EventTypeSchemaBase.Type.JSON_SCHEMA, ""),
+                "1.0.0", DateTime.now());
+        when(et1.getSchema()).thenReturn(etSchema);
+        when(et2.getSchema()).thenReturn(etSchema);
         when(eventTypeRepository.findByName(eq(eventTypeName))).thenReturn(et1, et2);
         when(eventValidatorBuilder.build(eq(et1))).thenReturn(validator1);
         when(eventValidatorBuilder.build(eq(et2))).thenReturn(validator2);


### PR DESCRIPTION
Nakadi needs modifications to schema registry to support Avro Schemas. 

This PR contains changes for accepting, storing and evolution of Avro schemas.

## Compatibility check API

### URL
POST `/event-types/{name}/schemas/{version}/compatibility-check` 

### Request Body
It accepts json body containing schema string and type,
for eg: 
``` json
  
 {
    "schema": "{\"type\":\"record\",\"name\":\"Person\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"age\",\"type\":\"int\"},{\"name\":\"address\",\"type\":{\"type\":\"record\",\"name\":\"Address\",\"fields\":[{\"name\":\"street\",\"type\":\"string\"},{\"name\":\"pincode\",\"type\":\"int\"}]}},{\"name\":\"email\",\"type\":\"string\"}]}"
  }
```
### Response Body for 200 status code

Sample response on validation failure,

``` json
{
   "compatible":false,
   "compatibility_mode":"forward",
   "error": “Failed to evolve avro schema due to [{    
             type:READER_FIELD_MISSING_DEFAULT_VALUE,
             location:/fields/0, message:name }]“,
   "validated_against_version": “47”
}

```

Sample response on validation pass,

``` json
{
   "compatible":true,
   "compatibility_mode":"forward",
   "validated_against_version": “47”
}

```
### Response codes
| Http Code | Description                                        |
|-----------|----------------------------------------------------|
| 200       | Validation was performed                           |
| 401       | Unauthenticated                                    |
| 403       | Unauthorised                                       |
| 404       | The version or event-type mentioned does not exist |
| 422       | Unable to parse/process request body                     |

## Create EventType API

Avro event types can now be created by specifying `type` value as `avro_schema` and the avro schema string in `schema` field.