### PR TITLE
Queue publishing of events for the same key in a batch

### DIFF
--- a/core-common/src/main/java/org/zalando/nakadi/domain/BatchItem.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/BatchItem.java
@@ -65,7 +65,6 @@ public class BatchItem implements Resource<BatchItem> {
     private String[] injectionValues;
     private final List<Integer> skipCharacters;
     private String partition;
-    private String brokerId;
     private String eventKey;
     private List<String> partitionKeys;
     private int eventSize;
@@ -114,15 +113,6 @@ public class BatchItem implements Resource<BatchItem> {
 
     public void setPartition(final String partition) {
         this.partition = partition;
-    }
-
-    @Nullable
-    public String getBrokerId() {
-        return brokerId;
-    }
-
-    public void setBrokerId(final String brokerId) {
-        this.brokerId = brokerId;
     }
 
     @Nullable

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -300,13 +300,13 @@ public class KafkaTopicRepository implements TopicRepository {
             final String topicId, final List<BatchItem> batch, final String eventType, final boolean delete)
             throws EventPublishingException {
 
-        final List<BatchItem> unkeyedEvents =
+        final List<BatchItem> unkeyedItems =
                 batch.stream().filter(item -> item.getEventKey() == null).collect(Collectors.toList());
-        final List<BatchItem> keyedEvents =
+        final List<BatchItem> keyedItems =
                 batch.stream().filter(item -> item.getEventKey() != null).collect(Collectors.toList());
 
-        final List<Collection<BatchItem>> chunks = splitBatchIntoChunksOfUniqueKeys(keyedEvents);
-        chunks.add(0, unkeyedEvents);
+        final List<Collection<BatchItem>> chunks = splitIntoChunksOfUniqueKeys(keyedItems);
+        chunks.add(0, unkeyedItems);
 
         Collection<BatchItem> currentChunk = null;
 
@@ -367,17 +367,11 @@ public class KafkaTopicRepository implements TopicRepository {
      * event for any given key will be seen in the first chunk, the next event for the same key, if any, in the second
      * chunk, and so on.
      */
-    static List<Collection<BatchItem>> splitBatchIntoChunksOfUniqueKeys(final List<BatchItem> batch) {
+    static List<Collection<BatchItem>> splitIntoChunksOfUniqueKeys(final List<BatchItem> keyedItems) {
         final List<Collection<BatchItem>> chunks = new LinkedList<>();
 
-        final Map<String, List<BatchItem>> itemsByKey = //new HashMap<>();
-                batch.stream()
+        final Map<String, List<BatchItem>> itemsByKey = keyedItems.stream()
                 .collect(Collectors.groupingBy(BatchItem::getEventKey));
-        // for (final BatchItem item : batch) {
-        //     itemsByKey
-        //             .computeIfAbsent(item.getEventKey(), k -> new LinkedList<>())
-        //             .add(item);
-        // }
 
         final Set<String> emptyKeys = new HashSet<>();
 

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -370,26 +370,26 @@ public class KafkaTopicRepository implements TopicRepository {
     static List<Collection<BatchItem>> splitIntoChunksOfUniqueKeys(final List<BatchItem> keyedItems) {
         final List<Collection<BatchItem>> chunks = new LinkedList<>();
 
-        final Map<String, List<BatchItem>> itemsByKey = keyedItems.stream()
-                .collect(Collectors.groupingBy(BatchItem::getEventKey));
-
-        final Set<String> emptyKeys = new HashSet<>();
+        final List<Map.Entry<String, List<BatchItem>>> itemsByKey = new LinkedList<>(
+                keyedItems.stream()
+                .collect(Collectors.groupingBy(BatchItem::getEventKey))
+                .entrySet());
 
         while (!itemsByKey.isEmpty()) {
             final Set<BatchItem> chunk = new HashSet<>();
 
-            for (final Map.Entry<String, List<BatchItem>> entry : itemsByKey.entrySet()) {
+            for (int i = 0; i < itemsByKey.size(); ) {
+                final Map.Entry<String, List<BatchItem>> entry = itemsByKey.get(i);
+
                 final List<BatchItem> items = entry.getValue();
                 chunk.add(items.remove(0));
+
                 if (items.isEmpty()) {
-                    emptyKeys.add(entry.getKey());
+                    itemsByKey.remove(i);
+                } else {
+                    ++i;
                 }
             }
-
-            for (final String key : emptyKeys) {
-                itemsByKey.remove(key);
-            }
-            emptyKeys.clear();
 
             chunks.add(chunk);
         }

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -339,7 +339,7 @@ public class KafkaTopicRepository implements TopicRepository {
                         .anyMatch(item -> item.getResponse().getPublishingStatus() == EventPublishingStatus.FAILED);
                 if (atLeastOneFailed) {
                     failUnpublished(topicId, eventType, currentChunk, chunks, "internal error");
-                    throw new EventPublishingException("Internal error publishing message to kafka", topicId, eventType);
+                    throw new EventPublishingException("Internal error when publishing to kafka", topicId, eventType);
                 }
 
                 timeoutMs -= System.currentTimeMillis() - chunkStartTime;

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -398,8 +398,7 @@ public class KafkaTopicRepositoryTest {
                 Set.of(firstItemA, itemB, firstItemC),
                 Set.of(secondItemA, secondItemC));
 
-        final List<Collection<BatchItem>> chunks =
-                KafkaTopicRepository.splitBatchIntoChunksOfUniqueKeys(batch);
+        final List<Collection<BatchItem>> chunks = KafkaTopicRepository.splitIntoChunksOfUniqueKeys(batch);
         assertThat(chunks, equalTo(expectedChunks));
     }
 

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -40,7 +40,6 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -346,63 +346,6 @@ public class KafkaTopicRepositoryTest {
     }
 
     @Test
-    public void splittingOfBatchIntoChunksByKey() {
-        final BatchItem firstItemA = new BatchItem(
-                "{}",
-                BatchItem.EmptyInjectionConfiguration.build(1, true),
-                new BatchItem.InjectionConfiguration[BatchItem.Injection.values().length],
-                Collections.emptyList());
-        firstItemA.setPartition("1");
-        firstItemA.setEventKey("A");
-
-        final BatchItem itemB = new BatchItem(
-                "{}",
-                BatchItem.EmptyInjectionConfiguration.build(1, true),
-                new BatchItem.InjectionConfiguration[BatchItem.Injection.values().length],
-                Collections.emptyList());
-        itemB.setPartition("2");
-        itemB.setEventKey("B");
-
-        final BatchItem secondItemA = new BatchItem(
-                "{}",
-                BatchItem.EmptyInjectionConfiguration.build(1, true),
-                new BatchItem.InjectionConfiguration[BatchItem.Injection.values().length],
-                Collections.emptyList());
-        secondItemA.setPartition("1");
-        secondItemA.setEventKey("A");
-
-        final BatchItem firstItemC = new BatchItem(
-                "{}",
-                BatchItem.EmptyInjectionConfiguration.build(1, true),
-                new BatchItem.InjectionConfiguration[BatchItem.Injection.values().length],
-                Collections.emptyList());
-        firstItemC.setPartition("2");
-        firstItemC.setEventKey("C");
-
-        final BatchItem secondItemC = new BatchItem(
-                "{}",
-                BatchItem.EmptyInjectionConfiguration.build(1, true),
-                new BatchItem.InjectionConfiguration[BatchItem.Injection.values().length],
-                Collections.emptyList());
-        secondItemC.setPartition("2");
-        secondItemC.setEventKey("C");
-
-        final List<BatchItem> batch = new ArrayList<>();
-        batch.add(firstItemA);
-        batch.add(itemB);
-        batch.add(firstItemC);
-        batch.add(secondItemC);
-        batch.add(secondItemA);
-
-        final List<Collection<BatchItem>> expectedChunks = List.of(
-                Set.of(firstItemA, itemB, firstItemC),
-                Set.of(secondItemA, secondItemC));
-
-        final List<Collection<BatchItem>> chunks = KafkaTopicRepository.splitIntoChunksOfUniqueKeys(batch);
-        assertThat(chunks, equalTo(expectedChunks));
-    }
-
-    @Test
     public void whenFirstItemFailsThenSecondItemForTheSameKeyIsAborted() {
         final BatchItem firstItemA = new BatchItem(
                 "{}",

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -56,7 +56,6 @@ import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -302,46 +301,6 @@ public class KafkaTopicRepositoryTest {
             assertThat(item.getResponse().getPublishingStatus(), equalTo(EventPublishingStatus.FAILED));
             assertThat(item.getResponse().getDetail(), equalTo("timed out"));
         }
-    }
-
-    @Test
-    public void whenPartitionLeaderNotFoundTheRestOfTheBatchOk() {
-        final BatchItem firstItem = new BatchItem(
-                "{}",
-                BatchItem.EmptyInjectionConfiguration.build(1, true),
-                new BatchItem.InjectionConfiguration[BatchItem.Injection.values().length],
-                Collections.emptyList());
-        firstItem.setPartition("1");
-
-        final BatchItem secondItem = new BatchItem(
-                "{}",
-                BatchItem.EmptyInjectionConfiguration.build(1, true),
-                new BatchItem.InjectionConfiguration[BatchItem.Injection.values().length],
-                Collections.emptyList());
-        secondItem.setPartition("2");
-
-        final List<BatchItem> batch = new ArrayList<>();
-        batch.add(firstItem);
-        batch.add(secondItem);
-
-        when(kafkaProducer.partitionsFor(EXPECTED_PRODUCER_RECORD.topic())).thenReturn(ImmutableList.of(
-                new PartitionInfo(EXPECTED_PRODUCER_RECORD.topic(), 1, null, null, null),
-                new PartitionInfo(EXPECTED_PRODUCER_RECORD.topic(), 2, NODE, null, null)));
-
-        when(kafkaProducer.send(any(), any())).thenAnswer(invocation -> {
-            final Callback callback = (Callback) invocation.getArguments()[1];
-            callback.onCompletion(null, null);
-            return null;
-        });
-
-        Assert.assertThrows(EventPublishingException.class, () -> {
-            kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(), batch, "random", false);
-        });
-
-        assertThat(firstItem.getResponse().getPublishingStatus(), equalTo(EventPublishingStatus.FAILED));
-        assertThat(firstItem.getResponse().getDetail(), containsString("No leader for partition"));
-
-        assertThat(secondItem.getResponse().getPublishingStatus(), equalTo(EventPublishingStatus.SUBMITTED));
     }
 
     @Test

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -355,14 +355,6 @@ public class KafkaTopicRepositoryTest {
         firstItemA.setPartition("1");
         firstItemA.setEventKey("A");
 
-        final BatchItem itemB = new BatchItem(
-                "{}",
-                BatchItem.EmptyInjectionConfiguration.build(1, true),
-                new BatchItem.InjectionConfiguration[BatchItem.Injection.values().length],
-                Collections.emptyList());
-        itemB.setPartition("2");
-        itemB.setEventKey("B");
-
         final BatchItem secondItemA = new BatchItem(
                 "{}",
                 BatchItem.EmptyInjectionConfiguration.build(1, true),
@@ -371,10 +363,27 @@ public class KafkaTopicRepositoryTest {
         secondItemA.setPartition("1");
         secondItemA.setEventKey("A");
 
+        final BatchItem firstItemB = new BatchItem(
+                "{}",
+                BatchItem.EmptyInjectionConfiguration.build(1, true),
+                new BatchItem.InjectionConfiguration[BatchItem.Injection.values().length],
+                Collections.emptyList());
+        firstItemB.setPartition("2");
+        firstItemB.setEventKey("B");
+
+        final BatchItem secondItemB = new BatchItem(
+                "{}",
+                BatchItem.EmptyInjectionConfiguration.build(1, true),
+                new BatchItem.InjectionConfiguration[BatchItem.Injection.values().length],
+                Collections.emptyList());
+        secondItemB.setPartition("2");
+        secondItemB.setEventKey("B");
+
         final List<BatchItem> batch = new ArrayList<>();
         batch.add(firstItemA);
-        batch.add(itemB);
+        batch.add(firstItemB);
         batch.add(secondItemA);
+        batch.add(secondItemB);
 
         when(kafkaProducer.partitionsFor(EXPECTED_PRODUCER_RECORD.topic())).thenReturn(ImmutableList.of(
                 new PartitionInfo(EXPECTED_PRODUCER_RECORD.topic(), 1, NODE, null, null),
@@ -397,11 +406,13 @@ public class KafkaTopicRepositoryTest {
 
         assertThat(
                 List.of(firstItemA.getResponse().getPublishingStatus(),
-                        itemB.getResponse().getPublishingStatus(),
-                        secondItemA.getResponse().getPublishingStatus()),
+                        firstItemB.getResponse().getPublishingStatus(),
+                        secondItemA.getResponse().getPublishingStatus(),
+                        secondItemB.getResponse().getPublishingStatus()),
                 equalTo(List.of(EventPublishingStatus.FAILED,
                                 EventPublishingStatus.SUBMITTED,
-                                EventPublishingStatus.ABORTED)));
+                                EventPublishingStatus.ABORTED,
+                                EventPublishingStatus.SUBMITTED)));
     }
 
     @Test


### PR DESCRIPTION
When hash partitioning (and/or log compaction) is used this approach ensures
that the order of events is preserved for each key in the face of intermittent
publishing errors.

For now we simply mark any events that were not attempted for publishing as
aborted.  Later this can be improved to implement retry of failed events.

No change of behavior when no event keys are set (random or user-defined
partitioning): the whole batch is submitted as a single chunk.