### PR TITLE
Disable idempotent producer

### DIFF
--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -55,7 +55,7 @@ nakadi:
     maxConnections: 5
     maxStreamMemoryBytes: 50000000 # ~50 MB
   kafka:
-    retries: 5
+    retries: 0
     request.timeout.ms: 30000
     instanceType: t2.large
     poll.timeoutMs: 100

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -123,7 +123,7 @@ public class KafkaLocationManager {
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
                 "org.apache.kafka.common.serialization.ByteArraySerializer");
         producerProps.put(ProducerConfig.ACKS_CONFIG, "all");
-        producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+        producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, false);
 
         producerProps.put(ProducerConfig.RETRIES_CONFIG, kafkaSettings.getRetries());
         producerProps.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, kafkaSettings.getRequestTimeoutMs());


### PR DESCRIPTION
Looks like it has a negative effect on Kafka G1 Old gen usage.