### PR TITLE
Quickfix for an edge case where repartition breaks

### DIFF
--- a/core-services/src/main/java/org/zalando/nakadi/service/timeline/TimelineService.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/timeline/TimelineService.java
@@ -158,7 +158,7 @@ public class TimelineService {
     public void updateTimeLineForRepartition(final EventType eventType, final int partitions)
             throws NakadiBaseException {
         for (final Timeline timeline : getActiveTimelinesOrdered(eventType.getName())) {
-            getTopicRepository(eventType).repartition(timeline.getTopic(), partitions);
+            getTopicRepository(timeline.getStorage()).repartition(timeline.getTopic(), partitions);
         }
 
         for (final Timeline timeline : getActiveTimelinesOrdered(eventType.getName())) {

--- a/core-services/src/test/java/org/zalando/nakadi/service/timeline/TimelineServiceTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/timeline/TimelineServiceTest.java
@@ -1,6 +1,7 @@
 package org.zalando.nakadi.service.timeline;
 
 import com.google.common.collect.ImmutableList;
+import org.assertj.core.util.Lists;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -177,4 +178,44 @@ public class TimelineServiceTest {
         timelineService.createTimeline("et1", "st1");
     }
 
+    @Test
+    public void whenRepartitioningEventTypeThenOk() {
+        final EventType eventType = buildDefaultEventType();
+
+        final Timeline t1 = Timeline.createTimeline(eventType.getName(), 1, null, "topic1", new Date());
+        t1.setSwitchedAt(new Date());
+        t1.setDeleted(true);
+
+        final Storage s1 = new Storage();
+        s1.setId("live");
+        s1.setType(Storage.Type.KAFKA);
+        final Timeline t2 = Timeline.createTimeline(eventType.getName(), 2, s1, "topic2", new Date());
+        t2.setSwitchedAt(new Date());
+        t2.setLatestPosition(new Timeline.KafkaStoragePosition(Lists.newArrayList(1l)));
+
+        final Storage s2 = new Storage();
+        s2.setId("backup");
+        s2.setType(Storage.Type.KAFKA);
+        final Timeline t3 = Timeline.createTimeline(eventType.getName(), 3, s2, "topic3", new Date());
+        t3.setSwitchedAt(new Date());
+        t3.setLatestPosition(new Timeline.KafkaStoragePosition(Lists.newArrayList(2l)));
+
+        final TopicRepository topicRepository1 = mock(TopicRepository.class);
+        final TopicRepository topicRepository2 = mock(TopicRepository.class);
+
+        when(eventTypeCache.getTimelinesOrdered(eventType.getName()))
+                .thenReturn(ImmutableList.of(t1, t2, t3));
+        when(topicRepositoryHolder.getTopicRepository(s1))
+                .thenReturn(topicRepository1);
+        when(topicRepositoryHolder.getTopicRepository(s2))
+                .thenReturn(topicRepository2);
+
+        timelineService.updateTimeLineForRepartition(eventType, 2);
+
+        Mockito.verify(topicRepository1, Mockito.times(1)).repartition("topic2", 2);
+        Mockito.verify(topicRepository2, Mockito.times(1)).repartition("topic3", 2);
+
+        Assert.assertEquals("[1, -1]", t2.getLatestPosition().toDebugString());
+        Assert.assertEquals("[2, -1]", t3.getLatestPosition().toDebugString());
+    }
 }

--- a/core-services/src/test/java/org/zalando/nakadi/service/timeline/TimelineServiceTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/timeline/TimelineServiceTest.java
@@ -179,7 +179,7 @@ public class TimelineServiceTest {
     }
 
     @Test
-    public void whenRepartitioningEventTypeThenOk() {
+    public void shouldRepartitionEventTypeToAnotherStorage() {
         final EventType eventType = buildDefaultEventType();
 
         final Timeline t1 = Timeline.createTimeline(eventType.getName(), 1, null, "topic1", new Date());

--- a/core-services/src/test/java/org/zalando/nakadi/service/timeline/TimelineServiceTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/timeline/TimelineServiceTest.java
@@ -198,7 +198,6 @@ public class TimelineServiceTest {
         s2.setType(Storage.Type.KAFKA);
         final Timeline t3 = Timeline.createTimeline(eventType.getName(), 3, s2, "topic3", new Date());
         t3.setSwitchedAt(new Date());
-        t3.setLatestPosition(new Timeline.KafkaStoragePosition(Lists.newArrayList(2l)));
 
         final TopicRepository topicRepository1 = mock(TopicRepository.class);
         final TopicRepository topicRepository2 = mock(TopicRepository.class);
@@ -216,6 +215,5 @@ public class TimelineServiceTest {
         Mockito.verify(topicRepository2, Mockito.times(1)).repartition("topic3", 2);
 
         Assert.assertEquals("[1, -1]", t2.getLatestPosition().toDebugString());
-        Assert.assertEquals("[2, -1]", t3.getLatestPosition().toDebugString());
     }
 }


### PR DESCRIPTION
When there are multiple active timelines across different Kafka clusters, repartitioning breaks.