### PR TITLE
multi-timeline consumer pool 

### DIFF
--- a/api-metastore/src/main/java/org/zalando/nakadi/service/SubscriptionTimeLagService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/SubscriptionTimeLagService.java
@@ -1,11 +1,14 @@
 package org.zalando.nakadi.service;
 
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import org.echocat.jomon.runtime.concurrent.RetryForSpecifiedTimeStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.zalando.nakadi.config.NakadiSettings;
 import org.zalando.nakadi.domain.ConsumedEvent;
 import org.zalando.nakadi.domain.EventTypePartition;
 import org.zalando.nakadi.domain.NakadiCursor;
@@ -16,21 +19,24 @@ import org.zalando.nakadi.exceptions.runtime.InvalidCursorException;
 import org.zalando.nakadi.service.timeline.HighLevelConsumer;
 import org.zalando.nakadi.service.timeline.TimelineService;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 import static org.echocat.jomon.runtime.concurrent.Retryer.executeWithRetry;
 
@@ -42,23 +48,36 @@ public class SubscriptionTimeLagService {
     private static final int MAX_THREADS_PER_REQUEST = 20;
     private static final int TIME_LAG_COMMON_POOL_SIZE = 400;
 
-    private final TimelineService timelineService;
     private final NakadiCursorComparator cursorComparator;
     private final ThreadPoolExecutor threadPool;
+    private final ConsumerPool consumerPool;
 
     @Autowired
     public SubscriptionTimeLagService(final TimelineService timelineService,
-                                      final NakadiCursorComparator cursorComparator) {
-        this.timelineService = timelineService;
+                                      final NakadiCursorComparator cursorComparator,
+                                      final MetricRegistry metricRegistry,
+                                      final NakadiSettings nakadiSettings) {
+        if (nakadiSettings.getKafkaTimeLagCheckerConsumerPoolSize() <= 0) {
+            this.threadPool = null;
+            this.consumerPool = null;
+        } else {
+            this.threadPool = new ThreadPoolExecutor(0, TIME_LAG_COMMON_POOL_SIZE, 60L, TimeUnit.SECONDS,
+                    new SynchronousQueue<>());
+            this.consumerPool = new ConsumerPool(
+                    nakadiSettings.getKafkaTimeLagCheckerConsumerPoolSize(),
+                    () -> timelineService.createEventConsumer("timelag-checker"),
+                    metricRegistry);
+        }
         this.cursorComparator = cursorComparator;
-        this.threadPool = new ThreadPoolExecutor(0, TIME_LAG_COMMON_POOL_SIZE, 60L, TimeUnit.SECONDS,
-                new SynchronousQueue<>());
     }
 
     public Map<EventTypePartition, Duration> getTimeLags(final Collection<NakadiCursor> committedPositions,
                                                          final List<PartitionEndStatistics> endPositions) {
+        if (consumerPool == null) {
+            throw new IllegalStateException("Consumer pool was not initialized, check pool config");
+        }
 
-        final TimeLagRequestHandler timeLagHandler = new TimeLagRequestHandler(timelineService, threadPool);
+        final TimeLagRequestHandler timeLagHandler = new TimeLagRequestHandler(threadPool, consumerPool);
         final Map<EventTypePartition, Duration> timeLags = new HashMap<>();
         final Map<EventTypePartition, CompletableFuture<Duration>> futureTimeLags = new HashMap<>();
         try {
@@ -97,13 +116,14 @@ public class SubscriptionTimeLagService {
 
     private static class TimeLagRequestHandler {
 
-        private final TimelineService timelineService;
+        private final ConsumerPool consumerPool;
         private final ThreadPoolExecutor threadPool;
         private final Semaphore semaphore;
         private final long timeoutTimestampMs;
 
-        TimeLagRequestHandler(final TimelineService timelineService, final ThreadPoolExecutor threadPool) {
-            this.timelineService = timelineService;
+        TimeLagRequestHandler(final ThreadPoolExecutor threadPool,
+                              final ConsumerPool consumerPool) {
+            this.consumerPool = consumerPool;
             this.threadPool = threadPool;
             this.semaphore = new Semaphore(MAX_THREADS_PER_REQUEST);
             this.timeoutTimestampMs = System.currentTimeMillis() + REQUEST_TIMEOUT_MS;
@@ -138,13 +158,13 @@ public class SubscriptionTimeLagService {
             }
         }
 
-        private Duration getNextEventTimeLag(final NakadiCursor cursor) throws ErrorGettingCursorTimeLagException,
-                InconsistentStateException {
+        private Duration getNextEventTimeLag(final NakadiCursor cursor)
+                throws ErrorGettingCursorTimeLagException, InconsistentStateException {
 
             final String clientId = String.format("time-lag-checker-%s-%s",
                     cursor.getEventType(), cursor.getPartition());
-            try (HighLevelConsumer consumer = timelineService.createEventConsumer(
-                    clientId, ImmutableList.of(cursor))) {
+            final HighLevelConsumer consumer = consumerPool.takeConsumer(ImmutableList.of(cursor));
+            try {
                 LOG.trace("client:{}, reading events for lag calculation", clientId);
                 final ConsumedEvent nextEvent = executeWithRetry(
                         () -> {
@@ -160,14 +180,69 @@ public class SubscriptionTimeLagService {
                 } else {
                     return Duration.ofMillis(new Date().getTime() - nextEvent.getTimestamp());
                 }
-            } catch (final IOException e) {
-                throw new InconsistentStateException("Unexpected error happened when getting consumer time lag", e);
             } catch (final InvalidCursorException e) {
                 throw new ErrorGettingCursorTimeLagException(cursor, e);
             } finally {
                 LOG.trace("client:{}, finished reading events for lag calculation", clientId);
+                consumerPool.returnConsumer(consumer);
             }
         }
+    }
+
+    private static class ConsumerPool {
+        private final BlockingQueue<HighLevelConsumer> pool;
+        private final Meter consumerPoolTakeMeter;
+        private final Meter consumerPoolReturnMeter;
+
+        ConsumerPool(final int consumerPoolSize,
+                     final Supplier<HighLevelConsumer> consumerCreator,
+                     final MetricRegistry metricsRegistry) {
+            LOG.info("Preparing timelag checker pool of {} multi-timeline consumers", consumerPoolSize);
+            this.pool = new LinkedBlockingQueue(consumerPoolSize);
+            for (int i = 0; i < consumerPoolSize; ++i) {
+                this.pool.add(consumerCreator.get());
+            }
+
+            this.consumerPoolTakeMeter = metricsRegistry.meter("nakadi.timelag-consumer.taken");
+            this.consumerPoolReturnMeter = metricsRegistry.meter("nakadi.timelag-consumer.returned");
+        }
+
+        private HighLevelConsumer takeConsumer(final List<NakadiCursor> cursors) {
+            final HighLevelConsumer consumer;
+
+            LOG.trace("Taking timelag consumer from the pool");
+            try {
+                consumer = pool.poll(30, TimeUnit.SECONDS);
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("interrupted while waiting for a consumer from the pool");
+            }
+            if (consumer == null) {
+                throw new RuntimeException("timed out while waiting for a consumer from the pool");
+            }
+
+            consumer.reassign(cursors);
+
+            consumerPoolTakeMeter.mark();
+
+            return consumer;
+        }
+
+        private void returnConsumer(final HighLevelConsumer consumer) {
+            LOG.trace("Returning timelag consumer to the pool");
+
+            consumer.reassign(Collections.emptyList());
+
+            consumerPoolReturnMeter.mark();
+
+            try {
+                pool.put(consumer);
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("interrupted while putting a consumer back to the pool");
+            }
+        }
+
     }
 
 }

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/SubscriptionTimeLagService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/SubscriptionTimeLagService.java
@@ -16,7 +16,6 @@ import org.zalando.nakadi.domain.PartitionEndStatistics;
 import org.zalando.nakadi.exceptions.runtime.ErrorGettingCursorTimeLagException;
 import org.zalando.nakadi.exceptions.runtime.InconsistentStateException;
 import org.zalando.nakadi.exceptions.runtime.InvalidCursorException;
-import org.zalando.nakadi.exceptions.runtime.NakadiBaseException;
 import org.zalando.nakadi.service.timeline.HighLevelConsumer;
 import org.zalando.nakadi.service.timeline.TimelineService;
 

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -56,7 +56,7 @@ nakadi:
     maxStreamMemoryBytes: 50000000 # ~50 MB
   kafka:
     producers.count: 1
-    time-lag-checker.consumer-pool.size: 0
+    time-lag-checker.consumer-pool.size: 1
     retries: 0
     request.timeout.ms: 30000
     instanceType: t2.large

--- a/core-common/src/main/java/org/zalando/nakadi/repository/KafkaRepositoryCreator.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/KafkaRepositoryCreator.java
@@ -32,9 +32,9 @@ public class KafkaRepositoryCreator implements TopicRepositoryCreator {
     private final KafkaSettings kafkaSettings;
     private final ZookeeperSettings zookeeperSettings;
     private final KafkaTopicConfigFactory kafkaTopicConfigFactory;
-    private final MetricRegistry metricRegistry;
     private final ObjectMapper objectMapper;
     private final NakadiRecordMapper nakadiRecordMapper;
+    private final MetricRegistry metricRegistry;
 
     @Autowired
     public KafkaRepositoryCreator(
@@ -42,16 +42,16 @@ public class KafkaRepositoryCreator implements TopicRepositoryCreator {
             final KafkaSettings kafkaSettings,
             final ZookeeperSettings zookeeperSettings,
             final KafkaTopicConfigFactory kafkaTopicConfigFactory,
-            final MetricRegistry metricRegistry,
             final ObjectMapper objectMapper,
-            final NakadiRecordMapper nakadiRecordMapper) {
+            final NakadiRecordMapper nakadiRecordMapper,
+            final MetricRegistry metricRegistry) {
         this.nakadiSettings = nakadiSettings;
         this.kafkaSettings = kafkaSettings;
         this.zookeeperSettings = zookeeperSettings;
         this.kafkaTopicConfigFactory = kafkaTopicConfigFactory;
-        this.metricRegistry = metricRegistry;
         this.objectMapper = objectMapper;
         this.nakadiRecordMapper = nakadiRecordMapper;
+        this.metricRegistry = metricRegistry;
     }
 
     @Override
@@ -64,9 +64,8 @@ public class KafkaRepositoryCreator implements TopicRepositoryCreator {
                     zookeeperSettings.getZkConnectionTimeoutMs(),
                     nakadiSettings);
             final KafkaLocationManager kafkaLocationManager = new KafkaLocationManager(zooKeeperHolder, kafkaSettings);
-            final KafkaFactory kafkaFactory = new KafkaFactory(kafkaLocationManager, metricRegistry,
-                    nakadiSettings.getKafkaActiveProducersCount(),
-                    nakadiSettings.getKafkaTimeLagCheckerConsumerPoolSize());
+            final KafkaFactory kafkaFactory = new KafkaFactory(kafkaLocationManager,
+                    metricRegistry, nakadiSettings.getKafkaActiveProducersCount());
             final KafkaZookeeper zk = new KafkaZookeeper(zooKeeperHolder, objectMapper);
             final KafkaTopicRepository kafkaTopicRepository =
                     new KafkaTopicRepository.Builder()

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaFactoryTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaFactoryTest.java
@@ -1,7 +1,6 @@
 package org.zalando.nakadi.repository.kafka;
 
 import com.codahale.metrics.MetricRegistry;
-import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.junit.Assert;
 import org.junit.Test;
@@ -14,24 +13,19 @@ import java.util.stream.IntStream;
 public class KafkaFactoryTest {
     private static class FakeKafkaFactory extends KafkaFactory {
 
-        FakeKafkaFactory(final int numActiveProducers, final int consumerPoolSize) {
-            super(null, new MetricRegistry(), numActiveProducers, consumerPoolSize);
+        FakeKafkaFactory(final int numActiveProducers) {
+            super(null, new MetricRegistry(), numActiveProducers);
         }
 
         @Override
         protected Producer<byte[], byte[]> createProducerInstance() {
             return Mockito.mock(Producer.class);
         }
-
-        @Override
-        protected Consumer<byte[], byte[]> createConsumerProxyInstance() {
-            return Mockito.mock(Consumer.class);
-        }
     }
 
     @Test
     public void whenSingleProducerThenTheSameProducerIsGiven() {
-        final KafkaFactory factory = new FakeKafkaFactory(1, 2);
+        final KafkaFactory factory = new FakeKafkaFactory(1);
         final Producer<byte[], byte[]> producer1 = factory.takeProducer("topic-id");
         try {
             Assert.assertNotNull(producer1);
@@ -49,7 +43,7 @@ public class KafkaFactoryTest {
 
     @Test
     public void verifySingleProducerIsClosedAtCorrectTime() {
-        final KafkaFactory factory = new FakeKafkaFactory(1, 2);
+        final KafkaFactory factory = new FakeKafkaFactory(1);
 
         final List<Producer<byte[], byte[]>> producers1 = IntStream.range(0, 10)
                 .mapToObj(ignore -> factory.takeProducer("topic-id")).collect(Collectors.toList());
@@ -80,7 +74,7 @@ public class KafkaFactoryTest {
 
     @Test
     public void verifyNewProducerCreatedAfterCloseOfSingle() {
-        final KafkaFactory factory = new FakeKafkaFactory(1, 2);
+        final KafkaFactory factory = new FakeKafkaFactory(1);
         final Producer<byte[], byte[]> producer1 = factory.takeProducer("topic-id");
         Assert.assertNotNull(producer1);
         factory.terminateProducer(producer1);
@@ -96,7 +90,7 @@ public class KafkaFactoryTest {
 
     @Test
     public void testGoldenPathWithManyActiveProducers() {
-        final KafkaFactory factory = new FakeKafkaFactory(4, 2);
+        final KafkaFactory factory = new FakeKafkaFactory(4);
 
         final List<Producer<byte[], byte[]>> producers = IntStream.range(0, 10)
                 .mapToObj(ignore -> factory.takeProducer("topic-id")).collect(Collectors.toList());

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,5 +62,3 @@ services:
       KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
       KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
-    volumes:
-    - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
# One-line summary
the commit creates a pool of nakadi multi-timeline consumers to avoid excessive heap allocations on Kafka

that was especially possible because of prio refactoring https://github.com/zalando/nakadi/pull/1516 and https://github.com/zalando/nakadi/pull/1517