### PR TITLE
Switch to JRE Eclipse Temurin 11 + Use Zalando Container Registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM container-registry.zalando.net/library/eclipse-temurin-11-jre:latest
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
 MAINTAINER Team Aruha, team-aruha@zalando.de
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/library/openjdk-11-jre-slim:latest
+FROM container-registry.zalando.net/library/eclipse-temurin-11-jre:latest
 
 MAINTAINER Team Aruha, team-aruha@zalando.de
 

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -1,9 +1,11 @@
 version: "2017-09-20"
 pipeline:
   - id: test
-    overlay: ci/java11
     type: script
-    vm: critical-large
+    vm_config:
+      type: linux
+      size: extra_large
+      image: cdp-runtime/jdk11
     commands:
       - desc: Checkstyle
         cmd: |
@@ -12,9 +14,11 @@ pipeline:
         cmd: |
           ./gradlew test --stacktrace
   - id: acceptance-test
-    overlay: ci/java11
     type: script
-    vm: critical-large
+    vm_config:
+      type: linux
+      size: extra_large
+      image: cdp-runtime/jdk11
     commands:
       - desc: Install dependencies
         cmd: |
@@ -26,16 +30,28 @@ pipeline:
         cmd: |
           ./gradlew fullAcceptanceTest --stacktrace
   - id: build-push
-    overlay: ci/java11
     type: script
-    vm: critical-large
+    vm_config:
+      type: linux
+      size: extra_large
+      image: cdp-runtime/jdk11
     commands:
       - desc: Build and push to repo
         cmd: |
           ./gradlew clean app:bootJar
-          IMAGE="registry-write.opensource.zalan.do/aruha/nakadi-oss:${CDP_BUILD_VERSION}"
+          IMAGE="container-registry-test.zalando.net/aruha/nakadi-oss:${CDP_BUILD_VERSION}"
           if [ "$CDP_PULL_REQUEST_NUMBER" ]; then
-            IMAGE="registry-write.opensource.zalan.do/aruha/nakadi-oss-pr:${CDP_BUILD_VERSION}"
+            IMAGE="container-registry-test.zalando.net/aruha/nakadi-oss-pr:${CDP_BUILD_VERSION}"
           fi
-          docker build -t ${IMAGE} .
-          docker push ${IMAGE}
+
+          docker buildx create \
+                --config /etc/cdp-buildkitd.toml \
+                --driver-opt network=host \
+                --name cdpbuildx \
+                --bootstrap \
+                --use
+
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            -t ${IMAGE} \
+            --push .

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -58,7 +58,7 @@ pipeline:
             --platform linux/amd64,linux/arm64 \
             -t ${MULTI_ARCH_IMAGE} \
             --push .
-          cdp-promote-image ${IMAGE}
+          cdp-promote-image ${MULTI_ARCH_IMAGE}
 
           #echo "Building oss image"
           docker build -t ${IMAGE} .

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -39,6 +39,7 @@ pipeline:
       - desc: Build and push to repo
         cmd: |
           ./gradlew clean app:bootJar
+          BASE_IMAGE="container-registry.zalando.net/library/eclipse-temurin-11-jre:latest"
           MULTI_ARCH_IMAGE="container-registry-test.zalando.net/aruha/nakadi-oss:${CDP_BUILD_VERSION}"
           IMAGE="registry-write.opensource.zalan.do/aruha/nakadi-oss:${CDP_BUILD_VERSION}"
           if [ "$CDP_PULL_REQUEST_NUMBER" ]; then
@@ -57,9 +58,10 @@ pipeline:
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
             -t ${MULTI_ARCH_IMAGE} \
+            --build-arg BASE_IMAGE=${BASE_IMAGE} \
             --push .
           cdp-promote-image ${MULTI_ARCH_IMAGE}
 
           #echo "Building oss image"
-          docker build -t ${IMAGE} .
+          docker build -t ${IMAGE} --build-arg BASE_IMAGE=${BASE_IMAGE} .
           docker push ${IMAGE}

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -39,11 +39,14 @@ pipeline:
       - desc: Build and push to repo
         cmd: |
           ./gradlew clean app:bootJar
-          IMAGE="container-registry-test.zalando.net/aruha/nakadi-oss:${CDP_BUILD_VERSION}"
+          MULTI_ARCH_IMAGE="container-registry-test.zalando.net/aruha/nakadi-oss:${CDP_BUILD_VERSION}"
+          IMAGE="registry-write.opensource.zalan.do/aruha/nakadi-oss:${CDP_BUILD_VERSION}"
           if [ "$CDP_PULL_REQUEST_NUMBER" ]; then
-            IMAGE="container-registry-test.zalando.net/aruha/nakadi-oss-pr:${CDP_BUILD_VERSION}"
+            IMAGE="registry-write.opensource.zalan.do/aruha/nakadi-oss-pr:${CDP_BUILD_VERSION}"
+            MULTI_ARCH_IMAGE="container-registry-test.zalando.net/aruha/nakadi-oss-pr:${CDP_BUILD_VERSION}"
           fi
 
+          echo "Building multi-arch image"
           docker buildx create \
                 --config /etc/cdp-buildkitd.toml \
                 --driver-opt network=host \
@@ -55,3 +58,8 @@ pipeline:
             --platform linux/amd64,linux/arm64 \
             -t ${IMAGE} \
             --push .
+          cdp-promote-image ${IMAGE}
+
+          echo "Building oss image"
+          docker build -t ${IMAGE} .
+          docker push ${IMAGE}

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -56,10 +56,10 @@ pipeline:
 
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
-            -t ${IMAGE} \
+            -t ${MULTI_ARCH_IMAGE} \
             --push .
           cdp-promote-image ${IMAGE}
 
-          echo "Building oss image"
+          #echo "Building oss image"
           docker build -t ${IMAGE} .
           docker push ${IMAGE}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,10 @@ version: '3'
 services:
 
   nakadi:
-    build: .
+    build:
+      context: .
+      args:
+        BASE_IMAGE: "registry.opensource.zalan.do/library/openjdk-11-jre-slim:latest"
     ports:
     - "8080:8080"
     depends_on:


### PR DESCRIPTION
Switch to JRE Eclipse Temurin 11 + Use Zalando Container Registry

Add support for multi-arch OCI 