### PR TITLE
pool kafka consumers for timelag checker, only for test

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -48,6 +48,7 @@ public class KafkaRepositoryAT extends BaseAT {
     private static final int ZK_CONNECTION_TIMEOUT = 10000;
     private static final int ZK_MAX_IN_FLIGHT_REQUESTS = 1000;
     private static final int ACTIVE_PRODUCERS_COUNT = 4;
+    private static final int TIMELAG_CHECKER_CONSUMER_POOL_SIZE = 2;
     private static final int NAKADI_SEND_TIMEOUT = 10000;
     private static final int NAKADI_POLL_TIMEOUT = 10000;
     private static final Long DEFAULT_RETENTION_TIME = 100L;
@@ -94,6 +95,7 @@ public class KafkaRepositoryAT extends BaseAT {
                 DEFAULT_TOPIC_ROTATION,
                 DEFAULT_COMMIT_TIMEOUT,
                 ACTIVE_PRODUCERS_COUNT,
+                TIMELAG_CHECKER_CONSUMER_POOL_SIZE,
                 NAKADI_POLL_TIMEOUT,
                 NAKADI_SEND_TIMEOUT,
                 TIMELINE_WAIT_TIMEOUT,

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/SubscriptionTimeLagService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/SubscriptionTimeLagService.java
@@ -23,7 +23,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
@@ -142,7 +141,8 @@ public class SubscriptionTimeLagService {
         private Duration getNextEventTimeLag(final NakadiCursor cursor) throws ErrorGettingCursorTimeLagException,
                 InconsistentStateException {
 
-            final String clientId = "time-lag-checker-" + UUID.randomUUID();
+            final String clientId = String.format("time-lag-checker-%s-%s",
+                    cursor.getEventType(), cursor.getPartition());
             try (EventConsumer consumer = timelineService.createEventConsumer(clientId, ImmutableList.of(cursor))) {
                 LOG.trace("client:{}, reading events for lag calculation", clientId);
                 final ConsumedEvent nextEvent = executeWithRetry(

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/SubscriptionTimeLagService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/SubscriptionTimeLagService.java
@@ -78,9 +78,9 @@ public class SubscriptionTimeLagService {
                 timeLags.put(partition, futureTimeLags.get(partition).get());
             }
         } catch (RejectedExecutionException | TimeoutException | ExecutionException e) {
-            LOG.warn("caught exception the timelag stats are not complete - " + e);
+            LOG.warn("caught exception the timelag stats are not complete", e);
         } catch (Throwable e) {
-            LOG.warn("caught throwable the timelag stats are not complete - " + e);
+            LOG.warn("caught throwable the timelag stats are not complete", e);
         }
         return timeLags;
     }

--- a/api-metastore/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/controller/EventTypeControllerTestCase.java
@@ -102,7 +102,7 @@ public class EventTypeControllerTestCase {
     @Before
     public void init() throws Exception {
 
-        final NakadiSettings nakadiSettings = new NakadiSettings(32, 0, 0, TOPIC_RETENTION_TIME_MS, 0, 60, 1,
+        final NakadiSettings nakadiSettings = new NakadiSettings(32, 0, 0, TOPIC_RETENTION_TIME_MS, 0, 60, 1, 2,
                 NAKADI_POLL_TIMEOUT, NAKADI_SEND_TIMEOUT, 0, NAKADI_EVENT_MAX_BYTES,
                 NAKADI_SUBSCRIPTION_MAX_PARTITIONS, "service", "org/zalando/nakadi", "I am warning you",
                 "I am warning you, even more", "nakadi_archiver", "nakadi_to_s3", 100, 10000);

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -56,6 +56,7 @@ nakadi:
     maxStreamMemoryBytes: 50000000 # ~50 MB
   kafka:
     producers.count: 1
+    time-lag-checker.consumer-pool.size: 1
     retries: 0
     request.timeout.ms: 30000
     instanceType: t2.large

--- a/core-common/src/main/java/org/zalando/nakadi/config/NakadiSettings.java
+++ b/core-common/src/main/java/org/zalando/nakadi/config/NakadiSettings.java
@@ -16,6 +16,7 @@ public class NakadiSettings {
     private final long defaultTopicRotationMs;
     private final long maxCommitTimeout;
     private final int kafkaActiveProducersCount;
+    private final int kafkaTimeLagCheckerConsumerPoolSize;
     private final long kafkaPollTimeoutMs;
     private final long kafkaSendTimeoutMs;
     private final long timelineWaitTimeoutMs;
@@ -37,6 +38,8 @@ public class NakadiSettings {
                           @Value("${nakadi.topic.default.rotationMs}") final long defaultTopicRotationMs,
                           @Value("${nakadi.stream.max.commitTimeout}") final long maxCommitTimeout,
                           @Value("${nakadi.kafka.producers.count}") final int kafkaActiveProducersCount,
+                          @Value("${nakadi.kafka.time-lag-checker.consumer-pool.size}")
+                              final int kafkaTimeLagCheckerConsumerPoolSize,
                           @Value("${nakadi.kafka.poll.timeoutMs}") final long kafkaPollTimeoutMs,
                           @Value("${nakadi.kafka.send.timeoutMs}") final long kafkaSendTimeoutMs,
                           @Value("${nakadi.timeline.wait.timeoutMs}") final long timelineWaitTimeoutMs,
@@ -61,6 +64,7 @@ public class NakadiSettings {
         this.defaultTopicRotationMs = defaultTopicRotationMs;
         this.maxCommitTimeout = maxCommitTimeout;
         this.kafkaActiveProducersCount = kafkaActiveProducersCount;
+        this.kafkaTimeLagCheckerConsumerPoolSize = kafkaTimeLagCheckerConsumerPoolSize;
         this.kafkaPollTimeoutMs = kafkaPollTimeoutMs;
         this.kafkaSendTimeoutMs = kafkaSendTimeoutMs;
         this.eventMaxBytes = eventMaxBytes;
@@ -101,6 +105,10 @@ public class NakadiSettings {
 
     public int getKafkaActiveProducersCount() {
         return kafkaActiveProducersCount;
+    }
+
+    public int getKafkaTimeLagCheckerConsumerPoolSize() {
+        return kafkaTimeLagCheckerConsumerPoolSize;
     }
 
     public long getKafkaPollTimeoutMs() {

--- a/core-common/src/main/java/org/zalando/nakadi/repository/KafkaRepositoryCreator.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/KafkaRepositoryCreator.java
@@ -65,7 +65,8 @@ public class KafkaRepositoryCreator implements TopicRepositoryCreator {
                     nakadiSettings);
             final KafkaLocationManager kafkaLocationManager = new KafkaLocationManager(zooKeeperHolder, kafkaSettings);
             final KafkaFactory kafkaFactory = new KafkaFactory(kafkaLocationManager,
-                    nakadiSettings.getKafkaActiveProducersCount());
+                    nakadiSettings.getKafkaActiveProducersCount(),
+                    nakadiSettings.getKafkaTimeLagCheckerConsumerPoolSize());
             final KafkaZookeeper zk = new KafkaZookeeper(zooKeeperHolder, objectMapper);
             final KafkaTopicRepository kafkaTopicRepository =
                     new KafkaTopicRepository.Builder()

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
@@ -178,7 +178,9 @@ public class KafkaFactory {
                 .findFirst()
                 .ifPresent(clientId -> {
                     consumersInUse.remove(clientId);
-                    consumerPoolLock.notifyAll();
+                    synchronized (consumerPoolLock) {
+                        consumerPoolLock.notifyAll();
+                    }
                 });
     }
 

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaFactoryTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaFactoryTest.java
@@ -1,5 +1,6 @@
 package org.zalando.nakadi.repository.kafka;
 
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.junit.Assert;
 import org.junit.Test;
@@ -12,19 +13,24 @@ import java.util.stream.IntStream;
 public class KafkaFactoryTest {
     private static class FakeKafkaFactory extends KafkaFactory {
 
-        FakeKafkaFactory(final int numActiveProducers) {
-            super(null, numActiveProducers);
+        FakeKafkaFactory(final int numActiveProducers, final int consumerPoolSize) {
+            super(null, numActiveProducers, consumerPoolSize);
         }
 
         @Override
         protected Producer<byte[], byte[]> createProducerInstance() {
             return Mockito.mock(Producer.class);
         }
+
+        @Override
+        protected Consumer<byte[], byte[]> createConsumerProxyInstance() {
+            return Mockito.mock(Consumer.class);
+        }
     }
 
     @Test
     public void whenSingleProducerThenTheSameProducerIsGiven() {
-        final KafkaFactory factory = new FakeKafkaFactory(1);
+        final KafkaFactory factory = new FakeKafkaFactory(1, 2);
         final Producer<byte[], byte[]> producer1 = factory.takeProducer("topic-id");
         try {
             Assert.assertNotNull(producer1);
@@ -42,7 +48,7 @@ public class KafkaFactoryTest {
 
     @Test
     public void verifySingleProducerIsClosedAtCorrectTime() {
-        final KafkaFactory factory = new FakeKafkaFactory(1);
+        final KafkaFactory factory = new FakeKafkaFactory(1, 2);
 
         final List<Producer<byte[], byte[]>> producers1 = IntStream.range(0, 10)
                 .mapToObj(ignore -> factory.takeProducer("topic-id")).collect(Collectors.toList());
@@ -73,7 +79,7 @@ public class KafkaFactoryTest {
 
     @Test
     public void verifyNewProducerCreatedAfterCloseOfSingle() {
-        final KafkaFactory factory = new FakeKafkaFactory(1);
+        final KafkaFactory factory = new FakeKafkaFactory(1, 2);
         final Producer<byte[], byte[]> producer1 = factory.takeProducer("topic-id");
         Assert.assertNotNull(producer1);
         factory.terminateProducer(producer1);
@@ -89,7 +95,7 @@ public class KafkaFactoryTest {
 
     @Test
     public void testGoldenPathWithManyActiveProducers() {
-        final KafkaFactory factory = new FakeKafkaFactory(4);
+        final KafkaFactory factory = new FakeKafkaFactory(4, 2);
 
         final List<Producer<byte[], byte[]>> producers = IntStream.range(0, 10)
                 .mapToObj(ignore -> factory.takeProducer("topic-id")).collect(Collectors.toList());

--- a/core-services/src/main/java/org/zalando/nakadi/service/timeline/MultiTimelineEventConsumer.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/timeline/MultiTimelineEventConsumer.java
@@ -333,19 +333,5 @@ public class MultiTimelineEventConsumer implements EventConsumer.ReassignableEve
         } catch (final InvalidCursorException e) {
             throw new IOException(e);
         }
-
-        // hack
-        eventConsumers.values().forEach((consumer) -> {
-            try {
-                consumer.close();
-            } catch (Exception e) {
-                // ignore, need to close everything
-                LOG.trace(
-                        "client:{}, failed to close underlying consumer, exception: {}",
-                        clientId, e.getMessage());
-            }
-        });
-
-        eventConsumers.clear();
     }
 }

--- a/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventPublisherTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventPublisherTest.java
@@ -94,7 +94,7 @@ public class EventPublisherTest {
     protected final Enrichment enrichment = mock(Enrichment.class);
     protected final AuthorizationValidator authzValidator = mock(AuthorizationValidator.class);
     protected final TimelineService timelineService = Mockito.mock(TimelineService.class);
-    protected final NakadiSettings nakadiSettings = new NakadiSettings(0, 0, 0, TOPIC_RETENTION_TIME_MS, 0, 60, 1,
+    protected final NakadiSettings nakadiSettings = new NakadiSettings(0, 0, 0, TOPIC_RETENTION_TIME_MS, 0, 60, 1, 2,
             NAKADI_POLL_TIMEOUT, NAKADI_SEND_TIMEOUT, TIMELINE_WAIT_TIMEOUT_MS, NAKADI_EVENT_MAX_BYTES,
             NAKADI_SUBSCRIPTION_MAX_PARTITIONS, "service", "org/zalando/nakadi", "", "",
             "nakadi_archiver", "nakadi_to_s3", 100, 10000);


### PR DESCRIPTION
at the moment time lag service generates hundreds of consumers to calculate lag, because Kafka consumer is created per partition. the change brings pool of consumers which should avoid constant generation of new consumers.