### PR TITLE
skipped events

### DIFF
--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -3,7 +3,6 @@ package org.zalando.nakadi.service.subscription.state;
 import com.codahale.metrics.Meter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zalando.nakadi.domain.ConsumedEvent;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,5 +62,3 @@ services:
       KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
       KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
-    volumes:
-    - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
# One-line summary
Provide number of skipped events due to retention time when stream is opened

example:
```
{"cursor":{...},"events":[...],"info":{"debug":"Skipped events due to retention time passed, count: 1"}}
```