### PR TITLE
fix log message for commits in the future

### DIFF
--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java
@@ -186,7 +186,7 @@ class PartitionData {
     CommitResult onCommitOffset(final NakadiCursor offset) {
         boolean seekKafka = false;
         if (comparator.compare(offset, sentOffset) > 0) {
-            LOG.error("Commit in future: new: {}, sent: {}, committed: {}. Will skip sending obsolete data", offset, sentOffset,
+            LOG.error("Commit in future: received: {}, sent: {}, committed: {}. Will skip sending obsolete data", offset, sentOffset,
                     commitOffset);
             seekKafka = true;
             sentOffset = offset;

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/PartitionData.java
@@ -186,7 +186,7 @@ class PartitionData {
     CommitResult onCommitOffset(final NakadiCursor offset) {
         boolean seekKafka = false;
         if (comparator.compare(offset, sentOffset) > 0) {
-            LOG.error("Commit in future: current: {}, committed {} will skip sending obsolete data", sentOffset,
+            LOG.error("Commit in future: new: {}, sent: {}, committed: {}. Will skip sending obsolete data", offset, sentOffset,
                     commitOffset);
             seekKafka = true;
             sentOffset = offset;


### PR DESCRIPTION
# One-line summary

Extend log message to include the offset just compared.

## Description

@tanvir002700 noted in an internal chat a situation (running Nakadi locally)
where this error message is raised. When trying to look into it, I noticed that the
offset printed as part of the error message is not too helpful:
Nakadi is comparing `offset` and `sentOffset`, but was logging `sentOffset` and `commitOffset`.

This PR adds `offset` to the log message, hopefully making it easier to debug problems when this occurs.

## Review
- [x] Tests
- [x] Documentation

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
