### PR TITLE
Revert "multi-timeline consumer pool"

### DIFF
--- a/api-metastore/src/test/java/org/zalando/nakadi/service/SubscriptionTimeLagServiceTest.java
+++ b/api-metastore/src/test/java/org/zalando/nakadi/service/SubscriptionTimeLagServiceTest.java
@@ -1,10 +1,8 @@
 package org.zalando.nakadi.service;
 
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;
-import org.zalando.nakadi.config.NakadiSettings;
 import org.zalando.nakadi.domain.ConsumedEvent;
 import org.zalando.nakadi.domain.EventTypePartition;
 import org.zalando.nakadi.domain.NakadiCursor;
@@ -23,7 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -32,15 +30,15 @@ public class SubscriptionTimeLagServiceTest {
     private static final long FAKE_EVENT_TIMESTAMP = 478220400000L;
 
     private NakadiCursorComparator cursorComparator;
+    private SubscriptionTimeLagService timeLagService;
     private TimelineService timelineService;
-    private NakadiSettings nakadiSettings;
 
     @Before
     public void setUp() {
         timelineService = mock(TimelineService.class);
+
         cursorComparator = mock(NakadiCursorComparator.class);
-        nakadiSettings = mock(NakadiSettings.class);
-        when(nakadiSettings.getKafkaTimeLagCheckerConsumerPoolSize()).thenReturn(2);
+        timeLagService = new SubscriptionTimeLagService(timelineService, cursorComparator);
     }
 
     @Test
@@ -55,7 +53,7 @@ public class SubscriptionTimeLagServiceTest {
                                 new ConsumedEvent(
                                         null, NakadiCursor.of(timeline, "", ""), FAKE_EVENT_TIMESTAMP, null)));
 
-        when(timelineService.createEventConsumer(anyString())).thenReturn(eventConsumer);
+        when(timelineService.createEventConsumer(any(), any())).thenReturn(eventConsumer);
 
         final Timeline et1Timeline = new Timeline("et1", 0, new Storage("", Storage.Type.KAFKA), "t1", null);
 
@@ -71,8 +69,6 @@ public class SubscriptionTimeLagServiceTest {
         // mock second committed cursor to be lower than tail - the expected time lag should be > 0
         when(cursorComparator.compare(committedCursor2, endStats2.getLast())).thenReturn(-1);
 
-        final SubscriptionTimeLagService timeLagService = new SubscriptionTimeLagService(
-                timelineService, cursorComparator, new MetricRegistry(), nakadiSettings);
         final Map<EventTypePartition, Duration> timeLags = timeLagService.getTimeLags(
                 ImmutableList.of(committedCursor1, committedCursor2),
                 ImmutableList.of(endStats1, endStats2));
@@ -85,12 +81,10 @@ public class SubscriptionTimeLagServiceTest {
 
     @Test
     public void whenNoSubscriptionThenReturnSizeZeroMap() {
+        when(timelineService.createEventConsumer(any(), any())).thenReturn(null);
         final Timeline et1Timeline = new Timeline("et1", 0, new Storage("", Storage.Type.KAFKA), "t1", null);
         final NakadiCursor committedCursor1 = NakadiCursor.of(et1Timeline, "p1", "o1");
 
-        when(timelineService.createEventConsumer(anyString())).thenReturn(mock(HighLevelConsumer.class));
-        final SubscriptionTimeLagService timeLagService = new SubscriptionTimeLagService(
-                timelineService, cursorComparator, new MetricRegistry(), nakadiSettings);
         final Map<EventTypePartition, Duration> result = timeLagService.getTimeLags
                 (ImmutableList.of(committedCursor1), ImmutableList.of());
         assertThat(result.size(), is(0));

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -56,7 +56,7 @@ nakadi:
     maxStreamMemoryBytes: 50000000 # ~50 MB
   kafka:
     producers.count: 1
-    time-lag-checker.consumer-pool.size: 1
+    time-lag-checker.consumer-pool.size: 0
     retries: 0
     request.timeout.ms: 30000
     instanceType: t2.large

--- a/core-common/src/main/java/org/zalando/nakadi/repository/KafkaRepositoryCreator.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/KafkaRepositoryCreator.java
@@ -32,9 +32,9 @@ public class KafkaRepositoryCreator implements TopicRepositoryCreator {
     private final KafkaSettings kafkaSettings;
     private final ZookeeperSettings zookeeperSettings;
     private final KafkaTopicConfigFactory kafkaTopicConfigFactory;
+    private final MetricRegistry metricRegistry;
     private final ObjectMapper objectMapper;
     private final NakadiRecordMapper nakadiRecordMapper;
-    private final MetricRegistry metricRegistry;
 
     @Autowired
     public KafkaRepositoryCreator(
@@ -42,16 +42,16 @@ public class KafkaRepositoryCreator implements TopicRepositoryCreator {
             final KafkaSettings kafkaSettings,
             final ZookeeperSettings zookeeperSettings,
             final KafkaTopicConfigFactory kafkaTopicConfigFactory,
+            final MetricRegistry metricRegistry,
             final ObjectMapper objectMapper,
-            final NakadiRecordMapper nakadiRecordMapper,
-            final MetricRegistry metricRegistry) {
+            final NakadiRecordMapper nakadiRecordMapper) {
         this.nakadiSettings = nakadiSettings;
         this.kafkaSettings = kafkaSettings;
         this.zookeeperSettings = zookeeperSettings;
         this.kafkaTopicConfigFactory = kafkaTopicConfigFactory;
+        this.metricRegistry = metricRegistry;
         this.objectMapper = objectMapper;
         this.nakadiRecordMapper = nakadiRecordMapper;
-        this.metricRegistry = metricRegistry;
     }
 
     @Override
@@ -64,8 +64,9 @@ public class KafkaRepositoryCreator implements TopicRepositoryCreator {
                     zookeeperSettings.getZkConnectionTimeoutMs(),
                     nakadiSettings);
             final KafkaLocationManager kafkaLocationManager = new KafkaLocationManager(zooKeeperHolder, kafkaSettings);
-            final KafkaFactory kafkaFactory = new KafkaFactory(kafkaLocationManager,
-                    metricRegistry, nakadiSettings.getKafkaActiveProducersCount());
+            final KafkaFactory kafkaFactory = new KafkaFactory(kafkaLocationManager, metricRegistry,
+                    nakadiSettings.getKafkaActiveProducersCount(),
+                    nakadiSettings.getKafkaTimeLagCheckerConsumerPoolSize());
             final KafkaZookeeper zk = new KafkaZookeeper(zooKeeperHolder, objectMapper);
             final KafkaTopicRepository kafkaTopicRepository =
                     new KafkaTopicRepository.Builder()

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
@@ -11,10 +11,14 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -29,11 +33,15 @@ public class KafkaFactory {
     private final ReadWriteLock rwLock;
     private final List<Producer<byte[], byte[]>> activeProducers;
 
+    private final BlockingQueue<Consumer<byte[], byte[]>> consumerPool;
     private final Meter consumerCreateMeter;
+    private final Meter consumerPoolTakeMeter;
+    private final Meter consumerPoolReturnMeter;
 
     public KafkaFactory(final KafkaLocationManager kafkaLocationManager,
                         final MetricRegistry metricsRegistry,
-                        final int numActiveProducers) {
+                        final int numActiveProducers,
+                        final int consumerPoolSize) {
         this.kafkaLocationManager = kafkaLocationManager;
 
         this.useCount = new ConcurrentHashMap<>();
@@ -45,7 +53,19 @@ public class KafkaFactory {
             this.activeProducers.add(null);
         }
 
+        if (consumerPoolSize > 0) {
+            LOG.info("Preparing timelag checker pool of {} Kafka consumers", consumerPoolSize);
+            this.consumerPool = new LinkedBlockingQueue(consumerPoolSize);
+            for (int i = 0; i < consumerPoolSize; ++i) {
+                this.consumerPool.add(createConsumerProxyInstance());
+            }
+        } else {
+            this.consumerPool = null;
+        }
+
         this.consumerCreateMeter = metricsRegistry.meter("nakadi.kafka.consumer.created");
+        this.consumerPoolTakeMeter = metricsRegistry.meter("nakadi.kafka.consumer.taken");
+        this.consumerPoolReturnMeter = metricsRegistry.meter("nakadi.kafka.consumer.returned");
     }
 
     @Nullable
@@ -148,7 +168,45 @@ public class KafkaFactory {
         return getConsumer();
     }
 
+    private Consumer<byte[], byte[]> takeConsumer() {
+        final Consumer<byte[], byte[]> consumer;
+
+        LOG.trace("Taking timelag consumer from the pool");
+        try {
+            consumer = consumerPool.poll(30, TimeUnit.SECONDS);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("interrupted while waiting for a consumer from the pool");
+        }
+        if (consumer == null) {
+            throw new RuntimeException("timed out while waiting for a consumer from the pool");
+        }
+
+        consumerPoolTakeMeter.mark();
+
+        return consumer;
+    }
+
+    private void returnConsumer(final Consumer<byte[], byte[]> consumer) {
+        LOG.trace("Returning timelag consumer to the pool");
+
+        consumer.assign(Collections.emptyList());
+
+        consumerPoolReturnMeter.mark();
+
+        try {
+            consumerPool.put(consumer);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("interrupted while putting a consumer back to the pool");
+        }
+    }
+
     public Consumer<byte[], byte[]> getConsumer() {
+        if (consumerPool != null) {
+            return takeConsumer();
+        }
+
         return getConsumer(kafkaLocationManager.getKafkaConsumerProperties());
     }
 
@@ -156,10 +214,26 @@ public class KafkaFactory {
 
         consumerCreateMeter.mark();
 
-        return new KafkaConsumer<>(properties);
+        return new KafkaConsumer<byte[], byte[]>(properties);
     }
 
     protected Producer<byte[], byte[]> createProducerInstance() {
-        return new KafkaProducer<>(kafkaLocationManager.getKafkaProducerProperties());
+        return new KafkaProducer<byte[], byte[]>(kafkaLocationManager.getKafkaProducerProperties());
+    }
+
+    protected Consumer<byte[], byte[]> createConsumerProxyInstance() {
+        return new KafkaConsumerProxy(kafkaLocationManager.getKafkaConsumerProperties());
+    }
+
+    public class KafkaConsumerProxy extends KafkaConsumer<byte[], byte[]> {
+
+        public KafkaConsumerProxy(final Properties properties) {
+            super(properties);
+        }
+
+        @Override
+        public void close() {
+            returnConsumer(this);
+        }
     }
 }

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaFactoryTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaFactoryTest.java
@@ -1,6 +1,7 @@
 package org.zalando.nakadi.repository.kafka;
 
 import com.codahale.metrics.MetricRegistry;
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.junit.Assert;
 import org.junit.Test;
@@ -13,19 +14,24 @@ import java.util.stream.IntStream;
 public class KafkaFactoryTest {
     private static class FakeKafkaFactory extends KafkaFactory {
 
-        FakeKafkaFactory(final int numActiveProducers) {
-            super(null, new MetricRegistry(), numActiveProducers);
+        FakeKafkaFactory(final int numActiveProducers, final int consumerPoolSize) {
+            super(null, new MetricRegistry(), numActiveProducers, consumerPoolSize);
         }
 
         @Override
         protected Producer<byte[], byte[]> createProducerInstance() {
             return Mockito.mock(Producer.class);
         }
+
+        @Override
+        protected Consumer<byte[], byte[]> createConsumerProxyInstance() {
+            return Mockito.mock(Consumer.class);
+        }
     }
 
     @Test
     public void whenSingleProducerThenTheSameProducerIsGiven() {
-        final KafkaFactory factory = new FakeKafkaFactory(1);
+        final KafkaFactory factory = new FakeKafkaFactory(1, 2);
         final Producer<byte[], byte[]> producer1 = factory.takeProducer("topic-id");
         try {
             Assert.assertNotNull(producer1);
@@ -43,7 +49,7 @@ public class KafkaFactoryTest {
 
     @Test
     public void verifySingleProducerIsClosedAtCorrectTime() {
-        final KafkaFactory factory = new FakeKafkaFactory(1);
+        final KafkaFactory factory = new FakeKafkaFactory(1, 2);
 
         final List<Producer<byte[], byte[]>> producers1 = IntStream.range(0, 10)
                 .mapToObj(ignore -> factory.takeProducer("topic-id")).collect(Collectors.toList());
@@ -74,7 +80,7 @@ public class KafkaFactoryTest {
 
     @Test
     public void verifyNewProducerCreatedAfterCloseOfSingle() {
-        final KafkaFactory factory = new FakeKafkaFactory(1);
+        final KafkaFactory factory = new FakeKafkaFactory(1, 2);
         final Producer<byte[], byte[]> producer1 = factory.takeProducer("topic-id");
         Assert.assertNotNull(producer1);
         factory.terminateProducer(producer1);
@@ -90,7 +96,7 @@ public class KafkaFactoryTest {
 
     @Test
     public void testGoldenPathWithManyActiveProducers() {
-        final KafkaFactory factory = new FakeKafkaFactory(4);
+        final KafkaFactory factory = new FakeKafkaFactory(4, 2);
 
         final List<Producer<byte[], byte[]>> producers = IntStream.range(0, 10)
                 .mapToObj(ignore -> factory.takeProducer("topic-id")).collect(Collectors.toList());

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,3 +62,5 @@ services:
       KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
       KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+    volumes:
+    - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Reverts zalando/nakadi#1520

The solution is incomplete due to consumers being created often in the middle layer for checking earlies/newest offsets within partition.  We will have to find a different approach, but for now stick with the consumer pool at the bottom layer that covers every use.