### PR TITLE
Update partition count logic

### DIFF
--- a/api-metastore/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
@@ -106,8 +106,7 @@ public class EventTypeControllerTestCase {
                 NAKADI_POLL_TIMEOUT, NAKADI_SEND_TIMEOUT, 0, NAKADI_EVENT_MAX_BYTES,
                 NAKADI_SUBSCRIPTION_MAX_PARTITIONS, "service", "org/zalando/nakadi", "I am warning you",
                 "I am warning you, even more", "nakadi_archiver", "nakadi_to_s3", 100, 10000);
-        final PartitionsCalculator partitionsCalculator = new KafkaConfig().createPartitionsCalculator(
-                "t2.large", TestUtils.OBJECT_MAPPER, nakadiSettings);
+        final PartitionsCalculator partitionsCalculator = new KafkaConfig().createPartitionsCalculator(nakadiSettings);
         when(timelineService.getTopicRepository((Timeline) any())).thenReturn(topicRepository);
         when(timelineService.getTopicRepository((EventTypeBase) any())).thenReturn(topicRepository);
         when(authorizationService.getSubject()).thenReturn(Optional.empty());

--- a/core-common/build.gradle
+++ b/core-common/build.gradle
@@ -107,9 +107,13 @@ dependencies {
     // tests
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile("org.springframework.boot:spring-boot-starter-validation")
-    testCompile('org.junit.jupiter:junit-jupiter-api:5.5.2') {
+    testCompile('org.junit.jupiter:junit-jupiter:5.7.2') {
         exclude module: "hamcrest-core"
     }
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.7.2'
+    testCompile 'junit:junit:4.13.1'
+
+
     testCompile "org.springframework:spring-test"
     testCompile 'org.springframework.boot:spring-boot-test'
     testCompile 'org.springframework.boot:spring-boot-starter-test'
@@ -120,7 +124,6 @@ dependencies {
         exclude module: "hamcrest-library"
     }
     testCompile 'com.jayway.jsonpath:json-path'
-    testCompile 'junit:junit:4.13.1'
     testRuntime 'org.pegdown:pegdown:1.6.0'
 }
 // end::dependencies[]
@@ -143,6 +146,10 @@ bootJar {
 }
 jar {
     enabled = true
+}
+
+test {
+    useJUnitPlatform()
 }
 
 import com.github.davidmc24.gradle.plugin.avro.GenerateAvroJavaTask

--- a/core-common/src/main/java/org/zalando/nakadi/domain/EventTypeStatistics.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/EventTypeStatistics.java
@@ -69,17 +69,13 @@ public class EventTypeStatistics {
             return false;
         }
         final EventTypeStatistics that = (EventTypeStatistics) o;
-        return Objects.equals(messagesPerMinute, that.messagesPerMinute)
-                && Objects.equals(messageSize, that.messageSize)
-                && Objects.equals(readParallelism, that.readParallelism)
+        return Objects.equals(readParallelism, that.readParallelism)
                 && Objects.equals(writeParallelism, that.writeParallelism);
     }
 
     @Override
     public int hashCode() {
-        int result = messagesPerMinute != null ? messagesPerMinute.hashCode() : 0;
-        result = 31 * result + (messageSize != null ? messageSize.hashCode() : 0);
-        result = 31 * result + (readParallelism != null ? readParallelism.hashCode() : 0);
+        int result = readParallelism != null ? readParallelism.hashCode() : 0;
         result = 31 * result + (writeParallelism != null ? writeParallelism.hashCode() : 0);
         return result;
     }

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaConfig.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaConfig.java
@@ -17,10 +17,7 @@ import java.io.IOException;
 public class KafkaConfig {
 
     @Bean
-    public PartitionsCalculator createPartitionsCalculator(
-            @Value("${nakadi.kafka.instanceType}") final String instanceType,
-            final ObjectMapper objectMapper,
-            final NakadiSettings nakadiSettings) throws IOException {
-        return PartitionsCalculator.load(objectMapper, instanceType, nakadiSettings);
+    public PartitionsCalculator createPartitionsCalculator(final NakadiSettings nakadiSettings) {
+        return PartitionsCalculator.load(nakadiSettings);
     }
 }

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaConfig.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaConfig.java
@@ -1,15 +1,11 @@
 package org.zalando.nakadi.repository.kafka;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 import org.zalando.nakadi.config.NakadiSettings;
 import org.zalando.nakadi.repository.zookeeper.ZookeeperConfig;
-
-import java.io.IOException;
 
 @Configuration
 @Import(ZookeeperConfig.class)

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/PartitionsCalculator.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/PartitionsCalculator.java
@@ -14,7 +14,7 @@ public class PartitionsCalculator {
     }
 
     public int getBestPartitionsCount(final EventTypeStatistics stat) {
-        if (null == stat || stat.getReadParallelism() == 0 && stat.getWriteParallelism() == 0) {
+        if (null == stat || stat.getReadParallelism() <= 0 && stat.getWriteParallelism() <= 0) {
             return defaultPartitionCount;
         }
         final int maxPartitionsDueParallelism = Math.max(stat.getReadParallelism(), stat.getWriteParallelism());

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/PartitionsCalculator.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/PartitionsCalculator.java
@@ -1,188 +1,30 @@
 package org.zalando.nakadi.repository.kafka;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.annotations.VisibleForTesting;
 import org.zalando.nakadi.config.NakadiSettings;
 import org.zalando.nakadi.domain.EventTypeStatistics;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.Objects;
-import java.util.TreeMap;
-import java.util.stream.Stream;
-
 public class PartitionsCalculator {
-    // Contains mapping from message size (in bytes) to list of throughput of kafka with (index + 1) as partition count.
-    private final NavigableMap<Integer, float[]> stats = new TreeMap<>();
     private final int maxPartitionCount;
     private final int defaultPartitionCount;
 
-    private PartitionsCalculator(final InstanceInfo instanceInfo,
-                                 final int defaultPartitionCount,
+    public PartitionsCalculator(final int defaultPartitionCount,
                                  final int maxPartitionCount) {
         this.defaultPartitionCount = defaultPartitionCount;
         this.maxPartitionCount = maxPartitionCount;
-        for (final SpeedStatistics ss : instanceInfo.getStats()) {
-            stats.put(ss.getMessageSize(), ss.getSpeed());
-        }
     }
 
     public int getBestPartitionsCount(final EventTypeStatistics stat) {
-        if (null == stat) {
+        if (null == stat || stat.getReadParallelism() == 0 && stat.getWriteParallelism() == 0) {
             return defaultPartitionCount;
         }
         final int maxPartitionsDueParallelism = Math.max(stat.getReadParallelism(), stat.getWriteParallelism());
-        if (maxPartitionsDueParallelism >= maxPartitionCount) {
-            return maxPartitionCount;
-        }
-        return Math.min(maxPartitionCount, Math.max(
-                maxPartitionsDueParallelism,
-                calculatePartitionsAccordingLoad(stat.getMessagesPerMinute(), stat.getMessageSize())));
 
+        return Math.min(maxPartitionsDueParallelism, maxPartitionCount);
     }
 
-    private int calculatePartitionsAccordingLoad(final int messagesPerMinute, final int avgEventSizeBytes) {
-        final float throughoutputMbPerSec = ((float) messagesPerMinute * (float) avgEventSizeBytes)
-                / (1024.f * 1024.f * 60.f);
-        return getBestPartitionsCount(avgEventSizeBytes, throughoutputMbPerSec);
+    static PartitionsCalculator load(final NakadiSettings nakadiSettings){
+        return new PartitionsCalculator(
+                        nakadiSettings.getDefaultTopicPartitionCount(),
+                        nakadiSettings.getMaxTopicPartitionCount());
     }
-
-    public int getBestPartitionsCount(final int messageSize, final float mbsPerSecond) {
-        final Map.Entry<Integer, float[]> floor = stats.floorEntry(messageSize);
-        final Map.Entry<Integer, float[]> ceil = stats.ceilingEntry(messageSize);
-        if (floor == null) {
-            return getBestPartitionsCount(ceil.getValue(), mbsPerSecond);
-        } else if (ceil == null) {
-            return getBestPartitionsCount(floor.getValue(), mbsPerSecond);
-        } else {
-            final int floorResult = getBestPartitionsCount(floor.getValue(), mbsPerSecond);
-            if (Objects.equals(floor.getKey(), ceil.getKey())) {
-                return floorResult;
-            }
-            final int ceilResult = getBestPartitionsCount(ceil.getValue(), mbsPerSecond);
-            return floorResult + ((ceilResult - floorResult) * (messageSize - floor.getKey())) / (ceil.getKey()
-                    - floor.getKey());
-        }
-    }
-
-    private static int getBestPartitionsCount(final float[] perPartitionThroughput, final float mbsPerSecond) {
-        int nearestIndex = -1;
-        for (int i = 0; i < perPartitionThroughput.length; ++i) {
-            if (mbsPerSecond <= perPartitionThroughput[i]) {
-                return i + 1;
-            }
-            if (nearestIndex == -1 || perPartitionThroughput[nearestIndex] < perPartitionThroughput[i]) {
-                nearestIndex = i;
-            }
-        }
-        return nearestIndex + 1;
-    }
-
-    private static final String PARTITION_STATISTICS = "/partitions_statistics.json";
-
-    private static class SpeedStatistics {
-        private int messageSize;
-        private float[] speed;
-
-        public int getMessageSize() {
-            return messageSize;
-        }
-
-        public void setMessageSize(final int messageSize) {
-            this.messageSize = messageSize;
-        }
-
-        public float[] getSpeed() {
-            return speed;
-        }
-
-        public void setSpeed(final float[] speed) {
-            this.speed = speed;
-        }
-
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            final SpeedStatistics that = (SpeedStatistics) o;
-            return messageSize == that.messageSize && Arrays.equals(speed, that.speed);
-        }
-
-        @Override
-        public int hashCode() {
-            return messageSize;
-        }
-    }
-
-    private static class InstanceInfo {
-        private String name;
-        private SpeedStatistics[] stats;
-
-        public String getName() {
-            return name;
-        }
-
-        public void setName(final String name) {
-            this.name = name;
-        }
-
-        public SpeedStatistics[] getStats() {
-            return stats;
-        }
-
-        public void setStats(final SpeedStatistics[] stats) {
-            this.stats = stats;
-        }
-
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            final InstanceInfo that = (InstanceInfo) o;
-            return name.equals(that.name) && Arrays.equals(stats, that.stats);
-        }
-
-        @Override
-        public int hashCode() {
-            return name.hashCode();
-        }
-    }
-
-    static PartitionsCalculator load(final ObjectMapper objectMapper, final String instanceType,
-                                     final NakadiSettings nakadiSettings)
-            throws IOException {
-        try (InputStream in = PartitionsCalculator.class.getResourceAsStream(PARTITION_STATISTICS)) {
-            if (null == in) {
-                throw new IOException("Resource with name " + PARTITION_STATISTICS + " is not found");
-            }
-            return load(objectMapper, instanceType, in, nakadiSettings.getDefaultTopicPartitionCount(),
-                    nakadiSettings.getMaxTopicPartitionCount());
-        }
-    }
-
-    @VisibleForTesting
-    protected static PartitionsCalculator load(final ObjectMapper objectMapper, final String instanceType,
-                                     final InputStream in, final int defaultPartitionsCount,
-                                     final int maxPartitionCount) throws IOException {
-        final InstanceInfo[] instanceInfos = objectMapper.readValue(in, InstanceInfo[].class);
-        final InstanceInfo instanceInfo = Stream.of(instanceInfos)
-                .filter(ii -> instanceType.equals(ii.getName()))
-                .findAny().orElseThrow(() -> new IllegalArgumentException("Failed to find instance " + instanceType
-                        + " configuration"));
-        return new PartitionsCalculator(instanceInfo, defaultPartitionsCount, maxPartitionCount);
-    }
-
 }

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/PartitionsCalculatorTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/PartitionsCalculatorTest.java
@@ -33,6 +33,9 @@ public class PartitionsCalculatorTest {
     static Stream<Arguments> partitionTestCases() {
         // readParallelism, writeParallelism, expectedBestPartitionCount
         return Stream.of(
+                arguments(0, -1, 1),
+                arguments(-1, 0, 1),
+                arguments(-1, -1, 1),
                 arguments(0, 0, 1),
                 arguments(2, 2, 2),
                 arguments(2, 3, 3),

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/PartitionsCalculatorTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/PartitionsCalculatorTest.java
@@ -20,8 +20,9 @@ public class PartitionsCalculatorTest {
 
     @ParameterizedTest
     @MethodSource("partitionTestCases")
-    public void test(int readParallelism, int writeParallelism,
-                                          int expectedBestPartitionCount) {
+    public void test(final int readParallelism,
+                     final int writeParallelism,
+                     final int expectedBestPartitionCount) {
         final PartitionsCalculator calculator = buildTest();
         final EventTypeStatistics statistics = new EventTypeStatistics();
         statistics.setReadParallelism(readParallelism);

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/PartitionsCalculatorTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/PartitionsCalculatorTest.java
@@ -1,108 +1,43 @@
 package org.zalando.nakadi.repository.kafka;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.zalando.nakadi.domain.EventTypeStatistics;
-import org.zalando.nakadi.utils.TestUtils;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.util.stream.Stream;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class PartitionsCalculatorTest {
 
     private static final int MAX_PARTITION_COUNT = 1000;
 
-    private static PartitionsCalculator buildTest() throws IOException {
-        return PartitionsCalculator.load(TestUtils.OBJECT_MAPPER, "t2.large", getTestStream(), 0, MAX_PARTITION_COUNT);
+    private static PartitionsCalculator buildTest() {
+        return new PartitionsCalculator(1, MAX_PARTITION_COUNT);
     }
 
-    private static InputStream getTestStream() {
-        return PartitionsCalculator.class.getResourceAsStream("test_partitions_statistics.json");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testLoadFailForUnknownName() throws IOException {
-        PartitionsCalculator.load(TestUtils.OBJECT_MAPPER, "null", getTestStream(), 0, 1000);
-    }
-
-    @Test
-    public void testLoadCorrectForCorrectName() throws IOException {
-        for (final String name : new String[]{"t2.large", "c4.xlarge"}) {
-            final PartitionsCalculator calculatorMap = PartitionsCalculator.load(TestUtils.OBJECT_MAPPER, name,
-                    getTestStream(), 0, MAX_PARTITION_COUNT);
-            assertThat(calculatorMap, notNullValue());
-        }
-    }
-
-    @Test
-    public void ensureCorrectValuesReturnedForSimpleCase() throws IOException {
-        final PartitionsCalculator calculator = buildTest();
-        // 48.12, 74.83, 92.89, 84.69, 91.19, 94.22, 88.34, 86.35
-        assertThat(calculator.getBestPartitionsCount(1000, 48.12f), equalTo(1));
-        assertThat(calculator.getBestPartitionsCount(1000, 48.13f), equalTo(2));
-        assertThat(calculator.getBestPartitionsCount(1000, 74.82f), equalTo(2));
-        assertThat(calculator.getBestPartitionsCount(1000, 74.84f), equalTo(3));
-        assertThat(calculator.getBestPartitionsCount(1000, 92.88f), equalTo(3));
-        assertThat(calculator.getBestPartitionsCount(1000, 92.90f), equalTo(6));
-        // ensure that we will try our best to perform task.
-        assertThat(calculator.getBestPartitionsCount(1000, 100.f), equalTo(6));
-    }
-
-    @Test
-    public void ensureCorrectValuesReturnedForCentralCase() throws IOException {
-        final PartitionsCalculator calculator = buildTest();
-        final int testCaseCount = 100;
-        for (int i = 0; i < testCaseCount; ++i) {
-            final float mbsPerSecond = (100.f * i) / testCaseCount;
-            final int countLower = calculator.getBestPartitionsCount(100, mbsPerSecond);
-            final int countUpper = calculator.getBestPartitionsCount(1000, mbsPerSecond);
-            final int countBetween = calculator.getBestPartitionsCount(550, mbsPerSecond);
-            if (countLower > countUpper) {
-                assertThat(countBetween, lessThanOrEqualTo(countLower));
-                assertThat(countBetween, greaterThanOrEqualTo(countUpper));
-            } else {
-                assertThat(countBetween, lessThanOrEqualTo(countUpper));
-                assertThat(countBetween, greaterThanOrEqualTo(countLower));
-            }
-        }
-    }
-
-    @Test
-    public void testSmallSizes() throws IOException {
-        final PartitionsCalculator calculator = buildTest();
-        // 25.27, 24.69, 25.48, 25.59, 24.95, 25.12, 25.17, 25.93
-        assertThat(calculator.getBestPartitionsCount(0, 22.f), equalTo(1));
-        assertThat(calculator.getBestPartitionsCount(0, 25.27f), equalTo(1));
-        assertThat(calculator.getBestPartitionsCount(0, 25.28f), equalTo(3));
-        assertThat(calculator.getBestPartitionsCount(0, 26.f), equalTo(8));
-    }
-
-    @Test
-    public void testLargeSizes() throws IOException {
-        final PartitionsCalculator calculator = buildTest();
-        // 35.34, 55.52, 57.14, 76.96, 89.56, 97.54, 94.73, 96.69
-        assertThat(calculator.getBestPartitionsCount(200000, 22.f), equalTo(1));
-        assertThat(calculator.getBestPartitionsCount(200000, 35.36f), equalTo(2));
-        assertThat(calculator.getBestPartitionsCount(200000, 57.f), equalTo(3));
-        assertThat(calculator.getBestPartitionsCount(200000, 96.f), equalTo(6));
-        assertThat(calculator.getBestPartitionsCount(200000, 100.f), equalTo(6));
-    }
-
-    @Test
-    public void testIntegerOverflowOnStatisticsCalculation() throws IOException {
+    @ParameterizedTest
+    @MethodSource("partitionTestCases")
+    public void test(int readParallelism, int writeParallelism,
+                                          int expectedBestPartitionCount) {
         final PartitionsCalculator calculator = buildTest();
         final EventTypeStatistics statistics = new EventTypeStatistics();
-        statistics.setReadParallelism(1);
-        statistics.setWriteParallelism(1);
-        statistics.setMessagesPerMinute(1000000000);
-        statistics.setMessageSize(1000000000);
-        Assert.assertThat(calculator.getBestPartitionsCount(statistics), equalTo(6));
+        statistics.setReadParallelism(readParallelism);
+        statistics.setWriteParallelism(writeParallelism);
+        Assertions.assertEquals(calculator.getBestPartitionsCount(statistics), expectedBestPartitionCount);
+    }
+
+    static Stream<Arguments> partitionTestCases() {
+        // readParallelism, writeParallelism, expectedBestPartitionCount
+        return Stream.of(
+                arguments(0, 0, 1),
+                arguments(2, 2, 2),
+                arguments(2, 3, 3),
+                arguments(3, 2, 3),
+                arguments(2000, 100, MAX_PARTITION_COUNT)
+        );
     }
 
 }


### PR DESCRIPTION
# One-line summary
Remove partition count logic that depended on messagePerMinute and messageSize from default statistics