### PR TITLE
multi-timeline consumer pool for subscription lag

### DIFF
--- a/api-metastore/src/main/java/org/zalando/nakadi/service/SubscriptionTimeLagService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/SubscriptionTimeLagService.java
@@ -1,5 +1,7 @@
 package org.zalando.nakadi.service;
 
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import org.echocat.jomon.runtime.concurrent.RetryForSpecifiedTimeStrategy;
 import org.slf4j.Logger;
@@ -16,21 +18,24 @@ import org.zalando.nakadi.exceptions.runtime.InvalidCursorException;
 import org.zalando.nakadi.service.timeline.HighLevelConsumer;
 import org.zalando.nakadi.service.timeline.TimelineService;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 import static org.echocat.jomon.runtime.concurrent.Retryer.executeWithRetry;
 
@@ -42,23 +47,28 @@ public class SubscriptionTimeLagService {
     private static final int MAX_THREADS_PER_REQUEST = 20;
     private static final int TIME_LAG_COMMON_POOL_SIZE = 400;
 
-    private final TimelineService timelineService;
     private final NakadiCursorComparator cursorComparator;
     private final ThreadPoolExecutor threadPool;
+    private final ConsumerPool consumerPool;
 
     @Autowired
     public SubscriptionTimeLagService(final TimelineService timelineService,
-                                      final NakadiCursorComparator cursorComparator) {
-        this.timelineService = timelineService;
+                                      final NakadiCursorComparator cursorComparator,
+                                      final MetricRegistry metricRegistry,
+                                      final int consumerPoolSize) {
         this.cursorComparator = cursorComparator;
         this.threadPool = new ThreadPoolExecutor(0, TIME_LAG_COMMON_POOL_SIZE, 60L, TimeUnit.SECONDS,
                 new SynchronousQueue<>());
+        this.consumerPool = new ConsumerPool(
+                consumerPoolSize,
+                () -> timelineService.createEventConsumer("timelag-checker"),
+                metricRegistry);
     }
 
     public Map<EventTypePartition, Duration> getTimeLags(final Collection<NakadiCursor> committedPositions,
                                                          final List<PartitionEndStatistics> endPositions) {
 
-        final TimeLagRequestHandler timeLagHandler = new TimeLagRequestHandler(timelineService, threadPool);
+        final TimeLagRequestHandler timeLagHandler = new TimeLagRequestHandler(threadPool, consumerPool);
         final Map<EventTypePartition, Duration> timeLags = new HashMap<>();
         final Map<EventTypePartition, CompletableFuture<Duration>> futureTimeLags = new HashMap<>();
         try {
@@ -97,13 +107,14 @@ public class SubscriptionTimeLagService {
 
     private static class TimeLagRequestHandler {
 
-        private final TimelineService timelineService;
+        private final ConsumerPool consumerPool;
         private final ThreadPoolExecutor threadPool;
         private final Semaphore semaphore;
         private final long timeoutTimestampMs;
 
-        TimeLagRequestHandler(final TimelineService timelineService, final ThreadPoolExecutor threadPool) {
-            this.timelineService = timelineService;
+        TimeLagRequestHandler(final ThreadPoolExecutor threadPool,
+                              final ConsumerPool consumerPool) {
+            this.consumerPool = consumerPool;
             this.threadPool = threadPool;
             this.semaphore = new Semaphore(MAX_THREADS_PER_REQUEST);
             this.timeoutTimestampMs = System.currentTimeMillis() + REQUEST_TIMEOUT_MS;
@@ -138,13 +149,13 @@ public class SubscriptionTimeLagService {
             }
         }
 
-        private Duration getNextEventTimeLag(final NakadiCursor cursor) throws ErrorGettingCursorTimeLagException,
-                InconsistentStateException {
+        private Duration getNextEventTimeLag(final NakadiCursor cursor)
+                throws ErrorGettingCursorTimeLagException, InconsistentStateException {
 
             final String clientId = String.format("time-lag-checker-%s-%s",
                     cursor.getEventType(), cursor.getPartition());
-            try (HighLevelConsumer consumer = timelineService.createEventConsumer(
-                    clientId, ImmutableList.of(cursor))) {
+            final HighLevelConsumer consumer = consumerPool.takeConsumer(ImmutableList.of(cursor));
+            try {
                 LOG.trace("client:{}, reading events for lag calculation", clientId);
                 final ConsumedEvent nextEvent = executeWithRetry(
                         () -> {
@@ -160,14 +171,69 @@ public class SubscriptionTimeLagService {
                 } else {
                     return Duration.ofMillis(new Date().getTime() - nextEvent.getTimestamp());
                 }
-            } catch (final IOException e) {
-                throw new InconsistentStateException("Unexpected error happened when getting consumer time lag", e);
             } catch (final InvalidCursorException e) {
                 throw new ErrorGettingCursorTimeLagException(cursor, e);
             } finally {
                 LOG.trace("client:{}, finished reading events for lag calculation", clientId);
+                consumerPool.returnConsumer(consumer);
             }
         }
+    }
+
+    private static class ConsumerPool {
+        private final BlockingQueue<HighLevelConsumer> pool;
+        private final Meter consumerPoolTakeMeter;
+        private final Meter consumerPoolReturnMeter;
+
+        ConsumerPool(final int consumerPoolSize,
+                     final Supplier<HighLevelConsumer> consumerCreator,
+                     final MetricRegistry metricsRegistry) {
+            LOG.info("Preparing timelag checker pool of {} Kafka consumers", consumerPoolSize);
+            this.pool = new LinkedBlockingQueue(consumerPoolSize);
+            for (int i = 0; i < consumerPoolSize; ++i) {
+                this.pool.add(consumerCreator.get());
+            }
+
+            this.consumerPoolTakeMeter = metricsRegistry.meter("nakadi.kafka.consumer.taken");
+            this.consumerPoolReturnMeter = metricsRegistry.meter("nakadi.kafka.consumer.returned");
+        }
+
+        private HighLevelConsumer takeConsumer(final List<NakadiCursor> cursors) {
+            final HighLevelConsumer consumer;
+
+            LOG.trace("Taking timelag consumer from the pool");
+            try {
+                consumer = pool.poll(30, TimeUnit.SECONDS);
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("interrupted while waiting for a consumer from the pool");
+            }
+            if (consumer == null) {
+                throw new RuntimeException("timed out while waiting for a consumer from the pool");
+            }
+
+            consumer.reassign(cursors);
+
+            consumerPoolTakeMeter.mark();
+
+            return consumer;
+        }
+
+        private void returnConsumer(final HighLevelConsumer consumer) {
+            LOG.trace("Returning timelag consumer to the pool");
+
+            consumer.reassign(Collections.emptyList());
+
+            consumerPoolReturnMeter.mark();
+
+            try {
+                pool.put(consumer);
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("interrupted while putting a consumer back to the pool");
+            }
+        }
+
     }
 
 }

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/SubscriptionTimeLagService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/SubscriptionTimeLagService.java
@@ -197,14 +197,14 @@ public class SubscriptionTimeLagService {
         ConsumerPool(final int consumerPoolSize,
                      final Supplier<HighLevelConsumer> consumerCreator,
                      final MetricRegistry metricsRegistry) {
-            LOG.info("Preparing timelag checker pool of {} Kafka consumers", consumerPoolSize);
+            LOG.info("Preparing timelag checker pool of {} multi-timeline consumers", consumerPoolSize);
             this.pool = new LinkedBlockingQueue(consumerPoolSize);
             for (int i = 0; i < consumerPoolSize; ++i) {
                 this.pool.add(consumerCreator.get());
             }
 
-            this.consumerPoolTakeMeter = metricsRegistry.meter("nakadi.kafka.consumer.taken");
-            this.consumerPoolReturnMeter = metricsRegistry.meter("nakadi.kafka.consumer.returned");
+            this.consumerPoolTakeMeter = metricsRegistry.meter("nakadi.timelag-consumer.taken");
+            this.consumerPoolReturnMeter = metricsRegistry.meter("nakadi.timelag-consumer.returned");
         }
 
         private HighLevelConsumer takeConsumer(final List<NakadiCursor> cursors) {

--- a/api-metastore/src/test/java/org/zalando/nakadi/service/SubscriptionTimeLagServiceTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/service/SubscriptionTimeLagServiceTest.java
@@ -1,5 +1,6 @@
 package org.zalando.nakadi.service;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,6 +23,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -30,15 +32,12 @@ public class SubscriptionTimeLagServiceTest {
     private static final long FAKE_EVENT_TIMESTAMP = 478220400000L;
 
     private NakadiCursorComparator cursorComparator;
-    private SubscriptionTimeLagService timeLagService;
     private TimelineService timelineService;
 
     @Before
     public void setUp() {
         timelineService = mock(TimelineService.class);
-
         cursorComparator = mock(NakadiCursorComparator.class);
-        timeLagService = new SubscriptionTimeLagService(timelineService, cursorComparator);
     }
 
     @Test
@@ -53,7 +52,7 @@ public class SubscriptionTimeLagServiceTest {
                                 new ConsumedEvent(
                                         null, NakadiCursor.of(timeline, "", ""), FAKE_EVENT_TIMESTAMP, null)));
 
-        when(timelineService.createEventConsumer(any(), any())).thenReturn(eventConsumer);
+        when(timelineService.createEventConsumer(anyString())).thenReturn(eventConsumer);
 
         final Timeline et1Timeline = new Timeline("et1", 0, new Storage("", Storage.Type.KAFKA), "t1", null);
 
@@ -69,6 +68,8 @@ public class SubscriptionTimeLagServiceTest {
         // mock second committed cursor to be lower than tail - the expected time lag should be > 0
         when(cursorComparator.compare(committedCursor2, endStats2.getLast())).thenReturn(-1);
 
+        final SubscriptionTimeLagService timeLagService = new SubscriptionTimeLagService(
+                timelineService, cursorComparator, new MetricRegistry(), 1);
         final Map<EventTypePartition, Duration> timeLags = timeLagService.getTimeLags(
                 ImmutableList.of(committedCursor1, committedCursor2),
                 ImmutableList.of(endStats1, endStats2));
@@ -81,10 +82,12 @@ public class SubscriptionTimeLagServiceTest {
 
     @Test
     public void whenNoSubscriptionThenReturnSizeZeroMap() {
-        when(timelineService.createEventConsumer(any(), any())).thenReturn(null);
         final Timeline et1Timeline = new Timeline("et1", 0, new Storage("", Storage.Type.KAFKA), "t1", null);
         final NakadiCursor committedCursor1 = NakadiCursor.of(et1Timeline, "p1", "o1");
 
+        when(timelineService.createEventConsumer(anyString())).thenReturn(mock(HighLevelConsumer.class));
+        final SubscriptionTimeLagService timeLagService = new SubscriptionTimeLagService(
+                timelineService, cursorComparator, new MetricRegistry(), 1);
         final Map<EventTypePartition, Duration> result = timeLagService.getTimeLags
                 (ImmutableList.of(committedCursor1), ImmutableList.of());
         assertThat(result.size(), is(0));

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -56,7 +56,7 @@ nakadi:
     maxStreamMemoryBytes: 50000000 # ~50 MB
   kafka:
     producers.count: 1
-    time-lag-checker.consumer-pool.size: 0
+    time-lag-checker.consumer-pool.size: 1
     retries: 0
     request.timeout.ms: 30000
     instanceType: t2.large

--- a/core-common/src/main/java/org/zalando/nakadi/repository/KafkaRepositoryCreator.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/KafkaRepositoryCreator.java
@@ -1,6 +1,5 @@
 package org.zalando.nakadi.repository;
 
-import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -32,7 +31,6 @@ public class KafkaRepositoryCreator implements TopicRepositoryCreator {
     private final KafkaSettings kafkaSettings;
     private final ZookeeperSettings zookeeperSettings;
     private final KafkaTopicConfigFactory kafkaTopicConfigFactory;
-    private final MetricRegistry metricRegistry;
     private final ObjectMapper objectMapper;
     private final NakadiRecordMapper nakadiRecordMapper;
 
@@ -42,14 +40,12 @@ public class KafkaRepositoryCreator implements TopicRepositoryCreator {
             final KafkaSettings kafkaSettings,
             final ZookeeperSettings zookeeperSettings,
             final KafkaTopicConfigFactory kafkaTopicConfigFactory,
-            final MetricRegistry metricRegistry,
             final ObjectMapper objectMapper,
             final NakadiRecordMapper nakadiRecordMapper) {
         this.nakadiSettings = nakadiSettings;
         this.kafkaSettings = kafkaSettings;
         this.zookeeperSettings = zookeeperSettings;
         this.kafkaTopicConfigFactory = kafkaTopicConfigFactory;
-        this.metricRegistry = metricRegistry;
         this.objectMapper = objectMapper;
         this.nakadiRecordMapper = nakadiRecordMapper;
     }
@@ -64,9 +60,8 @@ public class KafkaRepositoryCreator implements TopicRepositoryCreator {
                     zookeeperSettings.getZkConnectionTimeoutMs(),
                     nakadiSettings);
             final KafkaLocationManager kafkaLocationManager = new KafkaLocationManager(zooKeeperHolder, kafkaSettings);
-            final KafkaFactory kafkaFactory = new KafkaFactory(kafkaLocationManager, metricRegistry,
-                    nakadiSettings.getKafkaActiveProducersCount(),
-                    nakadiSettings.getKafkaTimeLagCheckerConsumerPoolSize());
+            final KafkaFactory kafkaFactory = new KafkaFactory(kafkaLocationManager,
+                    nakadiSettings.getKafkaActiveProducersCount());
             final KafkaZookeeper zk = new KafkaZookeeper(zooKeeperHolder, objectMapper);
             final KafkaTopicRepository kafkaTopicRepository =
                     new KafkaTopicRepository.Builder()

--- a/core-common/src/main/java/org/zalando/nakadi/repository/KafkaRepositoryCreator.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/KafkaRepositoryCreator.java
@@ -1,5 +1,6 @@
 package org.zalando.nakadi.repository;
 
+import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -33,6 +34,7 @@ public class KafkaRepositoryCreator implements TopicRepositoryCreator {
     private final KafkaTopicConfigFactory kafkaTopicConfigFactory;
     private final ObjectMapper objectMapper;
     private final NakadiRecordMapper nakadiRecordMapper;
+    private final MetricRegistry metricRegistry;
 
     @Autowired
     public KafkaRepositoryCreator(
@@ -41,13 +43,15 @@ public class KafkaRepositoryCreator implements TopicRepositoryCreator {
             final ZookeeperSettings zookeeperSettings,
             final KafkaTopicConfigFactory kafkaTopicConfigFactory,
             final ObjectMapper objectMapper,
-            final NakadiRecordMapper nakadiRecordMapper) {
+            final NakadiRecordMapper nakadiRecordMapper,
+            final MetricRegistry metricRegistry) {
         this.nakadiSettings = nakadiSettings;
         this.kafkaSettings = kafkaSettings;
         this.zookeeperSettings = zookeeperSettings;
         this.kafkaTopicConfigFactory = kafkaTopicConfigFactory;
         this.objectMapper = objectMapper;
         this.nakadiRecordMapper = nakadiRecordMapper;
+        this.metricRegistry = metricRegistry;
     }
 
     @Override
@@ -61,7 +65,7 @@ public class KafkaRepositoryCreator implements TopicRepositoryCreator {
                     nakadiSettings);
             final KafkaLocationManager kafkaLocationManager = new KafkaLocationManager(zooKeeperHolder, kafkaSettings);
             final KafkaFactory kafkaFactory = new KafkaFactory(kafkaLocationManager,
-                    nakadiSettings.getKafkaActiveProducersCount());
+                    metricRegistry, nakadiSettings.getKafkaActiveProducersCount());
             final KafkaZookeeper zk = new KafkaZookeeper(zooKeeperHolder, objectMapper);
             final KafkaTopicRepository kafkaTopicRepository =
                     new KafkaTopicRepository.Builder()

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
@@ -1,7 +1,5 @@
 package org.zalando.nakadi.repository.kafka;
 
-import com.codahale.metrics.Meter;
-import com.codahale.metrics.MetricRegistry;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -11,14 +9,10 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -33,15 +27,8 @@ public class KafkaFactory {
     private final ReadWriteLock rwLock;
     private final List<Producer<byte[], byte[]>> activeProducers;
 
-    private final BlockingQueue<Consumer<byte[], byte[]>> consumerPool;
-    private final Meter consumerCreateMeter;
-    private final Meter consumerPoolTakeMeter;
-    private final Meter consumerPoolReturnMeter;
-
     public KafkaFactory(final KafkaLocationManager kafkaLocationManager,
-                        final MetricRegistry metricsRegistry,
-                        final int numActiveProducers,
-                        final int consumerPoolSize) {
+                        final int numActiveProducers) {
         this.kafkaLocationManager = kafkaLocationManager;
 
         this.useCount = new ConcurrentHashMap<>();
@@ -52,20 +39,6 @@ public class KafkaFactory {
         for (int i = 0; i < numActiveProducers; ++i) {
             this.activeProducers.add(null);
         }
-
-        if (consumerPoolSize > 0) {
-            LOG.info("Preparing timelag checker pool of {} Kafka consumers", consumerPoolSize);
-            this.consumerPool = new LinkedBlockingQueue(consumerPoolSize);
-            for (int i = 0; i < consumerPoolSize; ++i) {
-                this.consumerPool.add(createConsumerProxyInstance());
-            }
-        } else {
-            this.consumerPool = null;
-        }
-
-        this.consumerCreateMeter = metricsRegistry.meter("nakadi.kafka.consumer.created");
-        this.consumerPoolTakeMeter = metricsRegistry.meter("nakadi.kafka.consumer.taken");
-        this.consumerPoolReturnMeter = metricsRegistry.meter("nakadi.kafka.consumer.returned");
     }
 
     @Nullable
@@ -168,72 +141,15 @@ public class KafkaFactory {
         return getConsumer();
     }
 
-    private Consumer<byte[], byte[]> takeConsumer() {
-        final Consumer<byte[], byte[]> consumer;
-
-        LOG.trace("Taking timelag consumer from the pool");
-        try {
-            consumer = consumerPool.poll(30, TimeUnit.SECONDS);
-        } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("interrupted while waiting for a consumer from the pool");
-        }
-        if (consumer == null) {
-            throw new RuntimeException("timed out while waiting for a consumer from the pool");
-        }
-
-        consumerPoolTakeMeter.mark();
-
-        return consumer;
-    }
-
-    private void returnConsumer(final Consumer<byte[], byte[]> consumer) {
-        LOG.trace("Returning timelag consumer to the pool");
-
-        consumer.assign(Collections.emptyList());
-
-        consumerPoolReturnMeter.mark();
-
-        try {
-            consumerPool.put(consumer);
-        } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("interrupted while putting a consumer back to the pool");
-        }
-    }
-
     public Consumer<byte[], byte[]> getConsumer() {
-        if (consumerPool != null) {
-            return takeConsumer();
-        }
-
         return getConsumer(kafkaLocationManager.getKafkaConsumerProperties());
     }
 
     private Consumer<byte[], byte[]> getConsumer(final Properties properties) {
-
-        consumerCreateMeter.mark();
-
-        return new KafkaConsumer<byte[], byte[]>(properties);
+        return new KafkaConsumer<>(properties);
     }
 
     protected Producer<byte[], byte[]> createProducerInstance() {
-        return new KafkaProducer<byte[], byte[]>(kafkaLocationManager.getKafkaProducerProperties());
-    }
-
-    protected Consumer<byte[], byte[]> createConsumerProxyInstance() {
-        return new KafkaConsumerProxy(kafkaLocationManager.getKafkaConsumerProperties());
-    }
-
-    public class KafkaConsumerProxy extends KafkaConsumer<byte[], byte[]> {
-
-        public KafkaConsumerProxy(final Properties properties) {
-            super(properties);
-        }
-
-        @Override
-        public void close() {
-            returnConsumer(this);
-        }
+        return new KafkaProducer<>(kafkaLocationManager.getKafkaProducerProperties());
     }
 }

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaFactoryTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaFactoryTest.java
@@ -1,5 +1,6 @@
 package org.zalando.nakadi.repository.kafka;
 
+import com.codahale.metrics.MetricRegistry;
 import org.apache.kafka.clients.producer.Producer;
 import org.junit.Assert;
 import org.junit.Test;
@@ -13,7 +14,7 @@ public class KafkaFactoryTest {
     private static class FakeKafkaFactory extends KafkaFactory {
 
         FakeKafkaFactory(final int numActiveProducers) {
-            super(null, numActiveProducers);
+            super(null, new MetricRegistry(), numActiveProducers);
         }
 
         @Override

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaFactoryTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaFactoryTest.java
@@ -1,7 +1,5 @@
 package org.zalando.nakadi.repository.kafka;
 
-import com.codahale.metrics.MetricRegistry;
-import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.junit.Assert;
 import org.junit.Test;
@@ -14,24 +12,19 @@ import java.util.stream.IntStream;
 public class KafkaFactoryTest {
     private static class FakeKafkaFactory extends KafkaFactory {
 
-        FakeKafkaFactory(final int numActiveProducers, final int consumerPoolSize) {
-            super(null, new MetricRegistry(), numActiveProducers, consumerPoolSize);
+        FakeKafkaFactory(final int numActiveProducers) {
+            super(null, numActiveProducers);
         }
 
         @Override
         protected Producer<byte[], byte[]> createProducerInstance() {
             return Mockito.mock(Producer.class);
         }
-
-        @Override
-        protected Consumer<byte[], byte[]> createConsumerProxyInstance() {
-            return Mockito.mock(Consumer.class);
-        }
     }
 
     @Test
     public void whenSingleProducerThenTheSameProducerIsGiven() {
-        final KafkaFactory factory = new FakeKafkaFactory(1, 2);
+        final KafkaFactory factory = new FakeKafkaFactory(1);
         final Producer<byte[], byte[]> producer1 = factory.takeProducer("topic-id");
         try {
             Assert.assertNotNull(producer1);
@@ -49,7 +42,7 @@ public class KafkaFactoryTest {
 
     @Test
     public void verifySingleProducerIsClosedAtCorrectTime() {
-        final KafkaFactory factory = new FakeKafkaFactory(1, 2);
+        final KafkaFactory factory = new FakeKafkaFactory(1);
 
         final List<Producer<byte[], byte[]>> producers1 = IntStream.range(0, 10)
                 .mapToObj(ignore -> factory.takeProducer("topic-id")).collect(Collectors.toList());
@@ -80,7 +73,7 @@ public class KafkaFactoryTest {
 
     @Test
     public void verifyNewProducerCreatedAfterCloseOfSingle() {
-        final KafkaFactory factory = new FakeKafkaFactory(1, 2);
+        final KafkaFactory factory = new FakeKafkaFactory(1);
         final Producer<byte[], byte[]> producer1 = factory.takeProducer("topic-id");
         Assert.assertNotNull(producer1);
         factory.terminateProducer(producer1);
@@ -96,7 +89,7 @@ public class KafkaFactoryTest {
 
     @Test
     public void testGoldenPathWithManyActiveProducers() {
-        final KafkaFactory factory = new FakeKafkaFactory(4, 2);
+        final KafkaFactory factory = new FakeKafkaFactory(4);
 
         final List<Producer<byte[], byte[]>> producers = IntStream.range(0, 10)
                 .mapToObj(ignore -> factory.takeProducer("topic-id")).collect(Collectors.toList());


### PR DESCRIPTION
the commit creates a pool of nakadi multi-timeline consumers to avoid excessive heap allocations on Kafka

that was especially possible because of prio refactoring #1516 and #1517