### PR TITLE
Do not close producers on specific errors

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/utils/NakadiTestUtils.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/utils/NakadiTestUtils.java
@@ -111,7 +111,9 @@ public class NakadiTestUtils {
         given()
                 .body("[" + events + "]")
                 .contentType(JSON)
-                .post(path);
+                .post(path)
+                .then()
+                .statusCode(HttpStatus.SC_OK);
     }
 
     public static void repartitionEventType(final EventType eventType, final int partitionsNumber)

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaFactory.java
@@ -9,29 +9,20 @@ import org.apache.kafka.clients.producer.Producer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class KafkaFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaFactory.class);
     private final KafkaLocationManager kafkaLocationManager;
 
-    private final Map<Producer<byte[], byte[]>, AtomicInteger> useCount;
-    private final ReadWriteLock rwLock;
-    private final List<Producer<byte[], byte[]>> activeProducers;
+    private final List<Producer<byte[], byte[]>> producers;
 
     private final BlockingQueue<Consumer<byte[], byte[]>> consumerPool;
     private final Meter consumerCreateMeter;
@@ -44,13 +35,10 @@ public class KafkaFactory {
                         final int consumerPoolSize) {
         this.kafkaLocationManager = kafkaLocationManager;
 
-        this.useCount = new ConcurrentHashMap<>();
-        this.rwLock = new ReentrantReadWriteLock();
-
-        LOG.info("Allocating up to {} active Kafka producers", numActiveProducers);
-        this.activeProducers = new ArrayList<>(numActiveProducers);
+        LOG.info("Allocating {} Kafka producers", numActiveProducers);
+        this.producers = new ArrayList<>(numActiveProducers);
         for (int i = 0; i < numActiveProducers; ++i) {
-            this.activeProducers.add(null);
+            this.producers.add(createProducerInstance());
         }
 
         if (consumerPoolSize > 0) {
@@ -68,100 +56,9 @@ public class KafkaFactory {
         this.consumerPoolReturnMeter = metricsRegistry.meter("nakadi.kafka.consumer.returned");
     }
 
-    @Nullable
-    private Producer<byte[], byte[]> takeUnderLock(final int index, final boolean canCreate) {
-        final Lock lock = canCreate ? rwLock.writeLock() : rwLock.readLock();
-        lock.lock();
-        try {
-            Producer<byte[], byte[]> producer = activeProducers.get(index);
-            if (null != producer) {
-                useCount.get(producer).incrementAndGet();
-                return producer;
-            } else if (canCreate) {
-                producer = createProducerInstance();
-                useCount.put(producer, new AtomicInteger(1));
-                activeProducers.set(index, producer);
-
-                LOG.info("New producer instance created: " + producer);
-                return producer;
-            } else {
-                return null;
-            }
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    /**
-     * Takes producer from producer cache. Every producer, that was received by this method must be released with
-     * {@link #releaseProducer(Producer)} method.
-     *
-     * @return Initialized kafka producer instance.
-     */
     public Producer<byte[], byte[]> takeProducer(final String topic) {
-        final int index = Math.abs(topic.hashCode() % activeProducers.size());
-
-        Producer<byte[], byte[]> result = takeUnderLock(index, false);
-        if (null == result) {
-            result = takeUnderLock(index, true);
-        }
-        return result;
-    }
-
-    /**
-     * Release kafka producer that was obtained by {@link #takeProducer(String)} method. If producer was not obtained by
-     * {@link #takeProducer(String)} call - method will throw {@link NullPointerException}
-     *
-     * @param producer Producer to release.
-     */
-    public void releaseProducer(final Producer<byte[], byte[]> producer) {
-        final AtomicInteger counter = useCount.get(producer);
-        if (counter != null && 0 == counter.decrementAndGet()) {
-            final boolean deleteProducer;
-            rwLock.readLock().lock();
-            try {
-                deleteProducer = !activeProducers.contains(producer);
-            } finally {
-                rwLock.readLock().unlock();
-            }
-            if (deleteProducer) {
-                rwLock.writeLock().lock();
-                try {
-                    if (counter.get() == 0 && null != useCount.remove(producer)) {
-                        LOG.info("Stopping producer instance - It was reported that instance should be refreshed " +
-                                "and it is not used anymore: " + producer);
-                        producer.close();
-                    }
-                } finally {
-                    rwLock.writeLock().unlock();
-                }
-            }
-        }
-    }
-
-    /**
-     * Notifies producer cache, that this producer should be marked as obsolete. All methods, that are using this
-     * producer instance right now can continue using it, but new calls to {@link #takeProducer(String)}
-     * will use some other producers.
-     * It is allowed to call this method only between {@link #takeProducer(String)} and
-     * {@link #releaseProducer(Producer)} method calls.
-     * (You can not terminate something that you do not own)
-     *
-     * @param producer Producer instance to terminate.
-     */
-    public void terminateProducer(final Producer<byte[], byte[]> producer) {
-        LOG.info("Received signal to terminate producer " + producer);
-        rwLock.writeLock().lock();
-        try {
-            final int index = activeProducers.indexOf(producer);
-            if (index >= 0) {
-                activeProducers.set(index, null);
-            } else {
-                LOG.info("Signal for producer termination already received: " + producer);
-            }
-        } finally {
-            rwLock.writeLock().unlock();
-        }
+        final int index = Math.abs(topic.hashCode() % producers.size());
+        return producers.get(index);
     }
 
     public Consumer<byte[], byte[]> getConsumer(final String clientId /* ignored */) {

--- a/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaFactoryTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/repository/kafka/KafkaFactoryTest.java
@@ -33,65 +33,10 @@ public class KafkaFactoryTest {
     public void whenSingleProducerThenTheSameProducerIsGiven() {
         final KafkaFactory factory = new FakeKafkaFactory(1, 2);
         final Producer<byte[], byte[]> producer1 = factory.takeProducer("topic-id");
-        try {
-            Assert.assertNotNull(producer1);
-        } finally {
-            factory.releaseProducer(producer1);
-        }
-
-        final Producer<byte[], byte[]> producer2 = factory.takeProducer("topic-id");
-        try {
-            Assert.assertSame(producer1, producer2);
-        } finally {
-            factory.releaseProducer(producer2);
-        }
-    }
-
-    @Test
-    public void verifySingleProducerIsClosedAtCorrectTime() {
-        final KafkaFactory factory = new FakeKafkaFactory(1, 2);
-
-        final List<Producer<byte[], byte[]>> producers1 = IntStream.range(0, 10)
-                .mapToObj(ignore -> factory.takeProducer("topic-id")).collect(Collectors.toList());
-        final Producer<byte[], byte[]> producer = producers1.get(0);
-        Assert.assertNotNull(producer);
-        producers1.forEach(p -> Assert.assertSame(producer, p));
-        producers1.forEach(factory::releaseProducer);
-
-        Mockito.verify(producer, Mockito.times(0)).close();
-
-
-        final List<Producer<byte[], byte[]>> producers2 = IntStream.range(0, 10)
-                .mapToObj(ignore -> factory.takeProducer("topic-id")).collect(Collectors.toList());
-        final Producer<byte[], byte[]> additionalProducer = factory.takeProducer("topic-id");
-
-        Assert.assertSame(producer, additionalProducer);
-        producers2.forEach(p -> Assert.assertSame(producer, p));
-
-        factory.terminateProducer(producers2.get(0));
-        Mockito.verify(producer, Mockito.times(0)).close();
-
-        producers2.forEach(factory::releaseProducer);
-        Mockito.verify(producer, Mockito.times(0)).close();
-
-        factory.releaseProducer(additionalProducer);
-        Mockito.verify(producer, Mockito.times(1)).close();
-    }
-
-    @Test
-    public void verifyNewProducerCreatedAfterCloseOfSingle() {
-        final KafkaFactory factory = new FakeKafkaFactory(1, 2);
-        final Producer<byte[], byte[]> producer1 = factory.takeProducer("topic-id");
         Assert.assertNotNull(producer1);
-        factory.terminateProducer(producer1);
-        factory.releaseProducer(producer1);
-        Mockito.verify(producer1, Mockito.times(1)).close();
 
         final Producer<byte[], byte[]> producer2 = factory.takeProducer("topic-id");
-        Assert.assertNotNull(producer2);
-        Assert.assertNotSame(producer1, producer2);
-        factory.releaseProducer(producer2);
-        Mockito.verify(producer2, Mockito.times(0)).close();
+        Assert.assertSame(producer1, producer2);
     }
 
     @Test
@@ -102,6 +47,5 @@ public class KafkaFactoryTest {
                 .mapToObj(ignore -> factory.takeProducer("topic-id")).collect(Collectors.toList());
 
         producers.forEach(Assert::assertNotNull);
-        producers.forEach(factory::releaseProducer);
     }
 }


### PR DESCRIPTION
Not removing producers means we do not explicitly close them, so we don't need all the locking code around take/terminate/release in `KafkaFactory`.

Note the change in `KafkaTopicRepository::listPartitionNames`: use admin client instead of some producer, because we need the up-to-date result, not some cached value.  This call is not used in hot path, as the partitions list is storead in the `EventTypeCache`.  Also when invalidating that cache entry we need to fetch an up-to-date value.