### PR TITLE
Experimenting with a Builder for EventMetadata

### DIFF
--- a/app/src/main/java/org/zalando/nakadi/service/job/DiskUsageStatsJob.java
+++ b/app/src/main/java/org/zalando/nakadi/service/job/DiskUsageStatsJob.java
@@ -120,7 +120,8 @@ public class DiskUsageStatsJob {
                     final JSONObject event = new JSONObject();
                     event.put("event_type", x.getKey());
                     event.put("size_bytes", x.getValue() * 1024);
-                    return eventMetadata.addTo(event);
+                    event.put(EventMetadata.METADATA_FIELD, eventMetadata.generateMetadata().asJson());
+                    return event;
                 })
                 .forEach(item -> eventsProcessor.queueEvent(config.getEventTypeName(), item));
     }

--- a/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventMetadata.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventMetadata.java
@@ -1,14 +1,27 @@
 package org.zalando.nakadi.service.publishing;
 
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
 import org.json.JSONObject;
 import org.springframework.stereotype.Component;
 import org.zalando.nakadi.util.FlowIdUtils;
 import org.zalando.nakadi.util.UUIDGenerator;
 
 import java.time.Instant;
+import java.util.UUID;
 
 @Component
 public class EventMetadata {
+    public static final String METADATA_FIELD = "metadata";
+    public static final String OCCURRED_AT_FIELD = "occurred_at";
+    public static final String EID_FIELD = "eid";
+    public static final String FLOW_ID_FIELD = "flow_id";
+    public static final String RECEIVED_AT_FIELD = "received_at";
+    public static final String SCHEMA_VERSION_FIELD = "schema_version";
+    public static final String PUBLISHED_BY_FIELD = "published_by";
+    public static final String EVENT_TYPE_FIELD = "event_type";
+    public static final String PARTITION_FIELD = "partition";
 
     private final UUIDGenerator uuidGenerator;
 
@@ -16,10 +29,127 @@ public class EventMetadata {
         this.uuidGenerator = uuidGenerator;
     }
 
+    @Deprecated
     public JSONObject addTo(final JSONObject event) {
-        return event.put("metadata", new JSONObject()
+        return event.put(METADATA_FIELD, new JSONObject()
                 .put("occurred_at", Instant.now())
                 .put("eid", uuidGenerator.randomUUID())
                 .put("flow_id", FlowIdUtils.peek()));
+    }
+
+    public Builder generateMetadata() {
+        return new Builder()
+                .setOccurredAt(Instant.now())
+                .setEid(uuidGenerator.randomUUID())
+                .setFlowId(FlowIdUtils.peek());
+    }
+
+    public static class Builder {
+        private Instant occurredAt;
+        private UUID eid;
+        private String flowId;
+        private Instant receivedAt;
+        private String schemaVersion;
+        private String publishedBy;
+        private String eventType;
+        private Integer partition;
+
+        public Instant getOccurredAt() {
+            return occurredAt;
+        }
+
+        public Builder setOccurredAt(final Instant occurredAt) {
+            this.occurredAt = occurredAt;
+            return this;
+        }
+
+        public UUID getEid() {
+            return eid;
+        }
+
+        public Builder setEid(final UUID eid) {
+            this.eid = eid;
+            return this;
+        }
+
+        public String getFlowId() {
+            return flowId;
+        }
+
+        public Builder setFlowId(final String flowId) {
+            this.flowId = flowId;
+            return this;
+        }
+
+        public Instant getReceivedAt() {
+            return receivedAt;
+        }
+
+        public Builder setReceivedAt(final Instant receivedAt) {
+            this.receivedAt = receivedAt;
+            return this;
+        }
+
+        public String getSchemaVersion() {
+            return schemaVersion;
+        }
+
+        public Builder setSchemaVersion(final String schemaVersion) {
+            this.schemaVersion = schemaVersion;
+            return this;
+        }
+
+        public String getPublishedBy() {
+            return publishedBy;
+        }
+
+        public Builder setPublishedBy(final String publishedBy) {
+            this.publishedBy = publishedBy;
+            return this;
+        }
+
+        public String getEventType() {
+            return eventType;
+        }
+
+        public Builder setEventType(final String eventType) {
+            this.eventType = eventType;
+            return this;
+        }
+
+        public Integer getPartition() {
+            return partition;
+        }
+
+        public Builder setPartition(final Integer partition) {
+            this.partition = partition;
+            return this;
+        }
+
+        public JSONObject asJson() {
+            return new JSONObject()
+                    .put(OCCURRED_AT_FIELD, occurredAt)
+                    .put(EID_FIELD, eid)
+                    .put(FLOW_ID_FIELD, flowId)
+                    .put(RECEIVED_AT_FIELD, receivedAt)
+                    .put(SCHEMA_VERSION_FIELD, schemaVersion)
+                    .put(PUBLISHED_BY_FIELD, publishedBy)
+                    .put(EVENT_TYPE_FIELD, eventType)
+                    .put(PARTITION_FIELD, partition);
+        }
+
+        public GenericRecord asAvroGenericRecord(final Schema schema) {
+
+            return new GenericRecordBuilder(schema)
+                    .set(OCCURRED_AT_FIELD, occurredAt.toEpochMilli())
+                    .set(EID_FIELD, eid.toString())
+                    .set(FLOW_ID_FIELD, flowId)
+                    .set(EVENT_TYPE_FIELD, eventType)
+                    .set(PARTITION_FIELD, partition)
+                    .set(RECEIVED_AT_FIELD, receivedAt.toEpochMilli())
+                    .set(SCHEMA_VERSION_FIELD, schemaVersion)
+                    .set(PUBLISHED_BY_FIELD, publishedBy)
+                    .build();
+        }
     }
 }

--- a/core-services/src/main/java/org/zalando/nakadi/service/publishing/NakadiAuditLogPublisher.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/publishing/NakadiAuditLogPublisher.java
@@ -81,10 +81,11 @@ public class NakadiAuditLogPublisher {
             final JSONObject dataEvent = new JSONObject()
                     .put("data_type", resourceType.name().toLowerCase())
                     .put("data_op", actionType.getShortname())
-                    .put("data", payload);
+                    .put("data", payload)
+                    .put(EventMetadata.METADATA_FIELD, eventMetadata.generateMetadata().asJson());
 
             eventsProcessor.sendEvents(auditEventType,
-                    Collections.singletonList(eventMetadata.addTo(dataEvent)));
+                    Collections.singletonList(dataEvent));
         } catch (final Throwable e) {
             LOG.error("Error occurred when submitting audit event for publishing", e);
         }

--- a/core-services/src/main/java/org/zalando/nakadi/service/publishing/NakadiKpiPublisher.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/publishing/NakadiKpiPublisher.java
@@ -14,7 +14,6 @@ import org.zalando.nakadi.domain.NakadiRecord;
 import org.zalando.nakadi.security.UsernameHasher;
 import org.zalando.nakadi.service.AvroSchema;
 import org.zalando.nakadi.service.FeatureToggleService;
-import org.zalando.nakadi.util.UUIDGenerator;
 
 import java.time.Instant;
 import java.util.Map;
@@ -30,7 +29,6 @@ public class NakadiKpiPublisher {
     private final BinaryEventProcessor binaryEventsProcessor;
     private final UsernameHasher usernameHasher;
     private final EventMetadata eventMetadata;
-    private final UUIDGenerator uuidGenerator;
     private final AvroSchema avroSchema;
 
     @Autowired
@@ -40,14 +38,12 @@ public class NakadiKpiPublisher {
             final BinaryEventProcessor binaryEventsProcessor,
             final UsernameHasher usernameHasher,
             final EventMetadata eventMetadata,
-            final UUIDGenerator uuidGenerator,
             final AvroSchema avroSchema) {
         this.featureToggleService = featureToggleService;
         this.jsonEventsProcessor = jsonEventsProcessor;
         this.binaryEventsProcessor = binaryEventsProcessor;
         this.usernameHasher = usernameHasher;
         this.eventMetadata = eventMetadata;
-        this.uuidGenerator = uuidGenerator;
         this.avroSchema = avroSchema;
     }
 

--- a/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventMetadataTestStub.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventMetadataTestStub.java
@@ -12,4 +12,14 @@ public class EventMetadataTestStub extends EventMetadata {
     public JSONObject addTo(final JSONObject event) {
         return event;
     }
+
+    @Override
+    public Builder generateMetadata() {
+        return new Builder() {
+            @Override
+            public JSONObject asJson() {
+                return null;
+            }
+        };
+    }
 }

--- a/core-services/src/test/java/org/zalando/nakadi/service/publishing/NakadiKpiPublisherTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/publishing/NakadiKpiPublisherTest.java
@@ -45,7 +45,8 @@ public class NakadiKpiPublisherTest {
     public void testPublishWithFeatureToggleOn() throws Exception {
         when(featureToggleService.isFeatureEnabled(Feature.KPI_COLLECTION))
                 .thenReturn(true);
-        final Supplier<JSONObject> dataSupplier = () -> null;
+        final var testKpiEvent = new JSONObject();
+        final Supplier<JSONObject> dataSupplier = () -> testKpiEvent;
         new NakadiKpiPublisher(featureToggleService,
                 jsonProcessor, binaryProcessor, usernameHasher,
                 new EventMetadataTestStub(), uuidGenerator, avroSchema)
@@ -85,7 +86,7 @@ public class NakadiKpiPublisherTest {
         final var avroSchema = new AvroSchema(new AvroMapper(), new ObjectMapper(), eventTypeRes);
         final NakadiKpiPublisher publisher = new NakadiKpiPublisher(featureToggleService,
                 jsonProcessor, binaryProcessor, usernameHasher,
-                new EventMetadataTestStub(), new UUIDGenerator(), avroSchema);
+                new EventMetadata(new UUIDGenerator()), new UUIDGenerator(), avroSchema);
         publisher.publishAccessLogEvent("POST",
                 "/test", "", "", "", "",
                 "", 200, 1L, 1L, 1L);

--- a/core-services/src/test/java/org/zalando/nakadi/service/publishing/NakadiKpiPublisherTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/publishing/NakadiKpiPublisherTest.java
@@ -49,7 +49,7 @@ public class NakadiKpiPublisherTest {
         final Supplier<JSONObject> dataSupplier = () -> testKpiEvent;
         new NakadiKpiPublisher(featureToggleService,
                 jsonProcessor, binaryProcessor, usernameHasher,
-                new EventMetadataTestStub(), uuidGenerator, avroSchema)
+                new EventMetadataTestStub(), avroSchema)
                 .publish("test_et_name", dataSupplier);
 
         verify(jsonProcessor).queueEvent("test_et_name", dataSupplier.get());
@@ -62,7 +62,7 @@ public class NakadiKpiPublisherTest {
         final Supplier<JSONObject> dataSupplier = () -> null;
         new NakadiKpiPublisher(featureToggleService,
                 jsonProcessor, binaryProcessor, usernameHasher,
-                new EventMetadataTestStub(), uuidGenerator, avroSchema)
+                new EventMetadataTestStub(), avroSchema)
                 .publish("test_et_name", dataSupplier);
 
         verify(jsonProcessor, Mockito.never()).queueEvent("test_et_name", dataSupplier.get());
@@ -72,7 +72,7 @@ public class NakadiKpiPublisherTest {
     public void testHash() throws Exception {
         final NakadiKpiPublisher publisher = new NakadiKpiPublisher(featureToggleService,
                 jsonProcessor, binaryProcessor, usernameHasher,
-                new EventMetadataTestStub(), uuidGenerator, avroSchema);
+                new EventMetadataTestStub(), avroSchema);
         assertThat(publisher.hash("application"),
                 equalTo("befee725ab2ed3b17020112089a693ad8d8cfbf62b2442dcb5b89d66ce72391e"));
     }
@@ -86,7 +86,7 @@ public class NakadiKpiPublisherTest {
         final var avroSchema = new AvroSchema(new AvroMapper(), new ObjectMapper(), eventTypeRes);
         final NakadiKpiPublisher publisher = new NakadiKpiPublisher(featureToggleService,
                 jsonProcessor, binaryProcessor, usernameHasher,
-                new EventMetadata(new UUIDGenerator()), new UUIDGenerator(), avroSchema);
+                new EventMetadata(new UUIDGenerator()), avroSchema);
         publisher.publishAccessLogEvent("POST",
                 "/test", "", "", "", "",
                 "", 200, 1L, 1L, 1L);


### PR DESCRIPTION
# Experimenting with a Builder for EventMetadata

With the introduction of Avro, Metadata, among other KPI objects, should be serialized to JSON or Avro based on settings. Currently we have two independent implementation for building a Metadata object, one for JSON and one for Avro. The PR attempt to unify this and have a single Metadata builder object that can build either an Avro version or a JSON version as necessary. 