### PR TITLE
Avoid logging stacktrace on streaming exceptions

### DIFF
--- a/api-consumption/src/main/java/org/zalando/nakadi/controller/SubscriptionStreamController.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/controller/SubscriptionStreamController.java
@@ -146,7 +146,13 @@ public class SubscriptionStreamController {
 
         @Override
         public void onException(final Exception ex) {
-            LOG.warn("Exception occurred while streaming", ex);
+            //
+            // Here we are trying to avoid spamming the logs with stacktraces for very common errors like "no free
+            // slots" or "access denied".
+            //
+            // FIXME: maybe these should not be exceptions in the first place?..
+            //
+            LOG.warn("Exception occurred while streaming: {}: {}", ex.getClass().getName(), ex.getMessage());
             if (!headersSent) {
                 headersSent = true;
                 try {


### PR DESCRIPTION
The common cases are spamming the logs with useless stacktraces.
Follow-up on: #1302