### PR TITLE
Fix incorrect schema validation during compatible mode

### DIFF
--- a/core-services/src/main/java/org/zalando/nakadi/service/SchemaService.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/SchemaService.java
@@ -236,7 +236,7 @@ public class SchemaService implements SchemaProviderService {
             throw new SchemaValidationException(
                     "`ordering_instance_ids` field can not be defined without defining `ordering_key_fields`");
         }
-        final JSONObject effectiveSchemaAsJson = jsonSchemaEnrichment.effectiveSchema(eventType, schemaAsJson);
+        final JSONObject effectiveSchemaAsJson = jsonSchemaEnrichment.effectiveSchema(eventType, eventTypeSchema);
         final Schema effectiveSchema = SchemaLoader.load(effectiveSchemaAsJson);
         validateFieldsInSchema("ordering_key_fields", orderingKeyFields, effectiveSchema);
         validateFieldsInSchema("ordering_instance_ids", orderingInstanceIds, effectiveSchema);

--- a/core-services/src/main/java/org/zalando/nakadi/validation/EventValidatorBuilder.java
+++ b/core-services/src/main/java/org/zalando/nakadi/validation/EventValidatorBuilder.java
@@ -31,7 +31,7 @@ public class EventValidatorBuilder {
         }
 
         final Schema schema = SchemaLoader.builder()
-                .schemaJson(loader.effectiveSchema(eventType, new JSONObject(jsonSchema.get().getSchema())))
+                .schemaJson(loader.effectiveSchema(eventType, jsonSchema.get().getSchema()))
                 .addFormatValidator(new RFC3339DateTimeValidator())
                 .build()
                 .load()

--- a/core-services/src/main/java/org/zalando/nakadi/validation/JsonSchemaEnrichment.java
+++ b/core-services/src/main/java/org/zalando/nakadi/validation/JsonSchemaEnrichment.java
@@ -53,8 +53,8 @@ public class JsonSchemaEnrichment {
         }
     }
 
-    public JSONObject effectiveSchema(final EventTypeBase eventType, final JSONObject schema) {
-
+    public JSONObject effectiveSchema(final EventTypeBase eventType, final String schemaString) {
+        final JSONObject schema = new JSONObject(schemaString);
         if (eventType.getCompatibilityMode().equals(CompatibilityMode.COMPATIBLE)) {
             this.enforceStrictValidation(schema);
         }

--- a/core-services/src/test/java/org/zalando/nakadi/service/SchemaServiceTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/SchemaServiceTest.java
@@ -277,7 +277,7 @@ public class SchemaServiceTest {
     }
 
     @Test
-    public void whenSomething() throws Exception {
+    public void testNoExceptionThrownWhenSchemaHasArrayItems() throws Exception {
         final String jsonSchemaString = Resources.toString(
                 Resources.getResource("compatible-additional-item-schema.json"),
                 Charsets.UTF_8);

--- a/core-services/src/test/java/org/zalando/nakadi/service/SchemaServiceTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/SchemaServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mockito;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.zalando.nakadi.cache.EventTypeCache;
 import org.zalando.nakadi.config.NakadiSettings;
+import org.zalando.nakadi.domain.CompatibilityMode;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.EventTypeSchema;
 import org.zalando.nakadi.domain.EventTypeSchemaBase;
@@ -30,6 +31,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.zalando.nakadi.domain.EventCategory.BUSINESS;
@@ -51,7 +53,7 @@ public class SchemaServiceTest {
     public void setUp() throws IOException {
         schemaRepository = Mockito.mock(SchemaRepository.class);
         paginationService = Mockito.mock(PaginationService.class);
-        jsonSchemaEnrichment = Mockito.mock(JsonSchemaEnrichment.class);
+        jsonSchemaEnrichment = new JsonSchemaEnrichment(new DefaultResourceLoader(), "classpath:schema_metadata.json");
         schemaEvolutionService = Mockito.mock(SchemaEvolutionService.class);
         eventTypeRepository = Mockito.mock(EventTypeRepository.class);
         eventTypeCache = Mockito.mock(EventTypeCache.class);
@@ -272,6 +274,18 @@ public class SchemaServiceTest {
         schemaService.getAvroSchemaVersion("nakadi.batch.published", new BatchPublishedEvent().getSchema());
 
         Mockito.reset(schemaRepository);
+    }
+
+    @Test
+    public void whenSomething() throws Exception {
+        final String jsonSchemaString = Resources.toString(
+                Resources.getResource("compatible-additional-item-schema.json"),
+                Charsets.UTF_8);
+
+        eventType.getSchema().setSchema(jsonSchemaString);
+        eventType.setCategory(BUSINESS);
+        eventType.setCompatibilityMode(CompatibilityMode.COMPATIBLE);
+        assertDoesNotThrow(() -> schemaService.validateSchema(eventType));
     }
 
 }

--- a/core-services/src/test/java/org/zalando/nakadi/validation/JsonSchemaEnrichmentTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/validation/JsonSchemaEnrichmentTest.java
@@ -39,7 +39,8 @@ public class JsonSchemaEnrichmentTest {
 
             final EventType eventType = EventTypeTestBuilder.builder().schema(original).build();
 
-            assertThat(description, loader.effectiveSchema(eventType, original.toString()), is(sameJSONObjectAs(effective)));
+            assertThat(description, loader.effectiveSchema(eventType, original.toString()),
+                    is(sameJSONObjectAs(effective)));
         }
     }
 

--- a/core-services/src/test/java/org/zalando/nakadi/validation/JsonSchemaEnrichmentTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/validation/JsonSchemaEnrichmentTest.java
@@ -39,7 +39,7 @@ public class JsonSchemaEnrichmentTest {
 
             final EventType eventType = EventTypeTestBuilder.builder().schema(original).build();
 
-            assertThat(description, loader.effectiveSchema(eventType, original), is(sameJSONObjectAs(effective)));
+            assertThat(description, loader.effectiveSchema(eventType, original.toString()), is(sameJSONObjectAs(effective)));
         }
     }
 

--- a/core-services/src/test/resources/compatible-additional-item-schema.json
+++ b/core-services/src/test/resources/compatible-additional-item-schema.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "some_array": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}


### PR DESCRIPTION
# One-line summary
Internal ticket no: 1146

## Description
Due to a recent change, schema validation was being perfomed on effective schema accidentally. This change fixes the `effectiveSchema()` method so that it does not mutate input parameters.
