### PR TITLE
Revert "metrics to measure paritioning keys per batch (#1478)"

### DIFF
--- a/core-common/src/main/java/org/zalando/nakadi/metrics/NakadiMetricsModule.java
+++ b/core-common/src/main/java/org/zalando/nakadi/metrics/NakadiMetricsModule.java
@@ -76,8 +76,6 @@ public class NakadiMetricsModule extends Module {
             final Snapshot snapshot = histogram.getSnapshot();
             json.writeNumberField("count", histogram.getCount());
             json.writeNumberField("mean", snapshot.getMean());
-            json.writeNumberField("max", snapshot.getMax());
-            json.writeNumberField("min", snapshot.getMin());
 
             if (showSamples) {
                 json.writeObjectField("values", snapshot.getValues());

--- a/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventPublisherTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventPublisherTest.java
@@ -1,6 +1,5 @@
 package org.zalando.nakadi.service.publishing;
 
-import com.codahale.metrics.MetricRegistry;
 import org.apache.avro.specific.SpecificRecord;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -32,7 +31,6 @@ import org.zalando.nakadi.exceptions.runtime.EventTypeTimeoutException;
 import org.zalando.nakadi.exceptions.runtime.PartitioningException;
 import org.zalando.nakadi.kpi.event.NakadiAccessLog;
 import org.zalando.nakadi.mapper.NakadiRecordMapper;
-import org.zalando.nakadi.metrics.EventTypeMetricRegistry;
 import org.zalando.nakadi.partitioning.PartitionResolver;
 import org.zalando.nakadi.partitioning.PartitionStrategy;
 import org.zalando.nakadi.plugin.api.authz.Resource;
@@ -97,9 +95,7 @@ public class EventPublisherTest {
             NAKADI_POLL_TIMEOUT, NAKADI_SEND_TIMEOUT, TIMELINE_WAIT_TIMEOUT_MS, NAKADI_EVENT_MAX_BYTES,
             NAKADI_SUBSCRIPTION_MAX_PARTITIONS, "service", "org/zalando/nakadi", "", "",
             "nakadi_archiver", "nakadi_to_s3", 100, 10000);
-
     protected EventOwnerExtractorFactory eventOwnerExtractorFactory;
-    protected EventTypeMetricRegistry eventTypeMetricRegistry;
     protected EventPublisher publisher;
 
     @Before
@@ -111,11 +107,8 @@ public class EventPublisherTest {
         Mockito.when(timelineService.getActiveTimeline(any(EventType.class))).thenReturn(timeline);
 
         eventOwnerExtractorFactory = mock(EventOwnerExtractorFactory.class);
-        eventTypeMetricRegistry = new EventTypeMetricRegistry(new MetricRegistry());
-
         publisher = new EventPublisher(timelineService, cache, partitionResolver, enrichment,
-                nakadiSettings, timelineSync, authzValidator, eventOwnerExtractorFactory,
-                eventTypeMetricRegistry);
+                nakadiSettings, timelineSync, authzValidator, eventOwnerExtractorFactory);
     }
 
     @Test


### PR DESCRIPTION
This reverts commit 88ce0b1963336c3b7bb5f96b3e249db0921b9bb5 and 980f874af13fa1e796224d5863e460d91def0140, because test of the metrics was done and they are not needed anymore
