### PR TITLE
Bump zstd library to 1.5.2

### DIFF
--- a/core-common/build.gradle
+++ b/core-common/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     compile "org.apache.avro:avro:1.10.2"
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-avro:2.8.5"
 
-    compile 'com.github.luben:zstd-jni:1.5.0-4'
+    compile 'com.github.luben:zstd-jni:1.5.2-2'
 
     // tests
     testCompile 'org.hamcrest:hamcrest-all:1.3'


### PR DESCRIPTION
According to the release notes https://github.com/facebook/zstd/releases/tag/v1.5.2:

> This release also corrects a performance regression that was introduced in v1.5.0 that slows down compression of very small data when using the streaming API. Issue https://github.com/facebook/zstd/issues/2966 tracks that topic.

Closes #1399