### PR TITLE
Update zookeeper client

### DIFF
--- a/api-metastore/src/main/java/org/zalando/nakadi/model/AuthorizationAttributeQueryParser.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/model/AuthorizationAttributeQueryParser.java
@@ -1,6 +1,6 @@
 package org.zalando.nakadi.model;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.zalando.nakadi.domain.ResourceAuthorizationAttribute;
 import org.zalando.nakadi.plugin.api.authz.AuthorizationAttribute;
 

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/SubscriptionService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/SubscriptionService.java
@@ -2,7 +2,7 @@ package org.zalando.nakadi.service;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ subprojects {
             kafkaClientVersion = '3.3.2'
             dropwizardVersion = '3.1.3'
             curatorVersion = '5.1.0'
-            zookeeperVersion = '3.6.1'
+            zookeeperVersion = '3.6.4'
             jacksonVersion = '2.9.8'
             opentracingVersion = '0.33.0'
         }


### PR DESCRIPTION
# One-line summary

## Description
Update `org.apache.zookeeper` dependency to `3.6.1` (to reduce noisy logging) which includes fix for:
https://issues.apache.org/jira/browse/ZOOKEEPER-4376

## Deployment Notes
This change should be compatible with the Zookeeper server `3.6.1`.
