### PR TITLE
respond 'bad request' if content is not gzip

### DIFF
--- a/core-common/src/main/java/org/zalando/nakadi/util/CompressionBodyRequestFilter.java
+++ b/core-common/src/main/java/org/zalando/nakadi/util/CompressionBodyRequestFilter.java
@@ -2,10 +2,9 @@ package org.zalando.nakadi.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.luben.zstd.ZstdInputStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpMethod;
 import org.zalando.problem.Problem;
+import org.zalando.problem.Status;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -25,13 +24,12 @@ import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.util.Optional;
 import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipException;
 
 import static org.springframework.http.HttpHeaders.CONTENT_ENCODING;
 import static org.zalando.problem.Status.NOT_ACCEPTABLE;
 
 public class CompressionBodyRequestFilter implements Filter {
-
-    private static final Logger LOG = LoggerFactory.getLogger(CompressionBodyRequestFilter.class);
 
     private final ObjectMapper objectMapper;
 
@@ -46,32 +44,35 @@ public class CompressionBodyRequestFilter implements Filter {
             throws IOException, ServletException {
 
         HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
 
         final Optional<String> contentEncodingOpt = Optional.ofNullable(
                 request.getHeader(CONTENT_ENCODING));
         if (contentEncodingOpt.isPresent() && !HttpMethod.POST.matches(request.getMethod())) {
-            reportNotAcceptableError((HttpServletResponse) servletResponse, request);
+            respondWithError(response, Problem.valueOf(NOT_ACCEPTABLE,
+                    request.getMethod() + " method doesn't support gzip content encoding"));
             return;
         } else if (contentEncodingOpt.isPresent()) {
             final String contentEncoding = contentEncodingOpt.get();
             if (contentEncoding.contains("gzip")) {
-                request = new FilterServletRequestWrapper(request, new GZIPInputStream(request.getInputStream()));
-            } else if (contentEncoding.contains("zstd")) {
+                try {
+                    request = new FilterServletRequestWrapper(request, new GZIPInputStream(request.getInputStream()));
+                } catch (ZipException ze) {
+                    respondWithError(response, Problem.valueOf(Status.BAD_REQUEST, ze.getMessage()));
+                    return;
+                }
+            } else if (contentEncoding.contains("zstd"))
                 request = new FilterServletRequestWrapper(request, new ZstdInputStream(request.getInputStream()));
-            }
         }
 
         chain.doFilter(request, servletResponse);
     }
 
-    private void reportNotAcceptableError(final HttpServletResponse response,
-                                          final HttpServletRequest request)
+    private void respondWithError(final HttpServletResponse response,
+                                  final Problem problem)
             throws IOException {
-
-        response.setStatus(NOT_ACCEPTABLE.getStatusCode());
+        response.setStatus(problem.getStatus().getStatusCode());
         final PrintWriter writer = response.getWriter();
-        final Problem problem = Problem.valueOf(NOT_ACCEPTABLE,
-                request.getMethod() + " method doesn't support gzip content encoding");
         writer.write(objectMapper.writeValueAsString(problem));
         writer.close();
     }

--- a/core-common/src/main/java/org/zalando/nakadi/util/CompressionBodyRequestFilter.java
+++ b/core-common/src/main/java/org/zalando/nakadi/util/CompressionBodyRequestFilter.java
@@ -44,7 +44,7 @@ public class CompressionBodyRequestFilter implements Filter {
             throws IOException, ServletException {
 
         HttpServletRequest request = (HttpServletRequest) servletRequest;
-        HttpServletResponse response = (HttpServletResponse) servletResponse;
+        final HttpServletResponse response = (HttpServletResponse) servletResponse;
 
         final Optional<String> contentEncodingOpt = Optional.ofNullable(
                 request.getHeader(CONTENT_ENCODING));
@@ -57,12 +57,13 @@ public class CompressionBodyRequestFilter implements Filter {
             if (contentEncoding.contains("gzip")) {
                 try {
                     request = new FilterServletRequestWrapper(request, new GZIPInputStream(request.getInputStream()));
-                } catch (ZipException ze) {
+                } catch (final ZipException ze) {
                     respondWithError(response, Problem.valueOf(Status.BAD_REQUEST, ze.getMessage()));
                     return;
                 }
-            } else if (contentEncoding.contains("zstd"))
+            } else if (contentEncoding.contains("zstd")) {
                 request = new FilterServletRequestWrapper(request, new ZstdInputStream(request.getInputStream()));
+            }
         }
 
         chain.doFilter(request, servletResponse);

--- a/core-common/src/test/java/org/zalando/nakadi/util/CompressionBodyRequestFilterTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/util/CompressionBodyRequestFilterTest.java
@@ -1,11 +1,23 @@
 package org.zalando.nakadi.util;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.luben.zstd.ZstdInputStream;
+import org.apache.http.HttpStatus;
 import org.eclipse.jetty.server.Request;
 import org.json.JSONArray;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.zalando.problem.Problem;
+import org.zalando.problem.ProblemModule;
+import org.zalando.problem.Status;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 public class CompressionBodyRequestFilterTest {
 
@@ -23,4 +35,26 @@ public class CompressionBodyRequestFilterTest {
 
         Assert.assertEquals(1, array.length());
     }
+
+    @Test
+    public void shouldRespondBadRequestIfContentIsNotGZIP() throws ServletException, IOException {
+        var request = new MockHttpServletRequest();
+        request.addHeader(HttpHeaders.CONTENT_ENCODING, "gzip");
+        request.setMethod("POST");
+        request.setContent("that's test data is not GZIP".getBytes(StandardCharsets.UTF_8));
+
+        var response = new MockHttpServletResponse();
+
+        var objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new ProblemModule());
+
+        new CompressionBodyRequestFilter(objectMapper)
+                .doFilter(request, response, null);
+
+        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatus());
+        Assert.assertEquals(
+                objectMapper.writeValueAsString(Problem.valueOf(Status.BAD_REQUEST, "Not in GZIP format")),
+                response.getContentAsString());
+    }
+
 }

--- a/core-common/src/test/java/org/zalando/nakadi/util/CompressionBodyRequestFilterTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/util/CompressionBodyRequestFilterTest.java
@@ -38,14 +38,14 @@ public class CompressionBodyRequestFilterTest {
 
     @Test
     public void shouldRespondBadRequestIfContentIsNotGZIP() throws ServletException, IOException {
-        var request = new MockHttpServletRequest();
+        final var request = new MockHttpServletRequest();
         request.addHeader(HttpHeaders.CONTENT_ENCODING, "gzip");
         request.setMethod("POST");
         request.setContent("that's test data is not GZIP".getBytes(StandardCharsets.UTF_8));
 
-        var response = new MockHttpServletResponse();
+        final var response = new MockHttpServletResponse();
 
-        var objectMapper = new ObjectMapper();
+        final var objectMapper = new ObjectMapper();
         objectMapper.registerModule(new ProblemModule());
 
         new CompressionBodyRequestFilter(objectMapper)


### PR DESCRIPTION
at the moment nakadi throws 503 in case content encoding is set to gzip and the content is not gzip format. the commit changes the behaviour that nakadi responds with 400 in case of the content is not gzip format. it is harder to achieve for zstd because zstdinput stream does not validate the content on the start, the desicion is to keep it (the pubslishing will fail and user connection will be abrupted)