### PR TITLE
Reliably track request and response content length

### DIFF
--- a/app/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
+++ b/app/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
@@ -1,5 +1,7 @@
 package org.zalando.nakadi.filters;
 
+import com.google.common.io.CountingInputStream;
+import com.google.common.io.CountingOutputStream;
 import com.google.common.net.HttpHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,10 +18,22 @@ import org.zalando.nakadi.util.FlowIdUtils;
 import javax.servlet.AsyncEvent;
 import javax.servlet.AsyncListener;
 import javax.servlet.FilterChain;
+import javax.servlet.ReadListener;
 import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.OutputStream;
 import java.util.Optional;
 
 public class LoggingFilter extends OncePerRequestFilter {
@@ -40,50 +54,68 @@ public class LoggingFilter extends OncePerRequestFilter {
 
     private class RequestLogInfo {
 
-        private String userAgent;
-        private String user;
-        private String method;
-        private String path;
-        private String query;
-        private String contentEncoding;
-        private Long contentLength;
-        private String acceptEncoding;
-        private Long requestTime;
+        private final RequestWrapper requestWrapper;
+        private final ResponseWrapper responseWrapper;
 
-        private RequestLogInfo(final HttpServletRequest request, final long requestTime) {
-            this.userAgent = Optional.ofNullable(request.getHeader(HttpHeaders.USER_AGENT)).orElse("-");
+        private final String userAgent;
+        private final String user;
+        private final String method;
+        private final String path;
+        private final String query;
+        private final String contentEncoding;
+        private final String acceptEncoding;
+        private final long requestStartedAt;
+
+        private RequestLogInfo(final RequestWrapper requestWrapper, final ResponseWrapper responseWrapper,
+                final long requestStartedAt) {
+
+            this.requestWrapper = requestWrapper;
+            this.responseWrapper = responseWrapper;
+
+            this.userAgent = Optional.ofNullable(requestWrapper.getHeader(HttpHeaders.USER_AGENT)).orElse("-");
             this.user = authorizationService.getSubject().map(Subject::getName).orElse("-");
-            this.method = request.getMethod();
-            this.path = request.getRequestURI();
-            this.query = Optional.ofNullable(request.getQueryString()).map(q -> "?" + q).orElse("");
-            this.contentEncoding = Optional.ofNullable(request.getHeader(HttpHeaders.CONTENT_ENCODING)).orElse("-");
-            this.acceptEncoding = Optional.ofNullable(request.getHeader(HttpHeaders.ACCEPT_ENCODING)).orElse("-");
-            this.contentLength = request.getContentLengthLong() == -1 ? 0 : request.getContentLengthLong();
-            this.requestTime = requestTime;
+            this.method = requestWrapper.getMethod();
+            this.path = requestWrapper.getRequestURI();
+            this.query = Optional.ofNullable(requestWrapper.getQueryString()).map(q -> "?" + q).orElse("");
+            this.contentEncoding = Optional.ofNullable(
+                    requestWrapper.getHeader(HttpHeaders.CONTENT_ENCODING)).orElse("-");
+            this.acceptEncoding = Optional.ofNullable(
+                    requestWrapper.getHeader(HttpHeaders.ACCEPT_ENCODING)).orElse("-");
+
+            this.requestStartedAt = requestStartedAt;
+        }
+
+        private long getRequestLength() {
+            return requestWrapper.getInputStreamBytesCount();
+        }
+
+        private long getResponseLength() {
+            return responseWrapper.getOutputStreamBytesCount();
+        }
+
+        private int getResponseStatus() {
+            return responseWrapper.getStatus();
         }
     }
 
     private class AsyncRequestListener implements AsyncListener {
-        private final HttpServletResponse response;
-        private final String flowId;
         private final RequestLogInfo requestLogInfo;
+        private final String flowId;
 
-        private AsyncRequestListener(final HttpServletRequest request, final HttpServletResponse response,
-                                     final long startTime, final String flowId) {
-            this.response = response;
+        private AsyncRequestListener(final RequestLogInfo requestLogInfo, final String flowId) {
+
+            this.requestLogInfo = requestLogInfo;
             this.flowId = flowId;
-            this.requestLogInfo = new RequestLogInfo(request, startTime);
 
             if (isAccessLogEnabled()) {
-                final Long responseLength = 0L;
                 final Long timeSpentMs = 0L;
-                logToAccessLog(this.requestLogInfo, HttpStatus.PROCESSING.value(), responseLength, timeSpentMs);
+                logToAccessLog(this.requestLogInfo, HttpStatus.PROCESSING.value(), timeSpentMs);
             }
         }
 
         private void logOnEvent() {
             FlowIdUtils.push(this.flowId);
-            logRequest(this.requestLogInfo, this.response);
+            logRequest(this.requestLogInfo);
             FlowIdUtils.clear();
         }
 
@@ -112,44 +144,42 @@ public class LoggingFilter extends OncePerRequestFilter {
     protected void doFilterInternal(final HttpServletRequest request,
                                     final HttpServletResponse response, final FilterChain filterChain)
             throws IOException, ServletException {
+
         final long startTime = System.currentTimeMillis();
-        final RequestLogInfo requestLogInfo = new RequestLogInfo(request, startTime);
+        final RequestWrapper requestWrapper = new RequestWrapper(request);
+        final ResponseWrapper responseWrapper = new ResponseWrapper(response);
+        final RequestLogInfo requestLogInfo = new RequestLogInfo(requestWrapper, responseWrapper, startTime);
         try {
-            filterChain.doFilter(request, response);
+            filterChain.doFilter(requestWrapper, responseWrapper);
             if (request.isAsyncStarted()) {
                 final String flowId = FlowIdUtils.peek();
-                request.getAsyncContext().addListener(new AsyncRequestListener(request, response,
-                        startTime, flowId));
+                request.getAsyncContext().addListener(new AsyncRequestListener(requestLogInfo, flowId));
             }
         } finally {
             if (!request.isAsyncStarted()) {
-                logRequest(requestLogInfo, response);
+                logRequest(requestLogInfo);
             }
         }
     }
 
-    private void logRequest(final RequestLogInfo requestLogInfo, final HttpServletResponse response) {
-        final Long timeSpentMs = System.currentTimeMillis() - requestLogInfo.requestTime;
+    private void logRequest(final RequestLogInfo requestLogInfo) {
+        final Long timeSpentMs = System.currentTimeMillis() - requestLogInfo.requestStartedAt;
 
-        final String responseLengthHeader = response.getHeader(HttpHeaders.CONTENT_LENGTH);
-        final Long responseLength = responseLengthHeader == null ? 0L : Long.valueOf(responseLengthHeader);
-
-        final int statusCode = response.getStatus();
+        final int statusCode = requestLogInfo.getResponseStatus();
         final boolean isServerSideError = statusCode >= 500 || statusCode == 207;
 
         if (isServerSideError || (isAccessLogEnabled() && !isPublishingRequest(requestLogInfo))) {
-            logToAccessLog(requestLogInfo, statusCode, responseLength, timeSpentMs);
+            logToAccessLog(requestLogInfo, statusCode, timeSpentMs);
         }
 
-        logToKpiPublisher(requestLogInfo, statusCode, responseLength, timeSpentMs);
+        logToKpiPublisher(requestLogInfo, statusCode, timeSpentMs);
     }
 
     private boolean isAccessLogEnabled() {
         return featureToggleService.isFeatureEnabled(Feature.ACCESS_LOG_ENABLED);
     }
 
-    private void logToKpiPublisher(final RequestLogInfo requestLogInfo, final int statusCode, final Long responseLength,
-            final Long timeSpentMs) {
+    private void logToKpiPublisher(final RequestLogInfo requestLogInfo, final int statusCode, final Long timeSpentMs) {
 
         nakadiKpiPublisher.publish(() -> new AccessLogEvent()
                 .setMethod(requestLogInfo.method)
@@ -162,12 +192,11 @@ public class LoggingFilter extends OncePerRequestFilter {
                 .setAcceptEncoding(requestLogInfo.acceptEncoding)
                 .setStatusCode(statusCode)
                 .setTimeSpentMs(timeSpentMs)
-                .setRequestLength(requestLogInfo.contentLength)
-                .setResponseLength(responseLength));
+                .setRequestLength(requestLogInfo.getRequestLength())
+                .setResponseLength(requestLogInfo.getResponseLength()));
     }
 
-    private void logToAccessLog(final RequestLogInfo requestLogInfo, final int statusCode, final Long responseLength,
-            final Long timeSpentMs) {
+    private void logToAccessLog(final RequestLogInfo requestLogInfo, final int statusCode, final Long timeSpentMs) {
 
         ACCESS_LOGGER.info("{} \"{}{}\" \"{}\" \"{}\" {} {}ms \"{}\" \"{}\" {}B {}B",
                 requestLogInfo.method,
@@ -179,13 +208,152 @@ public class LoggingFilter extends OncePerRequestFilter {
                 timeSpentMs,
                 requestLogInfo.contentEncoding,
                 requestLogInfo.acceptEncoding,
-                requestLogInfo.contentLength,
-                responseLength);
+                requestLogInfo.getRequestLength(),
+                requestLogInfo.getResponseLength());
     }
 
     private boolean isPublishingRequest(final RequestLogInfo requestLogInfo) {
         return requestLogInfo.path != null && "POST".equals(requestLogInfo.method) &&
                 requestLogInfo.path.startsWith("/event-types/") &&
                 (requestLogInfo.path.endsWith("/events") || requestLogInfo.path.endsWith("/events/"));
+    }
+
+    // ====================================================================================================
+    private static class RequestWrapper extends HttpServletRequestWrapper {
+
+        private ServletInputStreamWrapper inputStream;
+        private BufferedReader reader;
+
+        RequestWrapper(final HttpServletRequest request) {
+            super(request);
+        }
+
+        long getInputStreamBytesCount() {
+            return inputStream != null ? inputStream.getCount() : 0;
+        }
+
+        @Override
+        public ServletInputStream getInputStream() throws IOException {
+            if (inputStream == null) {
+                inputStream = new ServletInputStreamWrapper(super.getInputStream());
+            }
+            return inputStream;
+        }
+
+        @Override
+        public BufferedReader getReader() throws IOException {
+            if (reader == null) {
+                reader = new BufferedReader(new InputStreamReader(getInputStream()));
+            }
+            return reader;
+        }
+    }
+
+    private static class ServletInputStreamWrapper extends ServletInputStream {
+
+        private final CountingInputStream inputStream;
+
+        ServletInputStreamWrapper(final InputStream inputStream) {
+            this.inputStream = new CountingInputStream(inputStream);
+        }
+
+        long getCount() {
+            return inputStream.getCount();
+        }
+
+        @Override
+        public int read() throws IOException {
+            return inputStream.read();
+        }
+
+        @Override
+        public void close() throws IOException {
+            inputStream.close();
+        }
+
+        @Override
+        public boolean isFinished() {
+            try {
+                return inputStream.available() == 0;
+            } catch (final IOException e) {
+                // TODO
+                //LOG.error("Error occurred when reading request input stream", e);
+                return false;
+            }
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(final ReadListener listener) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+    }
+
+    // ====================================================================================================
+    private static class ResponseWrapper extends HttpServletResponseWrapper {
+
+        private ServletOutputStreamWrapper outputStream;
+        private PrintWriter writer;
+
+        ResponseWrapper(final HttpServletResponse response) {
+            super(response);
+        }
+
+        long getOutputStreamBytesCount() {
+            return outputStream != null ? outputStream.getCount() : 0;
+        }
+
+        @Override
+        public ServletOutputStream getOutputStream() throws IOException {
+            if (outputStream == null) {
+                outputStream = new ServletOutputStreamWrapper(super.getOutputStream());
+            }
+            return outputStream;
+        }
+
+        @Override
+        public PrintWriter getWriter() throws IOException {
+            if (writer == null) {
+                writer = new PrintWriter(getOutputStream());
+            }
+            return writer;
+        }
+    }
+
+    private static class ServletOutputStreamWrapper extends ServletOutputStream {
+
+        private final CountingOutputStream outputStream;
+
+        ServletOutputStreamWrapper(final OutputStream outputStream) {
+            this.outputStream = new CountingOutputStream(outputStream);
+        }
+
+        long getCount() {
+            return outputStream.getCount();
+        }
+
+        @Override
+        public void write(final int b) throws IOException {
+            outputStream.write(b);
+        }
+
+        @Override
+        public void close() throws IOException {
+            outputStream.close();
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setWriteListener(final WriteListener listener) {
+            throw new UnsupportedOperationException("Not supported");
+        }
     }
 }

--- a/app/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
+++ b/app/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
@@ -216,7 +216,7 @@ public class LoggingFilter extends OncePerRequestFilter {
     // ====================================================================================================
     private static class RequestWrapper extends HttpServletRequestWrapper {
 
-        private ServletInputStreamWrapper inputStreamWrapper;
+        private CountingInputStreamWrapper inputStreamWrapper;
 
         RequestWrapper(final HttpServletRequest request) {
             super(request);
@@ -229,18 +229,18 @@ public class LoggingFilter extends OncePerRequestFilter {
         @Override
         public ServletInputStream getInputStream() throws IOException {
             if (inputStreamWrapper == null) {
-                inputStreamWrapper = new ServletInputStreamWrapper(super.getInputStream());
+                inputStreamWrapper = new CountingInputStreamWrapper(super.getInputStream());
             }
             return inputStreamWrapper;
         }
     }
 
-    private static class ServletInputStreamWrapper extends ServletInputStream {
+    private static class CountingInputStreamWrapper extends ServletInputStream {
 
         private final ServletInputStream wrappedInputStream;
         private final CountingInputStream countingInputStream;
 
-        ServletInputStreamWrapper(final ServletInputStream wrappedInputStream) {
+        CountingInputStreamWrapper(final ServletInputStream wrappedInputStream) {
             this.wrappedInputStream = wrappedInputStream;
             this.countingInputStream = new CountingInputStream(wrappedInputStream);
         }
@@ -288,7 +288,7 @@ public class LoggingFilter extends OncePerRequestFilter {
     // ====================================================================================================
     private static class ResponseWrapper extends HttpServletResponseWrapper {
 
-        private ServletOutputStreamWrapper outputStreamWrapper;
+        private CountingOutputStreamWrapper outputStreamWrapper;
 
         ResponseWrapper(final HttpServletResponse response) {
             super(response);
@@ -301,18 +301,18 @@ public class LoggingFilter extends OncePerRequestFilter {
         @Override
         public ServletOutputStream getOutputStream() throws IOException {
             if (outputStreamWrapper == null) {
-                outputStreamWrapper = new ServletOutputStreamWrapper(super.getOutputStream());
+                outputStreamWrapper = new CountingOutputStreamWrapper(super.getOutputStream());
             }
             return outputStreamWrapper;
         }
     }
 
-    private static class ServletOutputStreamWrapper extends ServletOutputStream {
+    private static class CountingOutputStreamWrapper extends ServletOutputStream {
 
         private final ServletOutputStream wrappedOutputStream;
         private final CountingOutputStream countingOutputStream;
 
-        ServletOutputStreamWrapper(final ServletOutputStream wrappedOutputStream) {
+        CountingOutputStreamWrapper(final ServletOutputStream wrappedOutputStream) {
             this.wrappedOutputStream = wrappedOutputStream;
             this.countingOutputStream = new CountingOutputStream(wrappedOutputStream);
         }

--- a/app/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
+++ b/app/src/main/java/org/zalando/nakadi/filters/LoggingFilter.java
@@ -237,12 +237,12 @@ public class LoggingFilter extends OncePerRequestFilter {
 
     private static class CountingInputStreamWrapper extends ServletInputStream {
 
-        private final ServletInputStream wrappedInputStream;
+        private final ServletInputStream originalInputStream;
         private final CountingInputStream countingInputStream;
 
-        CountingInputStreamWrapper(final ServletInputStream wrappedInputStream) {
-            this.wrappedInputStream = wrappedInputStream;
-            this.countingInputStream = new CountingInputStream(wrappedInputStream);
+        CountingInputStreamWrapper(final ServletInputStream originalInputStream) {
+            this.originalInputStream = originalInputStream;
+            this.countingInputStream = new CountingInputStream(originalInputStream);
         }
 
         long getCount() {
@@ -271,17 +271,17 @@ public class LoggingFilter extends OncePerRequestFilter {
 
         @Override
         public boolean isFinished() {
-            return wrappedInputStream.isFinished();
+            return originalInputStream.isFinished();
         }
 
         @Override
         public boolean isReady() {
-            return wrappedInputStream.isReady();
+            return originalInputStream.isReady();
         }
 
         @Override
         public void setReadListener(final ReadListener listener) {
-            wrappedInputStream.setReadListener(listener);
+            originalInputStream.setReadListener(listener);
         }
     }
 
@@ -309,12 +309,12 @@ public class LoggingFilter extends OncePerRequestFilter {
 
     private static class CountingOutputStreamWrapper extends ServletOutputStream {
 
-        private final ServletOutputStream wrappedOutputStream;
+        private final ServletOutputStream originalOutputStream;
         private final CountingOutputStream countingOutputStream;
 
-        CountingOutputStreamWrapper(final ServletOutputStream wrappedOutputStream) {
-            this.wrappedOutputStream = wrappedOutputStream;
-            this.countingOutputStream = new CountingOutputStream(wrappedOutputStream);
+        CountingOutputStreamWrapper(final ServletOutputStream originalOutputStream) {
+            this.originalOutputStream = originalOutputStream;
+            this.countingOutputStream = new CountingOutputStream(originalOutputStream);
         }
 
         long getCount() {
@@ -348,12 +348,12 @@ public class LoggingFilter extends OncePerRequestFilter {
 
         @Override
         public boolean isReady() {
-            return wrappedOutputStream.isReady();
+            return originalOutputStream.isReady();
         }
 
         @Override
         public void setWriteListener(final WriteListener listener) {
-            wrappedOutputStream.setWriteListener(listener);
+            originalOutputStream.setWriteListener(listener);
         }
     }
 }


### PR DESCRIPTION
Some user agents set the Content-Length header, but not all.  Use request and
response wrapper class together with counting input/output stream wrappers.