### PR TITLE
Use Kafka consumer pool always, if it is there

### DIFF
--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -56,7 +56,7 @@ nakadi:
     maxStreamMemoryBytes: 50000000 # ~50 MB
   kafka:
     producers.count: 1
-    time-lag-checker.consumer-pool.size: 1
+    time-lag-checker.consumer-pool.size: 0
     retries: 0
     request.timeout.ms: 30000
     instanceType: t2.large


### PR DESCRIPTION
1. For misc we always want to use the consumer pool to reduce the rate of creating consumers.
2. For the actual consumption stack we will be creating consumers normally.