### PR TITLE
Enforce alphabetic ISO-4217 currency format validation

### DIFF
--- a/core-common/src/main/java/org/zalando/nakadi/validation/ISO4217CurrencyCodeValidator.java
+++ b/core-common/src/main/java/org/zalando/nakadi/validation/ISO4217CurrencyCodeValidator.java
@@ -1,23 +1,18 @@
 package org.zalando.nakadi.validation;
 
 import org.everit.json.schema.FormatValidator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Currency;
 import java.util.Optional;
 
 public class ISO4217CurrencyCodeValidator implements FormatValidator {
-    private static final Logger LOG = LoggerFactory.getLogger(ISO4217CurrencyCodeValidator.class);
-    private final String eventTypeName;
     private final String formatName;
 
-    ISO4217CurrencyCodeValidator(final String eventTypeName) {
-        this(eventTypeName, "iso-4217");
+    ISO4217CurrencyCodeValidator() {
+        this("iso-4217");
     }
 
-    ISO4217CurrencyCodeValidator(final String eventTypeName, final String formatName) {
-        this.eventTypeName = eventTypeName;
+    ISO4217CurrencyCodeValidator(final String formatName) {
         this.formatName = formatName;
     }
 
@@ -26,9 +21,7 @@ public class ISO4217CurrencyCodeValidator implements FormatValidator {
         try {
             Currency.getInstance(value);
         } catch (IllegalArgumentException ex) {
-            // Note: not returning this as validation error (yet), but just log it.
-            LOG.warn("Currency format violation (format_name={}): [event_type={}, value={}]",
-                    formatName, eventTypeName, value);
+            return Optional.of(String.format("[%s] is not a valid alphabetic ISO 4217 currency code", value));
         }
         return Optional.empty();
     }

--- a/core-common/src/test/java/org/zalando/nakadi/validation/ISO4217CurrencyCodeValidatorTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/validation/ISO4217CurrencyCodeValidatorTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.zalando.nakadi.utils.IsOptional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 
 public class ISO4217CurrencyCodeValidatorTest {
 
@@ -31,10 +32,13 @@ public class ISO4217CurrencyCodeValidatorTest {
                 "SEK",
         };
 
-        final var validator = new ISO4217CurrencyCodeValidator("an-event-type");
+        final var validator = new ISO4217CurrencyCodeValidator();
         for (final String value : invalidValues) {
-            // For invalid values, the validator should return empty result.
-            assertThat("Test: " + value, validator.validate(value), IsOptional.isAbsent());
+            assertThat(
+                    "Test: " + value,
+                    validator.validate(value),
+                    IsOptional.matches(containsString(" is not a valid alphabetic ISO 4217 currency code"))
+            );
         }
 
         for (final String value : validValues) {

--- a/core-services/src/main/java/org/zalando/nakadi/validation/EventValidatorBuilder.java
+++ b/core-services/src/main/java/org/zalando/nakadi/validation/EventValidatorBuilder.java
@@ -33,8 +33,8 @@ public class EventValidatorBuilder {
         final Schema schema = SchemaLoader.builder()
                 .schemaJson(loader.effectiveSchema(eventType, jsonSchema.get().getSchema()))
                 .addFormatValidator(new RFC3339DateTimeValidator())
-                .addFormatValidator(new ISO4217CurrencyCodeValidator(eventType.getName()))
-                .addFormatValidator(new ISO4217CurrencyCodeValidator(eventType.getName(), "ISO-4217"))
+                .addFormatValidator(new ISO4217CurrencyCodeValidator())
+                .addFormatValidator(new ISO4217CurrencyCodeValidator("ISO-4217"))
                 .build()
                 .load()
                 .build();


### PR DESCRIPTION
# One-line summary

Changes `ISO4217CurrencyCodeValidator` to a proper schema (format) validator (instead of logging invalid values) for alphabetic ISO 4217 currency codes.

This is follow up of #1529.

## Description
Goal: reject publishing events with event type schemas' containing `iso-4217` format.

## Review
- [x] Tests

## Deployment Notes

The feature is not feature toggled (there is some inverse dependency of the `core-common` and the sub-project containing `FeatureToggleService`. For simplicity of implementation, this change assumes that there are no publishers violating this (new) restriction.