### PR TITLE
Remove duplicate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ Some other useful tasks are:
 - `./gradlew startNakadi`: build Nakadi and start docker-compose services: nakadi, postgresql, zookeeper and kafka
 - `./gradlew stopNakadi`: shutdown docker-compose services
 - `./gradlew startStorages`: start docker-compose services: postgres, zookeeper and kafka (useful for development purposes)
-- `./gradlew stopStorages`: shutdown docker-compose services
 - `./gradlew fullAcceptanceTest`: start Nakadi configured for acceptance tests and run acceptance tests
 
 For working with an IDE, the `eclipse` IDE task is available and you'll be able to import the `build.gradle` into Intellij IDEA directly.

--- a/build.gradle
+++ b/build.gradle
@@ -81,10 +81,6 @@ task startStorages(type: Exec) {
     commandLine "bash", "-c", "./nakadi.sh start-storages"
 }
 
-task stopStorages(type: Exec) {
-    commandLine "bash", "-c", "./nakadi.sh stop-storages"
-}
-
 task checkstyle {
     subprojects.each { dependsOn(":${it.name}:checkstyleMain") }
     subprojects.each { dependsOn(":${it.name}:checkstyleTest") }

--- a/nakadi.sh
+++ b/nakadi.sh
@@ -29,10 +29,6 @@ function startStorages() {
   docker-compose up -d postgres zookeeper kafka
 }
 
-function stopStorages() {
-  docker-compose down
-}
-
 function acceptanceTests() {
   export SPRING_PROFILES_ACTIVE=acceptanceTest
   docker-compose up -d --build


### PR DESCRIPTION
As it is pointed out in #1334, there is an ambiguity between commands. 
`stopStorages` command is removed by this PR. 

closes #1334 