### PR TITLE
use the latest version for metadata

### DIFF
--- a/core-services/src/main/java/org/zalando/nakadi/service/publishing/NakadiKpiPublisher.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/publishing/NakadiKpiPublisher.java
@@ -31,7 +31,7 @@ public class NakadiKpiPublisher {
 
     private static final Logger LOG = LoggerFactory.getLogger(NakadiKpiPublisher.class);
 
-    private static final String VERSION_METADATA = "1";
+    private static final String VERSION_METADATA = "5";
 
     private final FeatureToggleService featureToggleService;
     private final JsonEventProcessor jsonEventsProcessor;


### PR DESCRIPTION
# One-line summary
the metadata used was version 5, so returning it back