### PR TITLE
evict cache value only if load is successful

### DIFF
--- a/core-services/src/main/java/org/zalando/nakadi/cache/EventTypeCache.java
+++ b/core-services/src/main/java/org/zalando/nakadi/cache/EventTypeCache.java
@@ -150,10 +150,11 @@ public class EventTypeCache {
         this.eventTypeRepository = eventTypeRepository;
         this.timelineRepository = timelineRepository;
         this.topicRepositoryHolder = topicRepositoryHolder;
-        this.valueCache = CacheBuilder.newBuilder()
-                .expireAfterWrite(Duration.ofHours(2))
-                .build(CacheLoader.from(this::loadValue));
         this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        this.valueCache = CacheBuilder.newBuilder()
+                .refreshAfterWrite(Duration.ofHours(2))
+                .build(CacheLoader.asyncReloading(
+                        CacheLoader.from(this::loadValue), scheduledExecutorService));
         this.timelineSync = timelineSync;
         this.eventValidatorBuilder = eventValidatorBuilder;
         this.schemaService = schemaService;


### PR DESCRIPTION
at the moment if value was evicted and load from database fails cache wont have a value, that will create unavailability on the publishing path. the commit changes that behaviour to have value ecivted from the cache only in case the value was successfully loaded