### PR TITLE
remove excessive check for the leader

### DIFF
--- a/core-common/src/main/java/org/zalando/nakadi/domain/BatchItem.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/BatchItem.java
@@ -65,7 +65,6 @@ public class BatchItem implements Resource<BatchItem> {
     private String[] injectionValues;
     private final List<Integer> skipCharacters;
     private String partition;
-    private String brokerId;
     private String eventKey;
     private List<String> partitionKeys;
     private int eventSize;
@@ -114,15 +113,6 @@ public class BatchItem implements Resource<BatchItem> {
 
     public void setPartition(final String partition) {
         this.partition = partition;
-    }
-
-    @Nullable
-    public String getBrokerId() {
-        return brokerId;
-    }
-
-    public void setBrokerId(final String brokerId) {
-        this.brokerId = brokerId;
     }
 
     @Nullable

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -1,5 +1,6 @@
 package org.zalando.nakadi.repository.kafka;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.opentracing.Tracer;
@@ -305,6 +306,11 @@ public class KafkaTopicRepository implements TopicRepository {
             throws EventPublishingException {
         final Producer<byte[], byte[]> producer = kafkaFactory.takeProducer();
         try {
+            batch.forEach(item -> {
+                Preconditions.checkNotNull(
+                        item.getPartition(), "BatchItem partition can't be null at the moment of publishing!");
+            });
+
             final Map<BatchItem, CompletableFuture<Exception>> sendFutures = new HashMap<>();
             final Tracer.SpanBuilder sendBatchSpan = TracingService.buildNewSpan("send_batch_to_kafka")
                     .withTag(Tags.MESSAGE_BUS_DESTINATION.getKey(), topicId);

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -1,6 +1,5 @@
 package org.zalando.nakadi.repository.kafka;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.opentracing.Tracer;

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -56,7 +56,6 @@ import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepositoryTest.java
@@ -305,46 +305,6 @@ public class KafkaTopicRepositoryTest {
     }
 
     @Test
-    public void whenPartitionLeaderNotFoundTheRestOfTheBatchOk() {
-        final BatchItem firstItem = new BatchItem(
-                "{}",
-                BatchItem.EmptyInjectionConfiguration.build(1, true),
-                new BatchItem.InjectionConfiguration[BatchItem.Injection.values().length],
-                Collections.emptyList());
-        firstItem.setPartition("1");
-
-        final BatchItem secondItem = new BatchItem(
-                "{}",
-                BatchItem.EmptyInjectionConfiguration.build(1, true),
-                new BatchItem.InjectionConfiguration[BatchItem.Injection.values().length],
-                Collections.emptyList());
-        secondItem.setPartition("2");
-
-        final List<BatchItem> batch = new ArrayList<>();
-        batch.add(firstItem);
-        batch.add(secondItem);
-
-        when(kafkaProducer.partitionsFor(EXPECTED_PRODUCER_RECORD.topic())).thenReturn(ImmutableList.of(
-                new PartitionInfo(EXPECTED_PRODUCER_RECORD.topic(), 1, null, null, null),
-                new PartitionInfo(EXPECTED_PRODUCER_RECORD.topic(), 2, NODE, null, null)));
-
-        when(kafkaProducer.send(any(), any())).thenAnswer(invocation -> {
-            final Callback callback = (Callback) invocation.getArguments()[1];
-            callback.onCompletion(null, null);
-            return null;
-        });
-
-        Assert.assertThrows(EventPublishingException.class, () -> {
-            kafkaTopicRepository.syncPostBatch(EXPECTED_PRODUCER_RECORD.topic(), batch, "random", false);
-        });
-
-        assertThat(firstItem.getResponse().getPublishingStatus(), equalTo(EventPublishingStatus.FAILED));
-        assertThat(firstItem.getResponse().getDetail(), containsString("No leader for partition"));
-
-        assertThat(secondItem.getResponse().getPublishingStatus(), equalTo(EventPublishingStatus.SUBMITTED));
-    }
-
-    @Test
     public void whenPostEventOverflowsBufferThenUpdateItemStatus() {
         final BatchItem item = new BatchItem("{}",
                 BatchItem.EmptyInjectionConfiguration.build(1, true),


### PR DESCRIPTION
at the moment nakadi manually checks for the leader, that's not necessary because kafka producer does it for us. it also helps to keep the code clean and prepare for the future changes.