### PR TITLE
Implement optional settings that enable Nakadi security

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -77,6 +77,8 @@ public class KafkaRepositoryAT extends BaseAT {
     private static final long DEFAULT_CURATOR_MAX_LIFETIME_MS = 1000;
     private static final long DEFAULT_CURATOR_ROTATION_MS = 10000;
     private static final int TCP_SEND_BUFFER_SIZE = 128 * 1024;
+    private static final int PLAIN_TEXT_SERVER_PORT = 9092;
+    private static final int SASL_SERVER_PORT = 9093;
 
     private NakadiSettings nakadiSettings;
     private KafkaSettings kafkaSettings;
@@ -113,7 +115,9 @@ public class KafkaRepositoryAT extends BaseAT {
         kafkaSettings = new KafkaSettings(KAFKA_RETRIES, KAFKA_REQUEST_TIMEOUT, KAFKA_BATCH_SIZE, KAFKA_BUFFER_MEMORY,
                 KAFKA_LINGER_MS, KAFKA_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, KAFKA_ENABLE_AUTO_COMMIT,
                 KAFKA_MAX_REQUEST_SIZE, KAFKA_DELIVERY_TIMEOUT, KAFKA_MAX_BLOCK_TIMEOUT, "",
-                KAFKA_COMPRESSION_TYPE, TCP_SEND_BUFFER_SIZE);
+                KAFKA_COMPRESSION_TYPE, TCP_SEND_BUFFER_SIZE, Optional.of(9093),
+                Optional.of("SASL_PLAINTEXT"), Optional.of("PLAIN"), Optional.of("nakadi"),
+                Optional.of("nakadi_password"));
         kafkaHelper = new KafkaTestHelper(KAFKA_URL);
         defaultTopicConfig = new NakadiTopicConfig(DEFAULT_PARTITION_COUNT, DEFAULT_CLEANUP_POLICY,
                 Optional.of(DEFAULT_RETENTION_TIME));

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -77,8 +77,6 @@ public class KafkaRepositoryAT extends BaseAT {
     private static final long DEFAULT_CURATOR_MAX_LIFETIME_MS = 1000;
     private static final long DEFAULT_CURATOR_ROTATION_MS = 10000;
     private static final int TCP_SEND_BUFFER_SIZE = 128 * 1024;
-    private static final int PLAIN_TEXT_SERVER_PORT = 9092;
-    private static final int SASL_SERVER_PORT = 9093;
 
     private NakadiSettings nakadiSettings;
     private KafkaSettings kafkaSettings;

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -43,22 +43,25 @@ public class KafkaLocationManager {
     }
 
     private void applySecurityProperties() {
-        if (this.kafkaSettings.getSecurityProtocol().isPresent()) {
+        if (this.kafkaSettings.getSecurityProtocol().isPresent()
+                && this.kafkaSettings.getSaslMechanism().isPresent()
+                && this.kafkaSettings.getKafkaPassword().isPresent()
+                && this.kafkaSettings.getKafkaUsername().isPresent()) {
             this.kafkaProperties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,
                     this.kafkaSettings.getSecurityProtocol().get());
-        }
-        if (this.kafkaSettings.getSaslMechanism().isPresent()) {
             this.kafkaProperties.put(SaslConfigs.SASL_MECHANISM,
                     this.kafkaSettings.getSaslMechanism().get());
-        }
-        if (this.kafkaSettings.getKafkaUsername().isPresent() &&
-                this.kafkaSettings.getKafkaPassword().isPresent()) {
             this.kafkaProperties.put(SaslConfigs.SASL_JAAS_CONFIG,
                     "org.apache.kafka.common.security.plain.PlainLoginModule required " +
                             "username=" + this.kafkaSettings.getKafkaUsername().get()
                             + " password=\"" + this.kafkaSettings.getKafkaPassword().get() + "\";");
+        } else {
+            LOG.warn(String.format("To configure Kafka Client security " +
+                    "nakadi.kafka.security.protocol, " +
+                    "nakadi.kafka.sasl.mechanism, " +
+                    "nakadi.kafka.username and " +
+                    "nakadi.kafka.password are all required"));
         }
-        LOG.info("Kafka security settings" + this.kafkaProperties.toString());
     }
 
     private void updateBootstrapServersSafe(final boolean createWatcher) {

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -37,13 +37,12 @@ public class KafkaLocationManager {
         this.zkFactory = zkFactory;
         this.kafkaProperties = new Properties();
         this.kafkaSettings = kafkaSettings;
-        applySecurityProperties();
-        this.updateBootstrapServers(true);
+        applyKafkaSettings();
         this.scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
         this.scheduledExecutor.scheduleAtFixedRate(() -> updateBootstrapServersSafe(false), 1, 1, TimeUnit.MINUTES);
     }
 
-    private void applySecurityProperties() {
+    private void applyKafkaSettings() {
         if (this.kafkaSettings.getSecurityProtocol().isPresent()
                 && this.kafkaSettings.getSaslMechanism().isPresent()
                 && this.kafkaSettings.getKafkaPassword().isPresent()
@@ -63,6 +62,7 @@ public class KafkaLocationManager {
                     "nakadi.kafka.username and " +
                     "nakadi.kafka.password are all required"));
         }
+        this.updateBootstrapServers(true);
     }
 
     private void updateBootstrapServersSafe(final boolean createWatcher) {
@@ -163,7 +163,7 @@ public class KafkaLocationManager {
             this.host = host;
             this.port = port;
         }
-        
+
         static Broker fromByteJson(final byte[] data, final Optional<Integer> portOpt)
                 throws JSONException, UnsupportedEncodingException {
             final JSONObject json = new JSONObject(new String(data, "UTF-8"));

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -175,7 +175,7 @@ public class KafkaLocationManager {
                 throws JSONException, UnsupportedEncodingException {
             final JSONObject json = new JSONObject(new String(data, "UTF-8"));
             final String host = json.getString("host");
-            final int port = json.getInt("port");
+            final Integer port = json.getInt("port");
             return new Broker(host, port);
         }
 

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -5,6 +5,7 @@ import org.apache.curator.framework.api.GetChildrenBuilder;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.zookeeper.Watcher;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -35,9 +36,29 @@ public class KafkaLocationManager {
         this.zkFactory = zkFactory;
         this.kafkaProperties = new Properties();
         this.kafkaSettings = kafkaSettings;
+        applySecurityProperties();
         this.updateBootstrapServers(true);
         this.scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
         this.scheduledExecutor.scheduleAtFixedRate(() -> updateBootstrapServersSafe(false), 1, 1, TimeUnit.MINUTES);
+    }
+
+    private void applySecurityProperties() {
+        if (this.kafkaSettings.getSecurityProtocol().isPresent()) {
+            this.kafkaProperties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,
+                    this.kafkaSettings.getSecurityProtocol().get());
+        }
+        if (this.kafkaSettings.getSaslMechanism().isPresent()) {
+            this.kafkaProperties.put(SaslConfigs.SASL_MECHANISM,
+                    this.kafkaSettings.getSaslMechanism().get());
+        }
+        if (this.kafkaSettings.getKafkaUsername().isPresent() &&
+                this.kafkaSettings.getKafkaPassword().isPresent()) {
+            this.kafkaProperties.put(SaslConfigs.SASL_JAAS_CONFIG,
+                    "org.apache.kafka.common.security.plain.PlainLoginModule required " +
+                            "username=" + this.kafkaSettings.getKafkaUsername().get()
+                            + " password=\"" + this.kafkaSettings.getKafkaPassword().get() + "\";");
+        }
+        LOG.info("Kafka security settings" + this.kafkaProperties.toString());
     }
 
     private void updateBootstrapServersSafe(final boolean createWatcher) {
@@ -68,7 +89,12 @@ public class KafkaLocationManager {
             }
             for (final String brokerId : childrenBuilder.forPath(BROKERS_IDS_PATH)) {
                 final byte[] brokerData = curator.getData().forPath(BROKERS_IDS_PATH + "/" + brokerId);
-                brokers.add(Broker.fromByteJson(brokerData));
+                if (this.kafkaSettings.getPreferredListenerPort().isPresent()) {
+                    brokers.add(Broker.fromByteJson(brokerData,
+                            this.kafkaSettings.getPreferredListenerPort().get()));
+                } else {
+                    brokers.add(Broker.fromByteJson(brokerData));
+                }
             }
         } catch (final Exception e) {
             LOG.error("Failed to fetch list of brokers from ZooKeeper", e);
@@ -125,6 +151,7 @@ public class KafkaLocationManager {
         producerProps.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, kafkaSettings.getDeliveryTimeoutMs());
         producerProps.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, kafkaSettings.getMaxBlockMs());
         producerProps.put(ProducerConfig.SEND_BUFFER_CONFIG, kafkaSettings.getSocketSendBufferBytes());
+
         return producerProps;
     }
 
@@ -137,10 +164,18 @@ public class KafkaLocationManager {
             this.port = port;
         }
 
-        static Broker fromByteJson(final byte[] data) throws JSONException, UnsupportedEncodingException {
+        static Broker fromByteJson(final byte[] data, final int port)
+                throws JSONException, UnsupportedEncodingException {
             final JSONObject json = new JSONObject(new String(data, "UTF-8"));
             final String host = json.getString("host");
-            final Integer port = json.getInt("port");
+            return new Broker(host, port);
+        }
+
+        static Broker fromByteJson(final byte[] data)
+                throws JSONException, UnsupportedEncodingException {
+            final JSONObject json = new JSONObject(new String(data, "UTF-8"));
+            final String host = json.getString("host");
+            final int port = json.getInt("port");
             return new Broker(host, port);
         }
 

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -163,22 +163,7 @@ public class KafkaLocationManager {
             this.host = host;
             this.port = port;
         }
-
-        static Broker fromByteJson(final byte[] data, final int port)
-                throws JSONException, UnsupportedEncodingException {
-            final JSONObject json = new JSONObject(new String(data, "UTF-8"));
-            final String host = json.getString("host");
-            return new Broker(host, port);
-        }
-
-        static Broker fromByteJson(final byte[] data)
-                throws JSONException, UnsupportedEncodingException {
-            final JSONObject json = new JSONObject(new String(data, "UTF-8"));
-            final String host = json.getString("host");
-            final Integer port = json.getInt("port");
-            return new Broker(host, port);
-        }
-
+        
         static Broker fromByteJson(final byte[] data, final Optional<Integer> portOpt)
                 throws JSONException, UnsupportedEncodingException {
             final JSONObject json = new JSONObject(new String(data, "UTF-8"));

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -37,9 +37,8 @@ public class KafkaLocationManager {
         this.zkFactory = zkFactory;
         this.kafkaProperties = new Properties();
         this.kafkaSettings = kafkaSettings;
-        applyKafkaSettings();
         this.scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
-        this.scheduledExecutor.scheduleAtFixedRate(() -> updateBootstrapServersSafe(false), 1, 1, TimeUnit.MINUTES);
+        applyKafkaSettings();
     }
 
     private void applyKafkaSettings() {
@@ -63,6 +62,7 @@ public class KafkaLocationManager {
                     "nakadi.kafka.password are all required"));
         }
         this.updateBootstrapServers(true);
+        this.scheduledExecutor.scheduleAtFixedRate(() -> updateBootstrapServersSafe(false), 1, 1, TimeUnit.MINUTES);
     }
 
     private void updateBootstrapServersSafe(final boolean createWatcher) {

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -16,6 +16,7 @@ import org.zalando.nakadi.repository.zookeeper.ZooKeeperHolder;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -92,12 +93,8 @@ public class KafkaLocationManager {
             }
             for (final String brokerId : childrenBuilder.forPath(BROKERS_IDS_PATH)) {
                 final byte[] brokerData = curator.getData().forPath(BROKERS_IDS_PATH + "/" + brokerId);
-                if (this.kafkaSettings.getPreferredListenerPort().isPresent()) {
-                    brokers.add(Broker.fromByteJson(brokerData,
-                            this.kafkaSettings.getPreferredListenerPort().get()));
-                } else {
-                    brokers.add(Broker.fromByteJson(brokerData));
-                }
+                brokers.add(Broker.fromByteJson(brokerData,
+                        this.kafkaSettings.getPreferredListenerPort()));
             }
         } catch (final Exception e) {
             LOG.error("Failed to fetch list of brokers from ZooKeeper", e);
@@ -180,6 +177,13 @@ public class KafkaLocationManager {
             final String host = json.getString("host");
             final Integer port = json.getInt("port");
             return new Broker(host, port);
+        }
+
+        static Broker fromByteJson(final byte[] data, final Optional<Integer> portOpt)
+                throws JSONException, UnsupportedEncodingException {
+            final JSONObject json = new JSONObject(new String(data, "UTF-8"));
+            final String host = json.getString("host");
+            return new Broker(host, portOpt.orElse(json.getInt("port")));
         }
 
         public String toString() {

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -54,8 +54,14 @@ public class KafkaLocationManager {
                     "org.apache.kafka.common.security.plain.PlainLoginModule required " +
                             "username=" + this.kafkaSettings.getKafkaUsername().get()
                             + " password=\"" + this.kafkaSettings.getKafkaPassword().get() + "\";");
-        } else {
-            LOG.warn(String.format("To configure Kafka Client security " +
+        } else if (
+                this.kafkaSettings.getSecurityProtocol().isPresent()
+                        || this.kafkaSettings.getSaslMechanism().isPresent()
+                        || this.kafkaSettings.getKafkaPassword().isPresent()
+                        || this.kafkaSettings.getKafkaUsername().isPresent()
+        ) {
+            LOG.warn(String.format("Looks like you're trying to configure " +
+                    "Kafka client security. To configure Kafka Client security " +
                     "nakadi.kafka.security.protocol, " +
                     "nakadi.kafka.sasl.mechanism, " +
                     "nakadi.kafka.username and " +

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSettings.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSettings.java
@@ -4,6 +4,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @Component
 public class KafkaSettings {
 
@@ -26,7 +28,11 @@ public class KafkaSettings {
     private final String clientRack;
     private final String compressionType;
     private final int socketSendBufferBytes;
-
+    private final Optional<Integer> preferredListenerPort;
+    private final Optional<String> securityProtocol;
+    private final Optional<String> saslMechanism;
+    private final Optional<String> kafkaUsername;
+    private final Optional<String> kafkaPassword;
     @Autowired
     public KafkaSettings(@Value("${nakadi.kafka.retries}") final int retries,
                          @Value("${nakadi.kafka.request.timeout.ms}") final int requestTimeoutMs,
@@ -40,7 +46,13 @@ public class KafkaSettings {
                          @Value("${nakadi.kafka.max.block.ms}") final int maxBlockMs,
                          @Value("${nakadi.kafka.client.rack:}") final String clientRack,
                          @Value("${nakadi.kafka.compression.type:lz4}") final String compressionType,
-                         @Value("${nakadi.kafka.socket.send.buffer.bytes:}") final int socketSendBufferBytes) {
+                         @Value("${nakadi.kafka.socket.send.buffer.bytes:}") final int socketSendBufferBytes,
+                         @Value("${nakadi.kafka.preferred.listener.port:#{null}}")
+                             final Optional<Integer> preferredListenerPort,
+                         @Value("${nakadi.kafka.security.protocol:#{null}}") final Optional<String> securityProtocol,
+                         @Value("${nakadi.kafka.sasl.mechanism:#{null}}") final Optional<String> saslMechanism,
+                         @Value("${nakadi.kafka.username:#{null}}") final Optional<String> kafkaUsername,
+                         @Value("${nakadi.kafka.password:#{null}}") final Optional<String> kafkaPassword) {
         this.retries = retries;
         this.requestTimeoutMs = requestTimeoutMs;
         this.batchSize = batchSize;
@@ -54,6 +66,11 @@ public class KafkaSettings {
         this.clientRack = clientRack;
         this.compressionType = compressionType;
         this.socketSendBufferBytes = socketSendBufferBytes;
+        this.preferredListenerPort = preferredListenerPort;
+        this.securityProtocol = securityProtocol;
+        this.saslMechanism = saslMechanism;
+        this.kafkaUsername = kafkaUsername;
+        this.kafkaPassword = kafkaPassword;
     }
 
     public int getRetries() {
@@ -106,5 +123,25 @@ public class KafkaSettings {
 
     public int getSocketSendBufferBytes() {
         return socketSendBufferBytes;
+    }
+
+    public Optional<Integer> getPreferredListenerPort() {
+        return preferredListenerPort;
+    }
+
+    public Optional<String> getSecurityProtocol() {
+        return securityProtocol;
+    }
+
+    public Optional<String> getSaslMechanism() {
+        return saslMechanism;
+    }
+
+    public Optional<String> getKafkaUsername() {
+        return kafkaUsername;
+    }
+
+    public Optional<String> getKafkaPassword() {
+        return kafkaPassword;
     }
 }

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaLocationManagerTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaLocationManagerTest.java
@@ -1,0 +1,112 @@
+package org.zalando.nakadi.repository.kafka;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.GetChildrenBuilder;
+import org.apache.curator.framework.api.GetDataBuilder;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.zalando.nakadi.repository.zookeeper.ZooKeeperHolder;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class KafkaLocationManagerTest {
+    @Test
+    public void testItAppliesSecuritySettings() {
+        final var zkFactoryMock = mock(ZooKeeperHolder.class);
+        final var kafkaSettingsMock = mock(KafkaSettings.class);
+
+        when(kafkaSettingsMock.getSecurityProtocol()).thenReturn(Optional.of("SASL_PLAINTEXT"));
+        when(kafkaSettingsMock.getSaslMechanism()).thenReturn(Optional.of("PLAIN"));
+        when(kafkaSettingsMock.getKafkaUsername()).thenReturn(Optional.of("nakadi_user"));
+        when(kafkaSettingsMock.getKafkaPassword()).thenReturn(Optional.of("nakadi_password"));
+
+        final var kafkaLocationManager = new KafkaLocationManager(zkFactoryMock, kafkaSettingsMock);
+        final var kafkaProperties = kafkaLocationManager.getProperties();
+
+        Assertions.assertEquals("SASL_PLAINTEXT",
+                kafkaProperties.get(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
+        Assertions.assertEquals("PLAIN", kafkaProperties.get(SaslConfigs.SASL_MECHANISM));
+        Assertions.assertEquals("org.apache.kafka.common.security.plain.PlainLoginModule required " +
+                        "username=nakadi_user password=\"nakadi_password\";",
+                kafkaProperties.get(SaslConfigs.SASL_JAAS_CONFIG));
+
+    }
+
+    @Test
+    public void testItAppliesSecurityOnlyIfAllRequiredConfigsAreProvided() {
+        final var zkFactoryMock = mock(ZooKeeperHolder.class);
+        final var kafkaSettingsMock = mock(KafkaSettings.class);
+
+        when(kafkaSettingsMock.getSecurityProtocol()).thenReturn(Optional.of("SASL_PLAINTEXT"));
+
+        final var kafkaLocationManager = new KafkaLocationManager(zkFactoryMock, kafkaSettingsMock);
+        final var kafkaProperties = kafkaLocationManager.getProperties();
+
+        Assertions.assertEquals(null, kafkaProperties.get(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG));
+        Assertions.assertEquals(null, kafkaProperties.get(SaslConfigs.SASL_MECHANISM));
+        Assertions.assertEquals(null, kafkaProperties.get(SaslConfigs.SASL_JAAS_CONFIG));
+    }
+
+    @Test
+    public void testItGetsTheListOfBrokersFromZookeeperButListenerPortFromConfig() throws Exception {
+        final var zkFactoryMock = mock(ZooKeeperHolder.class);
+        final var kafkaSettingsMock = mock(KafkaSettings.class);
+        final var curatorMock = mock(CuratorFramework.class);
+        final var childrenBuilderMock = mock(GetChildrenBuilder.class);
+        final var getDataBuilderMock = mock(GetDataBuilder.class);
+
+        //Configuration mocks
+        when(kafkaSettingsMock.getPreferredListenerPort()).thenReturn(Optional.of(9093));
+        //Curator mocks
+        when(zkFactoryMock.get()).thenReturn(curatorMock);
+        when(curatorMock.getChildren()).thenReturn(childrenBuilderMock);
+        when(curatorMock.getData()).thenReturn(getDataBuilderMock);
+
+        when(childrenBuilderMock.forPath(anyString())).thenReturn(List.of("broker-1", "broker-2"));
+        when(getDataBuilderMock.forPath(contains("broker-1")))
+                .thenReturn("{\"host\": \"192.168.1.100\", \"port\":9092}".getBytes("UTF-8"));
+        when(getDataBuilderMock.forPath(contains("broker-2")))
+                .thenReturn("{\"host\": \"192.168.1.101\", \"port\":9092}".getBytes("UTF-8"));
+
+        final var kafkaLocationManager = new KafkaLocationManager(zkFactoryMock, kafkaSettingsMock);
+
+        final var kafkaProperties = kafkaLocationManager.getProperties();
+
+        Assertions.assertEquals("192.168.1.100:9093,192.168.1.101:9093",
+                kafkaProperties.get(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG));
+    }
+
+    @Test
+    public void testItGetsTheListOfBrokersFromZookeeper() throws Exception {
+        final var zkFactoryMock = mock(ZooKeeperHolder.class);
+        final var kafkaSettingsMock = mock(KafkaSettings.class);
+        final var curatorMock = mock(CuratorFramework.class);
+        final var childrenBuilderMock = mock(GetChildrenBuilder.class);
+        final var getDataBuilderMock = mock(GetDataBuilder.class);
+
+        when(zkFactoryMock.get()).thenReturn(curatorMock);
+        when(curatorMock.getChildren()).thenReturn(childrenBuilderMock);
+        when(curatorMock.getData()).thenReturn(getDataBuilderMock);
+
+        when(childrenBuilderMock.forPath(anyString())).thenReturn(List.of("broker-1", "broker-2"));
+        when(getDataBuilderMock.forPath(contains("broker-1")))
+                .thenReturn("{\"host\": \"192.168.1.100\", \"port\":9092}".getBytes("UTF-8"));
+        when(getDataBuilderMock.forPath(contains("broker-2")))
+                .thenReturn("{\"host\": \"192.168.1.101\", \"port\":9092}".getBytes("UTF-8"));
+
+        final var kafkaLocationManager = new KafkaLocationManager(zkFactoryMock, kafkaSettingsMock);
+
+        final var kafkaProperties = kafkaLocationManager.getProperties();
+
+        Assertions.assertEquals("192.168.1.100:9092,192.168.1.101:9092",
+                kafkaProperties.get(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG));
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,11 @@ services:
     - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/local_nakadi_db?preferQueryMode=simple
     - SPRING_DATASOURCE_USERNAME=nakadi
     - SPRING_DATASOURCE_PASSWORD=nakadi
+    - NAKADI_KAFKA_PREFERRED_LISTENER_PORT=9093
+    - NAKADI_KAFKA_SECURITY_PROTOCOL=SASL_PLAINTEXT
+    - NAKADI_KAFKA_SASL_MECHANISM=PLAIN
+    - NAKADI_KAFKA_USERNAME=nakadi
+    - NAKADI_KAFKA_PASSWORD=nakadi_password
 
   postgres:
     image: postgres:14
@@ -47,20 +52,25 @@ services:
     ports:
     - "29092:29092"
     - "9092:9092"
+    - "9093:9093"
     depends_on:
     - zookeeper
     environment:
       # to debug when the container doesn't start due to invalid config:
       BITNAMI_DEBUG: 'yes'
-
       ALLOW_PLAINTEXT_LISTENER: 'yes'
       KAFKA_ENABLE_KRAFT: 'no'
       KAFKA_BROKER_ID: 0
-      KAFKA_CFG_ADVERTISED_LISTENERS: INTERNAL://kafka:9092,EXTERNAL://localhost:29092
+      KAFKA_CFG_ADVERTISED_LISTENERS: INTERNAL://kafka:9092,EXTERNAL://localhost:29092,CLIENT://kafka:9093
+      KAFKA_CFG_LISTENERS: INTERNAL://kafka:9092,EXTERNAL://0.0.0.0:29092,CLIENT://:9093
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,CLIENT:SASL_PLAINTEXT
       KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: 'false'
-      KAFKA_CFG_LISTENERS: INTERNAL://kafka:9092,EXTERNAL://0.0.0.0:29092
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
       KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_CLIENT_USERS: nakadi, producer
+      KAFKA_CLIENT_PASSWORDS: nakadi_password, producer_password
+      KAFKA_CFG_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: INTERNAL
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock
+


### PR DESCRIPTION
Introduce `SECURITY_PROTOCOL`, `SASL_MECHANISM`, `KAFKA_USERNAME` and `KAFKA_PASSWORD` Nakadi settings that will allow Nakadi to configure Kafka clients with security SASL Plain username + password.

Nakadi discovers the list of Brokers by looking in all registered storages entries in Zookeeper, and iterates `/brokers/ids` to discover every broker IP address and Port. This PR introduces `PREFERRED_LISTENER_PORT` setting that allow Nakadi to connect to different listeners in Kafka(previously would connect to the port available in Zookeeper entry, which is the first port of all available listeners, and also an internal Zookeeper structure).