### PR TITLE
Assert equality of JSONObject::toMap instead of similar()

### DIFF
--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaRecordDeserializerTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaRecordDeserializerTest.java
@@ -62,11 +62,11 @@ public class KafkaRecordDeserializerTest {
                 data1
         );
 
-        Assert.assertTrue(
-                getExpectedNode0(null).similar(new JSONObject(new String(deserializedEvent0))));
+        Assert.assertEquals(
+                getExpectedNode0(null).toString(), new JSONObject(new String(deserializedEvent0)).toString());
 
-        Assert.assertTrue(
-                getExpectedNode1().similar(new JSONObject(new String(deserializedEvent1))));
+        Assert.assertEquals(
+                getExpectedNode1().toString(), new JSONObject(new String(deserializedEvent1)).toString());
     }
 
     @Test
@@ -80,7 +80,7 @@ public class KafkaRecordDeserializerTest {
 
         final var actualJson = getSerializedJsonObject(metadataVersion, jsonObject);
         final var expectedJson = getExpectedNode0(jsonObject);
-        Assert.assertTrue(expectedJson.similar(actualJson));
+        Assert.assertEquals(expectedJson.toString(), actualJson.toString());
     }
 
     @Test
@@ -94,7 +94,7 @@ public class KafkaRecordDeserializerTest {
 
         final var actualJson = getSerializedJsonObject(metadataVersion, jsonObject);
         final var expectedJson = getExpectedNode0(jsonObject);
-        Assert.assertTrue(expectedJson.similar(actualJson));
+        Assert.assertEquals(expectedJson.toString(), actualJson.toString());
     }
 
     @Test
@@ -107,7 +107,7 @@ public class KafkaRecordDeserializerTest {
 
         final var actualJson = getSerializedJsonObject(metadataVersion, jsonObject);
         final var expectedJson = getExpectedNode0(jsonObject);
-        Assert.assertTrue(expectedJson.similar(actualJson));
+        Assert.assertEquals(expectedJson.toString(), actualJson.toString());
     }
 
     @Test
@@ -132,8 +132,7 @@ public class KafkaRecordDeserializerTest {
 
         final var actualJson = getSerializedJsonObject(metadataVersion, jsonObject);
         final var expectedJson = getExpectedNode0(jsonObject);
-
-        Assert.assertTrue(expectedJson.similar(actualJson));
+        Assert.assertEquals(expectedJson.toString(), actualJson.toString());
     }
 
     @Test
@@ -148,7 +147,7 @@ public class KafkaRecordDeserializerTest {
 
         final var actualJson = getSerializedJsonObject(metadataVersion, jsonObject);
         final var expectedJson = getExpectedNode0(jsonObject);
-        Assert.assertTrue(expectedJson.similar(actualJson));
+        Assert.assertEquals(expectedJson.toString(), actualJson.toString());
     }
 
     @Test
@@ -186,8 +185,7 @@ public class KafkaRecordDeserializerTest {
 
         final var actualJson = getSerializedJsonObject(metadataVersion, jsonObject);
         final var expectedJson = getBaseExpectedNode(metadataVersion, "0", jsonObject);
-
-        Assert.assertTrue(expectedJson.similar(actualJson));
+        Assert.assertEquals(expectedJson.toString(), actualJson.toString());
     }
 
 

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaRecordDeserializerTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaRecordDeserializerTest.java
@@ -63,10 +63,10 @@ public class KafkaRecordDeserializerTest {
         );
 
         Assert.assertEquals(
-                getExpectedNode0(null).toString(), new JSONObject(new String(deserializedEvent0)).toString());
+                getExpectedNode0(null).toMap(), new JSONObject(new String(deserializedEvent0)).toMap());
 
         Assert.assertEquals(
-                getExpectedNode1().toString(), new JSONObject(new String(deserializedEvent1)).toString());
+                getExpectedNode1().toMap(), new JSONObject(new String(deserializedEvent1)).toMap());
     }
 
     @Test
@@ -80,7 +80,7 @@ public class KafkaRecordDeserializerTest {
 
         final var actualJson = getSerializedJsonObject(metadataVersion, jsonObject);
         final var expectedJson = getExpectedNode0(jsonObject);
-        Assert.assertEquals(expectedJson.toString(), actualJson.toString());
+        Assert.assertEquals(expectedJson.toMap(), actualJson.toMap());
     }
 
     @Test
@@ -94,7 +94,7 @@ public class KafkaRecordDeserializerTest {
 
         final var actualJson = getSerializedJsonObject(metadataVersion, jsonObject);
         final var expectedJson = getExpectedNode0(jsonObject);
-        Assert.assertEquals(expectedJson.toString(), actualJson.toString());
+        Assert.assertEquals(expectedJson.toMap(), actualJson.toMap());
     }
 
     @Test
@@ -107,7 +107,7 @@ public class KafkaRecordDeserializerTest {
 
         final var actualJson = getSerializedJsonObject(metadataVersion, jsonObject);
         final var expectedJson = getExpectedNode0(jsonObject);
-        Assert.assertEquals(expectedJson.toString(), actualJson.toString());
+        Assert.assertEquals(expectedJson.toMap(), actualJson.toMap());
     }
 
     @Test
@@ -132,7 +132,7 @@ public class KafkaRecordDeserializerTest {
 
         final var actualJson = getSerializedJsonObject(metadataVersion, jsonObject);
         final var expectedJson = getExpectedNode0(jsonObject);
-        Assert.assertEquals(expectedJson.toString(), actualJson.toString());
+        Assert.assertEquals(expectedJson.toMap(), actualJson.toMap());
     }
 
     @Test
@@ -147,7 +147,7 @@ public class KafkaRecordDeserializerTest {
 
         final var actualJson = getSerializedJsonObject(metadataVersion, jsonObject);
         final var expectedJson = getExpectedNode0(jsonObject);
-        Assert.assertEquals(expectedJson.toString(), actualJson.toString());
+        Assert.assertEquals(expectedJson.toMap(), actualJson.toMap());
     }
 
     @Test
@@ -185,7 +185,7 @@ public class KafkaRecordDeserializerTest {
 
         final var actualJson = getSerializedJsonObject(metadataVersion, jsonObject);
         final var expectedJson = getBaseExpectedNode(metadataVersion, "0", jsonObject);
-        Assert.assertEquals(expectedJson.toString(), actualJson.toString());
+        Assert.assertEquals(expectedJson.toMap(), actualJson.toMap());
     }
 
 


### PR DESCRIPTION
1. It seems that "similar" is "almost equal".
2. A failing test report is more helpful.