### PR TITLE
Implement `ResourceAuthorizationAttribute.toString()`

### DIFF
--- a/core-common/src/main/java/org/zalando/nakadi/domain/ResourceAuthorizationAttribute.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/ResourceAuthorizationAttribute.java
@@ -51,4 +51,12 @@ public class ResourceAuthorizationAttribute implements AuthorizationAttribute {
         result = 31 * result + (value != null ? value.hashCode() : 0);
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "ResourceAuthorizationAttribute{" +
+                "dataType='" + dataType + '\'' +
+                ", value='" + value + '\'' +
+                '}';
+    }
 }


### PR DESCRIPTION
Sometimes it is logged in the error messages, but provides no insight.