### PR TITLE
Relax Kafka producer reset cases

### DIFF
--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -18,7 +18,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.NetworkException;
-import org.apache.kafka.common.errors.NotLeaderForPartitionException;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -199,9 +199,7 @@ public class KafkaTopicRepository implements TopicRepository {
         if (null == exception) {
             return false;
         }
-        return Stream.of(NotLeaderForPartitionException.class, UnknownTopicOrPartitionException.class,
-                        org.apache.kafka.common.errors.TimeoutException.class, NetworkException.class,
-                        UnknownServerException.class)
+        return Stream.of(UnknownTopicOrPartitionException.class, NetworkException.class, UnknownServerException.class)
                 .anyMatch(clazz -> clazz.isAssignableFrom(exception.getClass()));
     }
 


### PR DESCRIPTION
Neither `NotLeaderOrFollower` nor `Timeout` is a good reason for resetting the producer.