### PR TITLE
Multiple active Kafka producers

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -47,6 +47,7 @@ public class KafkaRepositoryAT extends BaseAT {
     private static final int ZK_SESSION_TIMEOUT = 30000;
     private static final int ZK_CONNECTION_TIMEOUT = 10000;
     private static final int ZK_MAX_IN_FLIGHT_REQUESTS = 1000;
+    private static final int ACTIVE_PRODUCERS_COUNT = 4;
     private static final int NAKADI_SEND_TIMEOUT = 10000;
     private static final int NAKADI_POLL_TIMEOUT = 10000;
     private static final Long DEFAULT_RETENTION_TIME = 100L;
@@ -91,6 +92,7 @@ public class KafkaRepositoryAT extends BaseAT {
                 DEFAULT_TOPIC_RETENTION,
                 DEFAULT_TOPIC_ROTATION,
                 DEFAULT_COMMIT_TIMEOUT,
+                ACTIVE_PRODUCERS_COUNT,
                 NAKADI_POLL_TIMEOUT,
                 NAKADI_SEND_TIMEOUT,
                 TIMELINE_WAIT_TIMEOUT,

--- a/api-metastore/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
@@ -102,7 +102,7 @@ public class EventTypeControllerTestCase {
     @Before
     public void init() throws Exception {
 
-        final NakadiSettings nakadiSettings = new NakadiSettings(32, 0, 0, TOPIC_RETENTION_TIME_MS, 0, 60,
+        final NakadiSettings nakadiSettings = new NakadiSettings(32, 0, 0, TOPIC_RETENTION_TIME_MS, 0, 60, 1,
                 NAKADI_POLL_TIMEOUT, NAKADI_SEND_TIMEOUT, 0, NAKADI_EVENT_MAX_BYTES,
                 NAKADI_SUBSCRIPTION_MAX_PARTITIONS, "service", "org/zalando/nakadi", "I am warning you",
                 "I am warning you, even more", "nakadi_archiver", "nakadi_to_s3", 100, 10000);

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -55,6 +55,7 @@ nakadi:
     maxConnections: 5
     maxStreamMemoryBytes: 50000000 # ~50 MB
   kafka:
+    producers.count: 1
     retries: 0
     request.timeout.ms: 30000
     instanceType: t2.large

--- a/core-common/src/main/java/org/zalando/nakadi/config/NakadiSettings.java
+++ b/core-common/src/main/java/org/zalando/nakadi/config/NakadiSettings.java
@@ -15,6 +15,7 @@ public class NakadiSettings {
     private final long defaultTopicRetentionMs;
     private final long defaultTopicRotationMs;
     private final long maxCommitTimeout;
+    private final int kafkaActiveProducersCount;
     private final long kafkaPollTimeoutMs;
     private final long kafkaSendTimeoutMs;
     private final long timelineWaitTimeoutMs;
@@ -35,6 +36,7 @@ public class NakadiSettings {
                           @Value("${nakadi.topic.default.retentionMs}") final long defaultTopicRetentionMs,
                           @Value("${nakadi.topic.default.rotationMs}") final long defaultTopicRotationMs,
                           @Value("${nakadi.stream.max.commitTimeout}") final long maxCommitTimeout,
+                          @Value("${nakadi.kafka.producers.count}") final int kafkaActiveProducersCount,
                           @Value("${nakadi.kafka.poll.timeoutMs}") final long kafkaPollTimeoutMs,
                           @Value("${nakadi.kafka.send.timeoutMs}") final long kafkaSendTimeoutMs,
                           @Value("${nakadi.timeline.wait.timeoutMs}") final long timelineWaitTimeoutMs,
@@ -58,6 +60,7 @@ public class NakadiSettings {
         this.defaultTopicRetentionMs = defaultTopicRetentionMs;
         this.defaultTopicRotationMs = defaultTopicRotationMs;
         this.maxCommitTimeout = maxCommitTimeout;
+        this.kafkaActiveProducersCount = kafkaActiveProducersCount;
         this.kafkaPollTimeoutMs = kafkaPollTimeoutMs;
         this.kafkaSendTimeoutMs = kafkaSendTimeoutMs;
         this.eventMaxBytes = eventMaxBytes;
@@ -94,6 +97,10 @@ public class NakadiSettings {
 
     public long getMaxCommitTimeout() {
         return maxCommitTimeout;
+    }
+
+    public int getKafkaActiveProducersCount() {
+        return kafkaActiveProducersCount;
     }
 
     public long getKafkaPollTimeoutMs() {

--- a/core-common/src/main/java/org/zalando/nakadi/repository/KafkaRepositoryCreator.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/KafkaRepositoryCreator.java
@@ -64,8 +64,8 @@ public class KafkaRepositoryCreator implements TopicRepositoryCreator {
                     zookeeperSettings.getZkConnectionTimeoutMs(),
                     nakadiSettings);
             final KafkaLocationManager kafkaLocationManager = new KafkaLocationManager(zooKeeperHolder, kafkaSettings);
-            final KafkaFactory kafkaFactory =
-                    new KafkaFactory(kafkaLocationManager, nakadiSettings.getKafkaActiveProducersCount());
+            final KafkaFactory kafkaFactory = new KafkaFactory(new KafkaLocationManager(zooKeeperHolder, kafkaSettings),
+                    nakadiSettings.getKafkaActiveProducersCount());
             final KafkaZookeeper zk = new KafkaZookeeper(zooKeeperHolder, objectMapper);
             final KafkaTopicRepository kafkaTopicRepository =
                     new KafkaTopicRepository.Builder()

--- a/core-common/src/main/java/org/zalando/nakadi/repository/KafkaRepositoryCreator.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/KafkaRepositoryCreator.java
@@ -64,9 +64,8 @@ public class KafkaRepositoryCreator implements TopicRepositoryCreator {
                     zookeeperSettings.getZkConnectionTimeoutMs(),
                     nakadiSettings);
             final KafkaLocationManager kafkaLocationManager = new KafkaLocationManager(zooKeeperHolder, kafkaSettings);
-            final int kafkaActiveProducersCount = nakadiSettings.getKafkaActiveProducersCount();
             final KafkaFactory kafkaFactory =
-                    new KafkaFactory(kafkaLocationManager, metricRegistry, kafkaActiveProducersCount);
+                    new KafkaFactory(kafkaLocationManager, nakadiSettings.getKafkaActiveProducersCount());
             final KafkaZookeeper zk = new KafkaZookeeper(zooKeeperHolder, objectMapper);
             final KafkaTopicRepository kafkaTopicRepository =
                     new KafkaTopicRepository.Builder()

--- a/core-common/src/main/java/org/zalando/nakadi/repository/KafkaRepositoryCreator.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/KafkaRepositoryCreator.java
@@ -64,8 +64,9 @@ public class KafkaRepositoryCreator implements TopicRepositoryCreator {
                     zookeeperSettings.getZkConnectionTimeoutMs(),
                     nakadiSettings);
             final KafkaLocationManager kafkaLocationManager = new KafkaLocationManager(zooKeeperHolder, kafkaSettings);
+            final int kafkaActiveProducersCount = nakadiSettings.getKafkaActiveProducersCount();
             final KafkaFactory kafkaFactory =
-                    new KafkaFactory(new KafkaLocationManager(zooKeeperHolder, kafkaSettings), metricRegistry);
+                    new KafkaFactory(kafkaLocationManager, metricRegistry, kafkaActiveProducersCount);
             final KafkaZookeeper zk = new KafkaZookeeper(zooKeeperHolder, objectMapper);
             final KafkaTopicRepository kafkaTopicRepository =
                     new KafkaTopicRepository.Builder()

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaFactoryTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaFactoryTest.java
@@ -15,7 +15,7 @@ public class KafkaFactoryTest {
     private static class FakeKafkaFactory extends KafkaFactory {
 
         FakeKafkaFactory(final MetricRegistry metricRegistry) {
-            super(null, metricRegistry);
+            super(null, metricRegistry, 1);
         }
 
         @Override

--- a/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventPublisherTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventPublisherTest.java
@@ -91,7 +91,7 @@ public class EventPublisherTest {
     protected final Enrichment enrichment = mock(Enrichment.class);
     protected final AuthorizationValidator authzValidator = mock(AuthorizationValidator.class);
     protected final TimelineService timelineService = Mockito.mock(TimelineService.class);
-    protected final NakadiSettings nakadiSettings = new NakadiSettings(0, 0, 0, TOPIC_RETENTION_TIME_MS, 0, 60,
+    protected final NakadiSettings nakadiSettings = new NakadiSettings(0, 0, 0, TOPIC_RETENTION_TIME_MS, 0, 60, 1,
             NAKADI_POLL_TIMEOUT, NAKADI_SEND_TIMEOUT, TIMELINE_WAIT_TIMEOUT_MS, NAKADI_EVENT_MAX_BYTES,
             NAKADI_SUBSCRIPTION_MAX_PARTITIONS, "service", "org/zalando/nakadi", "", "",
             "nakadi_archiver", "nakadi_to_s3", 100, 10000);


### PR DESCRIPTION
A Kafka producer is single-threaded.  With our setup it makes sense to have more than one of them active, for better utilization of resources.

Internal ticket: 1298