### PR TITLE
Remove Kafka producer/consumer crutches

### DIFF
--- a/core-services/src/main/java/org/zalando/nakadi/service/timeline/MultiTimelineEventConsumer.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/timeline/MultiTimelineEventConsumer.java
@@ -13,7 +13,6 @@ import org.zalando.nakadi.exceptions.runtime.NakadiRuntimeException;
 import org.zalando.nakadi.exceptions.runtime.ServiceTemporarilyUnavailableException;
 import org.zalando.nakadi.repository.EventConsumer;
 import org.zalando.nakadi.repository.TopicRepository;
-import org.zalando.nakadi.repository.kafka.KafkaFactory;
 import org.zalando.nakadi.util.NakadiCollectionUtils;
 
 import java.io.IOException;
@@ -92,8 +91,8 @@ public class MultiTimelineEventConsumer implements EventConsumer.ReassignableEve
         final List<ConsumedEvent> result;
         try {
             result = poll();
-        } catch (KafkaFactory.KafkaCrutchException kce) {
-            LOG.warn("Kafka connections should be reinitialized because consumers should be recreated", kce);
+        } catch (final RuntimeException ex) {
+            LOG.warn("Kafka connections should be reinitialized because consumers should be recreated", ex);
             final List<NakadiCursor> tmpOffsets = new ArrayList<>(latestOffsets.values());
             // close all the clients
             reassign(Collections.emptyList());


### PR DESCRIPTION
There is no evidence that this was ever helpful, but there is evidence that it is sometimes harmful (e.g. restarting a Kafka broker, or adding empty ones).