### PR TITLE
Remove reassign() from TopicRepository interface

### DIFF
--- a/api-metastore/src/test/java/org/zalando/nakadi/service/SubscriptionTimeLagServiceTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/service/SubscriptionTimeLagServiceTest.java
@@ -31,14 +31,12 @@ public class SubscriptionTimeLagServiceTest {
 
     private static final long FAKE_EVENT_TIMESTAMP = 478220400000L;
 
-    private NakadiCursorComparator cursorComparator;
     private TimelineService timelineService;
     private NakadiSettings nakadiSettings;
 
     @Before
     public void setUp() {
         timelineService = mock(TimelineService.class);
-        cursorComparator = mock(NakadiCursorComparator.class);
         nakadiSettings = mock(NakadiSettings.class);
         when(nakadiSettings.getKafkaTimeLagCheckerConsumerPoolSize()).thenReturn(2);
     }
@@ -46,59 +44,44 @@ public class SubscriptionTimeLagServiceTest {
     @Test
     public void testTimeLagsForTailAndNotTailPositions() throws InvalidCursorException {
 
-        final HighLevelConsumer eventConsumer = mock(HighLevelConsumer.class);
+        final HighLevelConsumer eventConsumer1 = mock(HighLevelConsumer.class);
+        final HighLevelConsumer eventConsumer2 = mock(HighLevelConsumer.class);
+
         final Timeline timeline = mock(Timeline.class);
         when(timeline.getStorage()).thenReturn(new Storage("", Storage.Type.KAFKA));
-        when(eventConsumer.readEvents())
+
+        when(eventConsumer1.readEvents()).thenAnswer(invocation -> ImmutableList.of());
+        when(eventConsumer2.readEvents())
                 .thenAnswer(invocation ->
                         ImmutableList.of(
                                 new ConsumedEvent(
                                         null, NakadiCursor.of(timeline, "", ""), FAKE_EVENT_TIMESTAMP, null)));
 
-        when(timelineService.createEventConsumer(anyString())).thenReturn(eventConsumer);
+        when(timelineService.createEventConsumer(anyString()))
+                .thenReturn(eventConsumer1)
+                .thenReturn(eventConsumer2);
 
         final Timeline et1Timeline = new Timeline("et1", 0, new Storage("", Storage.Type.KAFKA), "t1", null);
 
         final NakadiCursor committedCursor1 = NakadiCursor.of(et1Timeline, "p1", "o1");
         final NakadiCursor committedCursor2 = NakadiCursor.of(et1Timeline, "p2", "o2");
 
-        final PartitionEndStatistics endStats1 = mockEndStats(NakadiCursor.of(et1Timeline, "p1", "o1"));
-        final PartitionEndStatistics endStats2 = mockEndStats(NakadiCursor.of(et1Timeline, "p2", "o3"));
-
-        // mock first committed cursor to be at the tail - the expected time lag should be 0
-        when(cursorComparator.compare(committedCursor1, endStats1.getLast())).thenReturn(0);
-
-        // mock second committed cursor to be lower than tail - the expected time lag should be > 0
-        when(cursorComparator.compare(committedCursor2, endStats2.getLast())).thenReturn(-1);
-
         final SubscriptionTimeLagService timeLagService = new SubscriptionTimeLagService(
-                timelineService, cursorComparator, new MetricRegistry(), nakadiSettings);
-        final Map<EventTypePartition, Duration> timeLags = timeLagService.getTimeLags(
-                ImmutableList.of(committedCursor1, committedCursor2),
-                ImmutableList.of(endStats1, endStats2));
+                timelineService, new MetricRegistry(), nakadiSettings);
+        final Map<EventTypePartition, Duration> timeLags =
+                timeLagService.getTimeLags(ImmutableList.of(committedCursor1, committedCursor2));
 
         assertThat(timeLags.entrySet(), hasSize(2));
-        assertThat(timeLags.get(new EventTypePartition("et1", "p1")), equalTo(Duration.ZERO));
-        assertThat(timeLags.get(new EventTypePartition("et1", "p2")), greaterThan(Duration.ZERO));
-    }
 
-
-    @Test
-    public void whenNoSubscriptionThenReturnSizeZeroMap() {
-        final Timeline et1Timeline = new Timeline("et1", 0, new Storage("", Storage.Type.KAFKA), "t1", null);
-        final NakadiCursor committedCursor1 = NakadiCursor.of(et1Timeline, "p1", "o1");
-
-        when(timelineService.createEventConsumer(anyString())).thenReturn(mock(HighLevelConsumer.class));
-        final SubscriptionTimeLagService timeLagService = new SubscriptionTimeLagService(
-                timelineService, cursorComparator, new MetricRegistry(), nakadiSettings);
-        final Map<EventTypePartition, Duration> result = timeLagService.getTimeLags
-                (ImmutableList.of(committedCursor1), ImmutableList.of());
-        assertThat(result.size(), is(0));
-    }
-
-    private PartitionEndStatistics mockEndStats(final NakadiCursor nakadiCursor) {
-        final PartitionEndStatistics endStats = mock(PartitionEndStatistics.class);
-        when(endStats.getLast()).thenReturn(nakadiCursor);
-        return endStats;
+        // we don't control the order in which the consumers are used, but can assert that one lag is 0, and the other
+        // one is not
+        final Duration dur1 = timeLags.get(new EventTypePartition("et1", "p1"));
+        final Duration dur2 = timeLags.get(new EventTypePartition("et1", "p2"));
+        if (dur1.equals(Duration.ZERO)) {
+            assertThat(dur2, greaterThan(Duration.ZERO));
+        } else {
+            assertThat(dur1, greaterThan(Duration.ZERO));
+            assertThat(dur2, equalTo(Duration.ZERO));
+        }
     }
 }

--- a/core-common/src/main/java/org/zalando/nakadi/repository/TopicRepository.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/TopicRepository.java
@@ -94,6 +94,4 @@ public interface TopicRepository {
             ServiceTemporarilyUnavailableException;
 
     void updateTopicConfig(String topic, Long retentionMs, CleanupPolicy cleanupPolicy) throws TopicConfigException;
-
-    void reassign(LowLevelConsumer consumer, List<NakadiCursor> cursors);
 }

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -715,13 +715,12 @@ public class KafkaTopicRepository implements TopicRepository {
             @Nullable final String clientId,
             final List<NakadiCursor> cursors)
             throws ServiceTemporarilyUnavailableException, InvalidCursorException {
-        validateReadCursors(cursors);
+
         final NakadiKafkaConsumer nakadiKafkaConsumer = new NakadiKafkaConsumer(
                 kafkaFactory.getConsumer(clientId),
                 nakadiSettings.getKafkaPollTimeoutMs());
         nakadiKafkaConsumer.reassign(cursors);
         return nakadiKafkaConsumer;
-
     }
 
     @Override
@@ -752,12 +751,6 @@ public class KafkaTopicRepository implements TopicRepository {
                 throw new InvalidCursorException(UNAVAILABLE, position);
             }
         }
-    }
-
-    @Override
-    public void reassign(final LowLevelConsumer consumer, final List<NakadiCursor> cursors) {
-        validateReadCursors(cursors);
-        consumer.reassign(cursors);
     }
 
     @Override

--- a/core-services/src/main/java/org/zalando/nakadi/service/timeline/MultiTimelineEventConsumer.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/timeline/MultiTimelineEventConsumer.java
@@ -232,14 +232,7 @@ public class MultiTimelineEventConsumer implements HighLevelConsumer {
         for (final Map.Entry<TopicRepository, List<NakadiCursor>> entry : newAssignment.entrySet()) {
             final LowLevelConsumer existingEventConsumer = eventConsumers.get(entry.getKey());
             if (null != existingEventConsumer) {
-                final Set<TopicPartition> newTopicPartitions = entry.getValue().stream()
-                        .map(NakadiCursor::getTopicPartition)
-                        .collect(Collectors.toSet());
-                final Set<TopicPartition> oldAssignment = existingEventConsumer.getAssignment();
-                if (!oldAssignment.equals(newTopicPartitions)
-                        || oldAssignment.stream().anyMatch(actualReadPositionChanged::contains)) {
-                    existingEventConsumer.reassign(entry.getValue());
-                }
+                existingEventConsumer.reassign(entry.getValue());
             }
         }
         // Start new consumers with changed configuration.


### PR DESCRIPTION
There is no reason for this method to be there.
