### PR TITLE
Make kafka producer retries setting configurable

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -54,6 +54,7 @@ public class KafkaRepositoryAT extends BaseAT {
     private static final Long DEFAULT_RETENTION_TIME = 100L;
     private static final Long DEFAULT_TOPIC_RETENTION = 100000000L;
     private static final CleanupPolicy DEFAULT_CLEANUP_POLICY = CleanupPolicy.DELETE;
+    private static final int KAFKA_RETRIES = 10;
     private static final int KAFKA_REQUEST_TIMEOUT = 30000;
     private static final int KAFKA_DELIVERY_TIMEOUT = 30000;
     private static final int KAFKA_MAX_BLOCK_TIMEOUT = 5000;
@@ -106,7 +107,7 @@ public class KafkaRepositoryAT extends BaseAT {
                 DEFAULT_CURATOR_MAX_LIFETIME_MS,
                 DEFAULT_CURATOR_ROTATION_MS);
 
-        kafkaSettings = new KafkaSettings(KAFKA_REQUEST_TIMEOUT, KAFKA_BATCH_SIZE, KAFKA_BUFFER_MEMORY,
+        kafkaSettings = new KafkaSettings(KAFKA_RETRIES, KAFKA_REQUEST_TIMEOUT, KAFKA_BATCH_SIZE, KAFKA_BUFFER_MEMORY,
                 KAFKA_LINGER_MS, KAFKA_ENABLE_AUTO_COMMIT, KAFKA_MAX_REQUEST_SIZE,
                 KAFKA_DELIVERY_TIMEOUT, KAFKA_MAX_BLOCK_TIMEOUT, "", KAFKA_COMPRESSION_TYPE);
         zookeeperSettings = new ZookeeperSettings(ZK_SESSION_TIMEOUT, ZK_CONNECTION_TIMEOUT, ZK_MAX_IN_FLIGHT_REQUESTS);

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -55,6 +55,7 @@ nakadi:
     maxConnections: 5
     maxStreamMemoryBytes: 50000000 # ~50 MB
   kafka:
+    retries: 5
     request.timeout.ms: 30000
     instanceType: t2.large
     poll.timeoutMs: 100

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -125,6 +125,7 @@ public class KafkaLocationManager {
         producerProps.put(ProducerConfig.ACKS_CONFIG, "all");
         producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
 
+        producerProps.put(ProducerConfig.RETRIES_CONFIG, kafkaSettings.getRetries());
         producerProps.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, kafkaSettings.getRequestTimeoutMs());
         producerProps.put(ProducerConfig.BUFFER_MEMORY_CONFIG, kafkaSettings.getBufferMemory());
         producerProps.put(ProducerConfig.BATCH_SIZE_CONFIG, kafkaSettings.getBatchSize());

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSettings.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSettings.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class KafkaSettings {
 
+    private final int retries;
     // kafka client requires this property to be int
     // https://github.com/apache/kafka/blob/d9206500bf2f99ce93f6ad64c7a89483100b3b5f/clients/src/main/java/org/apache
     // /kafka/clients/producer/ProducerConfig.java#L261
@@ -25,7 +26,8 @@ public class KafkaSettings {
     private final String compressionType;
 
     @Autowired
-    public KafkaSettings(@Value("${nakadi.kafka.request.timeout.ms}") final int requestTimeoutMs,
+    public KafkaSettings(@Value("${nakadi.kafka.retries}") final int retires,
+                         @Value("${nakadi.kafka.request.timeout.ms}") final int requestTimeoutMs,
                          @Value("${nakadi.kafka.batch.size}") final int batchSize,
                          @Value("${nakadi.kafka.buffer.memory}") final long bufferMemory,
                          @Value("${nakadi.kafka.linger.ms}") final int lingerMs,
@@ -35,6 +37,7 @@ public class KafkaSettings {
                          @Value("${nakadi.kafka.max.block.ms}") final int maxBlockMs,
                          @Value("${nakadi.kafka.client.rack:}") final String clientRack,
                          @Value("${nakadi.kafka.compression.type:lz4}") final String compressionType) {
+        this.retries = retries;
         this.requestTimeoutMs = requestTimeoutMs;
         this.batchSize = batchSize;
         this.bufferMemory = bufferMemory;
@@ -45,6 +48,10 @@ public class KafkaSettings {
         this.maxBlockMs = maxBlockMs;
         this.clientRack = clientRack;
         this.compressionType = compressionType;
+    }
+
+    public int getRetries() {
+        return retries;
     }
 
     public int getRequestTimeoutMs() {

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSettings.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSettings.java
@@ -26,7 +26,7 @@ public class KafkaSettings {
     private final String compressionType;
 
     @Autowired
-    public KafkaSettings(@Value("${nakadi.kafka.retries}") final int retires,
+    public KafkaSettings(@Value("${nakadi.kafka.retries}") final int retries,
                          @Value("${nakadi.kafka.request.timeout.ms}") final int requestTimeoutMs,
                          @Value("${nakadi.kafka.batch.size}") final int batchSize,
                          @Value("${nakadi.kafka.buffer.memory}") final long bufferMemory,


### PR DESCRIPTION
Enabling idempotent producer requires `retries` to be set to a value greater
than 0.  The default value is effectively "endless retries", but we might want
to stop trying earlier, so make it configurable and set it to a small value
for now.
