### PR TITLE
Use idempotent producer once again to enable safe retries

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -54,6 +54,8 @@ public class KafkaRepositoryAT extends BaseAT {
     private static final Long DEFAULT_RETENTION_TIME = 100L;
     private static final Long DEFAULT_TOPIC_RETENTION = 100000000L;
     private static final CleanupPolicy DEFAULT_CLEANUP_POLICY = CleanupPolicy.DELETE;
+    private static final int KAFKA_RETRIES = 10;
+    private static final boolean KAFKA_IDEMPOTENCE = false;
     private static final int KAFKA_REQUEST_TIMEOUT = 30000;
     private static final int KAFKA_DELIVERY_TIMEOUT = 30000;
     private static final int KAFKA_MAX_BLOCK_TIMEOUT = 5000;
@@ -109,7 +111,8 @@ public class KafkaRepositoryAT extends BaseAT {
                 DEFAULT_CURATOR_MAX_LIFETIME_MS,
                 DEFAULT_CURATOR_ROTATION_MS);
 
-        kafkaSettings = new KafkaSettings(KAFKA_REQUEST_TIMEOUT, KAFKA_BATCH_SIZE, KAFKA_BUFFER_MEMORY,
+        kafkaSettings = new KafkaSettings(KAFKA_RETRIES, KAFKA_IDEMPOTENCE, KAFKA_REQUEST_TIMEOUT,
+                KAFKA_BATCH_SIZE, KAFKA_BUFFER_MEMORY,
                 KAFKA_LINGER_MS, KAFKA_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, KAFKA_ENABLE_AUTO_COMMIT,
                 KAFKA_MAX_REQUEST_SIZE, KAFKA_DELIVERY_TIMEOUT, KAFKA_MAX_BLOCK_TIMEOUT, "",
                 KAFKA_COMPRESSION_TYPE, TCP_SEND_BUFFER_SIZE, Optional.of(9093),

--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -54,7 +54,6 @@ public class KafkaRepositoryAT extends BaseAT {
     private static final Long DEFAULT_RETENTION_TIME = 100L;
     private static final Long DEFAULT_TOPIC_RETENTION = 100000000L;
     private static final CleanupPolicy DEFAULT_CLEANUP_POLICY = CleanupPolicy.DELETE;
-    private static final int KAFKA_RETRIES = 10;
     private static final int KAFKA_REQUEST_TIMEOUT = 30000;
     private static final int KAFKA_DELIVERY_TIMEOUT = 30000;
     private static final int KAFKA_MAX_BLOCK_TIMEOUT = 5000;
@@ -110,7 +109,7 @@ public class KafkaRepositoryAT extends BaseAT {
                 DEFAULT_CURATOR_MAX_LIFETIME_MS,
                 DEFAULT_CURATOR_ROTATION_MS);
 
-        kafkaSettings = new KafkaSettings(KAFKA_RETRIES, KAFKA_REQUEST_TIMEOUT, KAFKA_BATCH_SIZE, KAFKA_BUFFER_MEMORY,
+        kafkaSettings = new KafkaSettings(KAFKA_REQUEST_TIMEOUT, KAFKA_BATCH_SIZE, KAFKA_BUFFER_MEMORY,
                 KAFKA_LINGER_MS, KAFKA_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, KAFKA_ENABLE_AUTO_COMMIT,
                 KAFKA_MAX_REQUEST_SIZE, KAFKA_DELIVERY_TIMEOUT, KAFKA_MAX_BLOCK_TIMEOUT, "",
                 KAFKA_COMPRESSION_TYPE, TCP_SEND_BUFFER_SIZE, Optional.of(9093),

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -57,6 +57,8 @@ nakadi:
   kafka:
     producers.count: 1
     time-lag-checker.consumer-pool.size: 0
+    retries: 0
+    idempotence: false
     request.timeout.ms: 30000
     instanceType: t2.large
     poll.timeoutMs: 100

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -57,7 +57,6 @@ nakadi:
   kafka:
     producers.count: 1
     time-lag-checker.consumer-pool.size: 0
-    retries: 0
     request.timeout.ms: 30000
     instanceType: t2.large
     poll.timeoutMs: 100

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -144,8 +144,9 @@ public class KafkaLocationManager {
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
                 "org.apache.kafka.common.serialization.ByteArraySerializer");
         producerProps.put(ProducerConfig.ACKS_CONFIG, "all");
-        producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
 
+        producerProps.put(ProducerConfig.RETRIES_CONFIG, kafkaSettings.getRetries());
+        producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, kafkaSettings.getIdempotence());
         producerProps.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, kafkaSettings.getRequestTimeoutMs());
         producerProps.put(ProducerConfig.BUFFER_MEMORY_CONFIG, kafkaSettings.getBufferMemory());
         producerProps.put(ProducerConfig.BATCH_SIZE_CONFIG, kafkaSettings.getBatchSize());

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaLocationManager.java
@@ -144,9 +144,8 @@ public class KafkaLocationManager {
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
                 "org.apache.kafka.common.serialization.ByteArraySerializer");
         producerProps.put(ProducerConfig.ACKS_CONFIG, "all");
-        producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, false);
+        producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
 
-        producerProps.put(ProducerConfig.RETRIES_CONFIG, kafkaSettings.getRetries());
         producerProps.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, kafkaSettings.getRequestTimeoutMs());
         producerProps.put(ProducerConfig.BUFFER_MEMORY_CONFIG, kafkaSettings.getBufferMemory());
         producerProps.put(ProducerConfig.BATCH_SIZE_CONFIG, kafkaSettings.getBatchSize());

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSettings.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSettings.java
@@ -8,6 +8,10 @@ import java.util.Optional;
 
 @Component
 public class KafkaSettings {
+
+    private final int retries;
+    private final boolean idempotence;
+
     // kafka client requires this property to be int
     // https://github.com/apache/kafka/blob/d9206500bf2f99ce93f6ad64c7a89483100b3b5f/clients/src/main/java/org/apache
     // /kafka/clients/producer/ProducerConfig.java#L261
@@ -32,7 +36,9 @@ public class KafkaSettings {
     private final Optional<String> kafkaUsername;
     private final Optional<String> kafkaPassword;
     @Autowired
-    public KafkaSettings(@Value("${nakadi.kafka.request.timeout.ms}") final int requestTimeoutMs,
+    public KafkaSettings(@Value("${nakadi.kafka.retries}") final int retries,
+                         @Value("${nakadi.kafka.idempotence}") final boolean idempotence,
+                         @Value("${nakadi.kafka.request.timeout.ms}") final int requestTimeoutMs,
                          @Value("${nakadi.kafka.batch.size}") final int batchSize,
                          @Value("${nakadi.kafka.buffer.memory}") final long bufferMemory,
                          @Value("${nakadi.kafka.linger.ms}") final int lingerMs,
@@ -50,6 +56,8 @@ public class KafkaSettings {
                          @Value("${nakadi.kafka.sasl.mechanism:#{null}}") final Optional<String> saslMechanism,
                          @Value("${nakadi.kafka.username:#{null}}") final Optional<String> kafkaUsername,
                          @Value("${nakadi.kafka.password:#{null}}") final Optional<String> kafkaPassword) {
+        this.retries = retries;
+        this.idempotence = idempotence;
         this.requestTimeoutMs = requestTimeoutMs;
         this.batchSize = batchSize;
         this.bufferMemory = bufferMemory;
@@ -67,6 +75,14 @@ public class KafkaSettings {
         this.saslMechanism = saslMechanism;
         this.kafkaUsername = kafkaUsername;
         this.kafkaPassword = kafkaPassword;
+    }
+
+    public int getRetries() {
+        return retries;
+    }
+
+    public boolean getIdempotence() {
+        return idempotence;
     }
 
     public int getRequestTimeoutMs() {

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSettings.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaSettings.java
@@ -8,8 +8,6 @@ import java.util.Optional;
 
 @Component
 public class KafkaSettings {
-
-    private final int retries;
     // kafka client requires this property to be int
     // https://github.com/apache/kafka/blob/d9206500bf2f99ce93f6ad64c7a89483100b3b5f/clients/src/main/java/org/apache
     // /kafka/clients/producer/ProducerConfig.java#L261
@@ -34,8 +32,7 @@ public class KafkaSettings {
     private final Optional<String> kafkaUsername;
     private final Optional<String> kafkaPassword;
     @Autowired
-    public KafkaSettings(@Value("${nakadi.kafka.retries}") final int retries,
-                         @Value("${nakadi.kafka.request.timeout.ms}") final int requestTimeoutMs,
+    public KafkaSettings(@Value("${nakadi.kafka.request.timeout.ms}") final int requestTimeoutMs,
                          @Value("${nakadi.kafka.batch.size}") final int batchSize,
                          @Value("${nakadi.kafka.buffer.memory}") final long bufferMemory,
                          @Value("${nakadi.kafka.linger.ms}") final int lingerMs,
@@ -53,7 +50,6 @@ public class KafkaSettings {
                          @Value("${nakadi.kafka.sasl.mechanism:#{null}}") final Optional<String> saslMechanism,
                          @Value("${nakadi.kafka.username:#{null}}") final Optional<String> kafkaUsername,
                          @Value("${nakadi.kafka.password:#{null}}") final Optional<String> kafkaPassword) {
-        this.retries = retries;
         this.requestTimeoutMs = requestTimeoutMs;
         this.batchSize = batchSize;
         this.bufferMemory = bufferMemory;
@@ -71,10 +67,6 @@ public class KafkaSettings {
         this.saslMechanism = saslMechanism;
         this.kafkaUsername = kafkaUsername;
         this.kafkaPassword = kafkaPassword;
-    }
-
-    public int getRetries() {
-        return retries;
     }
 
     public int getRequestTimeoutMs() {


### PR DESCRIPTION
The main objective is to enable retries, which we can only safely do when using the idempotence feature.

This change only enables us to configure idempotent producer with retries, but doesn't change the current default settings.