### PR TITLE
Persist annotations/labels on subscription update

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/SubscriptionAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/SubscriptionAT.java
@@ -52,7 +52,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.zalando.nakadi.utils.TestUtils.buildDefaultEventType;

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/SubscriptionAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/SubscriptionAT.java
@@ -285,7 +285,7 @@ public class SubscriptionAT extends BaseAT {
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("annotations.foo", is("bar"))
-                .body("annotations.kar", is("booz"));
+                .body("labels.kar", is("booz"));
     }
 
     @Test

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/SubscriptionAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/SubscriptionAT.java
@@ -259,7 +259,7 @@ public class SubscriptionAT extends BaseAT {
     public void testSubscriptionAnnotationLabelIsUpdated() throws IOException {
         final String eventType = createEventType().getName();
         final String subscription = "{\"owning_application\":\"app\",\"event_types\":" +
-                "[" + eventType +"]}";
+                "[\"" + eventType +"\"]}";
         final Response response = given()
                 .body(subscription)
                 .contentType(JSON)

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/SubscriptionAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/hila/SubscriptionAT.java
@@ -36,6 +36,7 @@ import org.zalando.problem.Problem;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -48,8 +49,10 @@ import static java.text.MessageFormat.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.zalando.nakadi.utils.TestUtils.buildDefaultEventType;
@@ -251,6 +254,39 @@ public class SubscriptionAT extends BaseAT {
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body(JSON_HELPER.matchesObject(expectedList));
+    }
+
+    @Test
+    public void testSubscriptionAnnotationLabelIsUpdated() throws IOException {
+        final String eventType = createEventType().getName();
+        final String subscription = "{\"owning_application\":\"app\",\"event_types\":" +
+                "[" + eventType +"]}";
+        final Response response = given()
+                .body(subscription)
+                .contentType(JSON)
+                .post(SUBSCRIPTIONS_URL);
+        // assert response
+        response.then().statusCode(HttpStatus.SC_CREATED);
+        final String responseBody = response.print();
+        final Subscription sub = MAPPER.readValue(responseBody, Subscription.class);
+        Assert.assertNotNull(sub.getId());
+
+        sub.setAnnotations(Map.of("foo", "bar"));
+        sub.setLabels(Map.of("kar", "booz"));
+
+        given()
+                .contentType(JSON)
+                .body(TestUtils.OBJECT_MAPPER.writeValueAsString(sub))
+                .put(SUBSCRIPTIONS_URL + "/" + sub.getId())
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        given()
+                .get(SUBSCRIPTIONS_URL + "/" + sub.getId())
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("annotations.foo", is("bar"))
+                .body("annotations.kar", is("booz"));
     }
 
     @Test

--- a/core-common/src/main/java/org/zalando/nakadi/domain/Subscription.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/Subscription.java
@@ -84,6 +84,8 @@ public class Subscription extends SubscriptionBase {
     public Subscription mergeFrom(final SubscriptionBase newValue) {
         final Subscription subscription = new Subscription(id, createdAt, new DateTime(DateTimeZone.UTC), this);
         subscription.setAuthorization(newValue.getAuthorization());
+        subscription.setAnnotations(newValue.getAnnotations());
+        subscription.setLabels(newValue.getLabels());
         return subscription;
     }
 


### PR DESCRIPTION
# One-line summary

In subscription update API, when performing update if the new subscription had annotation/label value set then they were ignored. This PR fixes this and adds a test case to verify.

