### PR TITLE
More effecient reading of compressed request body

### DIFF
--- a/core-common/src/test/java/org/zalando/nakadi/util/CompressionBodyRequestFilterTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/util/CompressionBodyRequestFilterTest.java
@@ -14,7 +14,7 @@ public class CompressionBodyRequestFilterTest {
         final CompressionBodyRequestFilter.FilterServletRequestWrapper wrapper =
                 new CompressionBodyRequestFilter.FilterServletRequestWrapper(
                         Mockito.mock(Request.class),
-                        (is) -> new ZstdInputStream(
+                        new ZstdInputStream(
                                 CompressionBodyRequestFilterTest.class.getResourceAsStream("event.zstd"))
                 );
 


### PR DESCRIPTION
- Override block reading methods for efficiency
- Delegate `isReady/isFinished/setReadListener` to the wrapped stream