### PR TITLE
allow fallback to remote on IO error

### DIFF
--- a/app/src/main/java/org/zalando/nakadi/config/AuthenticationConfig.java
+++ b/app/src/main/java/org/zalando/nakadi/config/AuthenticationConfig.java
@@ -22,6 +22,7 @@ import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
 import org.springframework.util.Assert;
 import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 import org.zalando.nakadi.exceptions.runtime.ServiceTemporarilyUnavailableException;
 import org.zalando.nakadi.service.FeatureToggleService;
@@ -154,7 +155,7 @@ public class AuthenticationConfig {
                     .header(HttpHeaders.AUTHORIZATION, String.format(BEARER_TOKEN_TEMPLATE, accessToken)).build();
             try {
                 return restTemplate.exchange(entity, TOKENINFO_MAP).getBody();
-            } catch (HttpStatusCodeException e) {
+            } catch (HttpStatusCodeException | ResourceAccessException e ) {
                 throw new ServiceTemporarilyUnavailableException("Unable to validate token", e);
             } catch (Exception e) {
                 LOGGER.warn("Unable to get authorisation from tokeninfo", e);

--- a/app/src/main/java/org/zalando/nakadi/config/NakadiResourceServerTokenServices.java
+++ b/app/src/main/java/org/zalando/nakadi/config/NakadiResourceServerTokenServices.java
@@ -7,7 +7,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
-import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
 import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
@@ -43,14 +42,6 @@ public class NakadiResourceServerTokenServices implements ResourceServerTokenSer
             if (!featureToggleService.isFeatureEnabled(Feature.REMOTE_TOKENINFO)) {
                 try {
                     return localService.loadAuthentication(accessToken);
-                }
-                catch (final InvalidTokenException ex) {
-                    //IO exceptions are wrapped in InvalidTokenException
-                    //so if message contains IO error then allow to use fallback
-                    //look at RestTemplate#doExecute for the IO error message
-                    if(!ex.getMessage().contains("I/O error")) {
-                        throw ex;
-                    }
                 }
                 catch (final OAuth2Exception ex) {
                     throw ex;

--- a/app/src/main/java/org/zalando/nakadi/config/NakadiResourceServerTokenServices.java
+++ b/app/src/main/java/org/zalando/nakadi/config/NakadiResourceServerTokenServices.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
 import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
@@ -42,9 +43,18 @@ public class NakadiResourceServerTokenServices implements ResourceServerTokenSer
             if (!featureToggleService.isFeatureEnabled(Feature.REMOTE_TOKENINFO)) {
                 try {
                     return localService.loadAuthentication(accessToken);
-                } catch (final OAuth2Exception ex) {
+                }
+                catch (final InvalidTokenException ex) {
+                    //IO exceptions are wrapped in InvalidTokenException so if message contains IO error then allow to use fallback
+                    //look at RestTemplate#doExecute for the IO error message
+                    if(!ex.getMessage().contains("I/O error")) {
+                        throw ex;
+                    }
+                }
+                catch (final OAuth2Exception ex) {
                     throw ex;
-                } catch (RuntimeException ex) {
+                }
+                catch (RuntimeException ex) {
                     // This event should be pretty rare, so it is fine to log this exception.
                     LOG.error("Failed to load local tokeninfo information", ex);
                 }

--- a/app/src/main/java/org/zalando/nakadi/config/NakadiResourceServerTokenServices.java
+++ b/app/src/main/java/org/zalando/nakadi/config/NakadiResourceServerTokenServices.java
@@ -45,7 +45,8 @@ public class NakadiResourceServerTokenServices implements ResourceServerTokenSer
                     return localService.loadAuthentication(accessToken);
                 }
                 catch (final InvalidTokenException ex) {
-                    //IO exceptions are wrapped in InvalidTokenException so if message contains IO error then allow to use fallback
+                    //IO exceptions are wrapped in InvalidTokenException
+                    //so if message contains IO error then allow to use fallback
                     //look at RestTemplate#doExecute for the IO error message
                     if(!ex.getMessage().contains("I/O error")) {
                         throw ex;

--- a/app/src/main/java/org/zalando/nakadi/config/NakadiResourceServerTokenServices.java
+++ b/app/src/main/java/org/zalando/nakadi/config/NakadiResourceServerTokenServices.java
@@ -42,11 +42,9 @@ public class NakadiResourceServerTokenServices implements ResourceServerTokenSer
             if (!featureToggleService.isFeatureEnabled(Feature.REMOTE_TOKENINFO)) {
                 try {
                     return localService.loadAuthentication(accessToken);
-                }
-                catch (final OAuth2Exception ex) {
+                } catch (final OAuth2Exception ex) {
                     throw ex;
-                }
-                catch (RuntimeException ex) {
+                } catch (RuntimeException ex) {
                     // This event should be pretty rare, so it is fine to log this exception.
                     LOG.error("Failed to load local tokeninfo information", ex);
                 }

--- a/app/src/test/java/org/zalando/nakadi/config/NakadiResourceServerTokenServicesTest.java
+++ b/app/src/test/java/org/zalando/nakadi/config/NakadiResourceServerTokenServicesTest.java
@@ -6,13 +6,15 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.web.client.ResourceAccessException;
 import org.zalando.nakadi.domain.Feature;
-import org.zalando.nakadi.exceptions.runtime.ServiceTemporarilyUnavailableException;
 import org.zalando.nakadi.service.FeatureToggleService;
+import org.zalando.stups.oauth2.spring.server.TokenInfoRequestExecutor;
 import org.zalando.stups.oauth2.spring.server.TokenInfoResourceServerTokenServices;
 
 import static org.junit.Assert.assertEquals;
@@ -20,6 +22,8 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,6 +35,7 @@ public class NakadiResourceServerTokenServicesTest {
     @Mock
     private MetricRegistry metricRegistry;
     @Mock
+    private TokenInfoRequestExecutor tokenInfoRequestExecutor;
     private TokenInfoResourceServerTokenServices localService;
     @Mock
     private TokenInfoResourceServerTokenServices remoteService;
@@ -44,7 +49,8 @@ public class NakadiResourceServerTokenServicesTest {
         final Timer.Context context = mock(Timer.Context.class);
         when(timer.time()).thenReturn(context);
         when(metricRegistry.timer(any())).thenReturn(timer);
-
+        localService = Mockito.
+                spy(new TokenInfoResourceServerTokenServices(tokenInfoRequestExecutor));
         objectToTest = new NakadiResourceServerTokenServices(
                 metricRegistry, localService, remoteService, featureToggleService);
     }
@@ -65,7 +71,7 @@ public class NakadiResourceServerTokenServicesTest {
         when(featureToggleService.isFeatureEnabled(eq(Feature.REMOTE_TOKENINFO))).thenReturn(false);
 
         final OAuth2Authentication expectedResponse = mock(OAuth2Authentication.class);
-        when(localService.loadAuthentication(any())).thenReturn(expectedResponse);
+        doReturn(expectedResponse).when(localService).loadAuthentication(any());
 
         final OAuth2Authentication response = objectToTest.loadAuthentication("bbb");
 
@@ -78,7 +84,7 @@ public class NakadiResourceServerTokenServicesTest {
         when(featureToggleService.isFeatureEnabled(eq(Feature.REMOTE_TOKENINFO))).thenReturn(false);
 
         final OAuth2Exception expectedException = mock(OAuth2Exception.class);
-        when(localService.loadAuthentication(any())).thenThrow(expectedException);
+        doThrow(expectedException).when(localService).loadAuthentication(any());
 
         try {
             objectToTest.loadAuthentication("bbb");
@@ -93,7 +99,7 @@ public class NakadiResourceServerTokenServicesTest {
     public void whenLocalBrokenRemoteValidUsed() {
         when(featureToggleService.isFeatureEnabled(eq(Feature.REMOTE_TOKENINFO))).thenReturn(false);
 
-        when(localService.loadAuthentication(any())).thenThrow(mock(RuntimeException.class));
+        doThrow(new RuntimeException("")).when(localService).loadAuthentication(any());
         final OAuth2Authentication expectedResponse = mock(OAuth2Authentication.class);
         when(remoteService.loadAuthentication(any())).thenReturn(expectedResponse);
 
@@ -105,7 +111,7 @@ public class NakadiResourceServerTokenServicesTest {
     public void whenLocalBrokenRemoteBadUsed() {
         when(featureToggleService.isFeatureEnabled(eq(Feature.REMOTE_TOKENINFO))).thenReturn(false);
 
-        when(localService.loadAuthentication(any())).thenThrow(mock(RuntimeException.class));
+        doThrow(new RuntimeException("")).when(localService).loadAuthentication(any());
         final OAuth2Exception expectedException = mock(OAuth2Exception.class);
         when(remoteService.loadAuthentication(any())).thenThrow(expectedException);
 
@@ -120,7 +126,7 @@ public class NakadiResourceServerTokenServicesTest {
     @Test
     public void whenLocalIsUnavailableRemoteIsUsed() {
         when(featureToggleService.isFeatureEnabled(eq(Feature.REMOTE_TOKENINFO))).thenReturn(false);
-        when(localService.loadAuthentication(any())).thenThrow(new ServiceTemporarilyUnavailableException(""));
+        when(tokenInfoRequestExecutor.getMap(any())).thenThrow(new ResourceAccessException(""));
         objectToTest.loadAuthentication("bbb");
         verify(localService, times(1)).loadAuthentication(eq("bbb"));
         verify(remoteService, times(1)).loadAuthentication(eq("bbb"));
@@ -130,7 +136,7 @@ public class NakadiResourceServerTokenServicesTest {
     public void whenLocalBrokenRemote500Replaced() {
         when(featureToggleService.isFeatureEnabled(eq(Feature.REMOTE_TOKENINFO))).thenReturn(false);
 
-        when(localService.loadAuthentication(any())).thenThrow(mock(RuntimeException.class));
+        doThrow(new RuntimeException("")).when(localService).loadAuthentication(any());
         when(remoteService.loadAuthentication(any())).thenThrow(new RuntimeException("msg"));
 
         try{

--- a/app/src/test/java/org/zalando/nakadi/config/NakadiResourceServerTokenServicesTest.java
+++ b/app/src/test/java/org/zalando/nakadi/config/NakadiResourceServerTokenServicesTest.java
@@ -137,8 +137,10 @@ public class NakadiResourceServerTokenServicesTest {
     @Test
     public void whenLocalThrowsInvalidTokenRemoteIsNotUsed() {
         when(featureToggleService.isFeatureEnabled(eq(Feature.REMOTE_TOKENINFO))).thenReturn(false);
-        when(localService.loadAuthentication(any())).thenThrow(new InvalidTokenException("tokeninfo returned error:"));
-        Assert.assertThrows(InvalidTokenException.class,  () -> objectToTest.loadAuthentication("bbb")) ;
+        when(localService.loadAuthentication(any())).
+                thenThrow(new InvalidTokenException("tokeninfo returned error:"));
+        Assert.assertThrows(InvalidTokenException.class,
+                () -> objectToTest.loadAuthentication("bbb")) ;
     }
 
     @Test

--- a/app/src/test/java/org/zalando/nakadi/config/NakadiResourceServerTokenServicesTest.java
+++ b/app/src/test/java/org/zalando/nakadi/config/NakadiResourceServerTokenServicesTest.java
@@ -2,17 +2,16 @@ package org.zalando.nakadi.config;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
 import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.zalando.nakadi.domain.Feature;
+import org.zalando.nakadi.exceptions.runtime.ServiceTemporarilyUnavailableException;
 import org.zalando.nakadi.service.FeatureToggleService;
 import org.zalando.stups.oauth2.spring.server.TokenInfoResourceServerTokenServices;
 
@@ -119,28 +118,12 @@ public class NakadiResourceServerTokenServicesTest {
     }
 
     @Test
-    public void whenLocalTimesOutRemoteIsUsed() {
+    public void whenLocalIsUnavailableRemoteIsUsed() {
         when(featureToggleService.isFeatureEnabled(eq(Feature.REMOTE_TOKENINFO))).thenReturn(false);
-
-        when(localService.loadAuthentication(any())).thenThrow(
-                new InvalidTokenException("tokeninfo returned error: I/O error on " +
-                "GET request for \"http://127.0.0.1:9021/oauth2/tokeninfo\": " +
-                "Timeout waiting for connection from pool; " +
-                "nested exception is org.apache.http.conn.ConnectionPoolTimeoutException: " +
-                "Timeout waiting for connection from pool"));
-
+        when(localService.loadAuthentication(any())).thenThrow(new ServiceTemporarilyUnavailableException(""));
         objectToTest.loadAuthentication("bbb");
         verify(localService, times(1)).loadAuthentication(eq("bbb"));
         verify(remoteService, times(1)).loadAuthentication(eq("bbb"));
-    }
-
-    @Test
-    public void whenLocalThrowsInvalidTokenRemoteIsNotUsed() {
-        when(featureToggleService.isFeatureEnabled(eq(Feature.REMOTE_TOKENINFO))).thenReturn(false);
-        when(localService.loadAuthentication(any())).
-                thenThrow(new InvalidTokenException("tokeninfo returned error:"));
-        Assert.assertThrows(InvalidTokenException.class,
-                () -> objectToTest.loadAuthentication("bbb")) ;
     }
 
     @Test


### PR DESCRIPTION
## Description
In Nakadi, there is logic to retry load token info first from local token and then fallback to remote token info on failure. This logic does not account for when the local token info fails with timeout/IO exception. This PR introduces fix so that it accounts for IO exception and retries remote token info.

## Review
- [x] Tests
