### PR TITLE
metrics to measure paritioning keys per batch

### DIFF
--- a/core-common/src/main/java/org/zalando/nakadi/metrics/NakadiMetricsModule.java
+++ b/core-common/src/main/java/org/zalando/nakadi/metrics/NakadiMetricsModule.java
@@ -76,6 +76,8 @@ public class NakadiMetricsModule extends Module {
             final Snapshot snapshot = histogram.getSnapshot();
             json.writeNumberField("count", histogram.getCount());
             json.writeNumberField("mean", snapshot.getMean());
+            json.writeNumberField("max", snapshot.getMax());
+            json.writeNumberField("min", snapshot.getMin());
 
             if (showSamples) {
                 json.writeObjectField("values", snapshot.getValues());

--- a/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventPublisherTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventPublisherTest.java
@@ -1,5 +1,6 @@
 package org.zalando.nakadi.service.publishing;
 
+import com.codahale.metrics.MetricRegistry;
 import org.apache.avro.specific.SpecificRecord;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -108,7 +109,8 @@ public class EventPublisherTest {
 
         eventOwnerExtractorFactory = mock(EventOwnerExtractorFactory.class);
         publisher = new EventPublisher(timelineService, cache, partitionResolver, enrichment,
-                nakadiSettings, timelineSync, authzValidator, eventOwnerExtractorFactory);
+                nakadiSettings, timelineSync, authzValidator, eventOwnerExtractorFactory,
+                mock(MetricRegistry.class));
     }
 
     @Test

--- a/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventPublisherTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventPublisherTest.java
@@ -110,7 +110,7 @@ public class EventPublisherTest {
         eventOwnerExtractorFactory = mock(EventOwnerExtractorFactory.class);
         publisher = new EventPublisher(timelineService, cache, partitionResolver, enrichment,
                 nakadiSettings, timelineSync, authzValidator, eventOwnerExtractorFactory,
-                mock(MetricRegistry.class));
+                new MetricRegistry());
     }
 
     @Test


### PR DESCRIPTION
# One-line summary

Measure how many partitioning keys are published per batch. It should help to understand the latencies in case Nakadi publishes events by keys in order (sequential)