### PR TITLE
Use ThreadLocalRandom for partitioning

### DIFF
--- a/core-services/src/main/java/org/zalando/nakadi/partitioning/PartitionResolver.java
+++ b/core-services/src/main/java/org/zalando/nakadi/partitioning/PartitionResolver.java
@@ -12,7 +12,6 @@ import org.zalando.nakadi.exceptions.runtime.PartitioningException;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 
 import static org.zalando.nakadi.domain.EventCategory.UNDEFINED;
 import static org.zalando.nakadi.partitioning.PartitionStrategy.HASH_STRATEGY;
@@ -32,7 +31,7 @@ public class PartitionResolver {
         partitionStrategies = Map.of(
                 HASH_STRATEGY, hashPartitionStrategy,
                 USER_DEFINED_STRATEGY, new UserDefinedPartitionStrategy(),
-                RANDOM_STRATEGY, new RandomPartitionStrategy(new Random())
+                RANDOM_STRATEGY, new RandomPartitionStrategy()
         );
     }
 

--- a/core-services/src/main/java/org/zalando/nakadi/partitioning/RandomPartitionStrategy.java
+++ b/core-services/src/main/java/org/zalando/nakadi/partitioning/RandomPartitionStrategy.java
@@ -5,15 +5,9 @@ import org.zalando.nakadi.domain.NakadiMetadata;
 import org.zalando.nakadi.exceptions.runtime.PartitioningException;
 
 import java.util.List;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class RandomPartitionStrategy implements PartitionStrategy {
-
-    private final Random random;
-
-    public RandomPartitionStrategy(final Random random) {
-        this.random = random;
-    }
 
     @Override
     public String calculatePartition(final BatchItem item, final List<String> orderedPartitions)
@@ -33,7 +27,7 @@ public class RandomPartitionStrategy implements PartitionStrategy {
         if (partitions.size() == 1) {
             return partitions.get(0);
         } else {
-            final int partitionIndex = random.nextInt(partitions.size());
+            final int partitionIndex = ThreadLocalRandom.current().nextInt(partitions.size());
             return partitions.get(partitionIndex);
         }
     }

--- a/core-services/src/test/java/org/zalando/nakadi/partitioning/RandomPartitionStrategyTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/partitioning/RandomPartitionStrategyTest.java
@@ -1,62 +1,17 @@
 package org.zalando.nakadi.partitioning;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Test;
-import org.mockito.Mockito;
-
 import java.util.List;
-import java.util.Random;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.hamcrest.Matchers.isIn;
 
 public class RandomPartitionStrategyTest {
-
     @Test
-    public void whenCalculatePartitionThenRandomGeneratorIsUsedCorrectly() {
-        final List<String> partitions = ImmutableList.of("a", "b", "c", "d", "e", "f", "g", "h");
+    public void selectsPartitionFromTheGivenList() {
+        final RandomPartitionStrategy strategy = new RandomPartitionStrategy();
 
-        final Random randomMock = mock(Random.class);
-        when(randomMock.nextInt(anyInt())).thenReturn(3, 0, 4, 1, 7);
-        final RandomPartitionStrategy strategy = new RandomPartitionStrategy(randomMock);
-
-        final List<String> resolvedPartitions = newArrayList();
-        final int numberOfRuns = 5;
-        for (int run = 0; run < numberOfRuns; run++) {
-            final String resolvedPartition = strategy.getRandomPartition(partitions);
-            resolvedPartitions.add(resolvedPartition);
-        }
-
-        assertThat(resolvedPartitions, equalTo(ImmutableList.of("d", "a", "e", "b", "h")));
-        verify(randomMock, times(5)).nextInt(partitions.size());
-    }
-
-    @Test
-    public void whenOnePartitionThenRandomGeneratorNotUsed() {
-        final Random randomMock = mock(Random.class);
-        final RandomPartitionStrategy strategy = new RandomPartitionStrategy(randomMock);
-
-        final String resolvedPartition = strategy.getRandomPartition(ImmutableList.of("a"));
-        assertThat(resolvedPartition, equalTo("a"));
-
-        verify(randomMock, Mockito.never()).nextInt(anyInt());
-    }
-
-    @Test
-    public void calculatesPartitionsForJsonAndAvro() {
-        final Random randomMock = mock(Random.class);
-        final RandomPartitionStrategy strategy = new RandomPartitionStrategy(randomMock);
-
-        strategy.getRandomPartition(ImmutableList.of("a", "b"));
-        strategy.getRandomPartition(ImmutableList.of("a", "b", "c"));
-
-        verify(randomMock, Mockito.times(1)).nextInt(2);
-        verify(randomMock, Mockito.times(1)).nextInt(3);
+        final List<String> partitions = List.of("a", "b", "c");
+        assertThat(strategy.getRandomPartition(partitions), isIn(partitions));
     }
 }


### PR DESCRIPTION
The `Random` class is synchronized, but we don't need that for our use case.