### PR TITLE
Validate `event_owner_selector` path refers to a field in the schema

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/EventTypeAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/EventTypeAT.java
@@ -161,9 +161,9 @@ public class EventTypeAT extends BaseAT {
     }
 
     @Test
-    public void whenEventAuthSelectorCreatedThenOK() throws Exception {
+    public void whenEventAuthSelectorSetOnCreateThenOK() throws Exception {
         final EventType eventType = buildDefaultEventType();
-        eventType.setEventOwnerSelector(new EventOwnerSelector(EventOwnerSelector.Type.PATH, "x", "y"));
+        eventType.setEventOwnerSelector(new EventOwnerSelector(EventOwnerSelector.Type.PATH, "x", "foo"));
 
         given().body(MAPPER.writer().writeValueAsString(eventType))
                 .header("accept", "application/json")
@@ -181,7 +181,7 @@ public class EventTypeAT extends BaseAT {
     @Test
     public void whenEventAuthSelectorCreateWithMetadataAndValueThen422() throws Exception {
         final EventType eventType = buildDefaultEventType();
-        eventType.setEventOwnerSelector(new EventOwnerSelector(EventOwnerSelector.Type.METADATA, "x", "y"));
+        eventType.setEventOwnerSelector(new EventOwnerSelector(EventOwnerSelector.Type.METADATA, "x", "foo"));
 
         given().body(MAPPER.writer().writeValueAsString(eventType))
                 .header("accept", "application/json")
@@ -191,7 +191,7 @@ public class EventTypeAT extends BaseAT {
     }
 
     @Test
-    public void whenEventAuthSelectorUpdatedThenOK() throws Exception {
+    public void whenEventAuthSelectorSetOnUpdateThenOK() throws Exception {
         final EventType eventType = buildDefaultEventType();
         eventType.setEventOwnerSelector(null);
 
@@ -207,7 +207,7 @@ public class EventTypeAT extends BaseAT {
                 EventType.class);
         Assert.assertNull(retrievedEventType.getEventOwnerSelector());
 
-        retrievedEventType.setEventOwnerSelector(new EventOwnerSelector(EventOwnerSelector.Type.PATH, "x", "y"));
+        retrievedEventType.setEventOwnerSelector(new EventOwnerSelector(EventOwnerSelector.Type.PATH, "x", "foo"));
         final String updateBody = MAPPER.writer().writeValueAsString(retrievedEventType);
 
         given().body(updateBody)

--- a/core-common/src/main/java/org/zalando/nakadi/exceptions/runtime/EventOwnerExtractionException.java
+++ b/core-common/src/main/java/org/zalando/nakadi/exceptions/runtime/EventOwnerExtractionException.java
@@ -1,0 +1,12 @@
+package org.zalando.nakadi.exceptions.runtime;
+
+public class EventOwnerExtractionException extends NakadiBaseException {
+
+    public EventOwnerExtractionException(final String msg, final Exception cause) {
+        super(msg, cause);
+    }
+
+    public EventOwnerExtractionException(final String msg) {
+        super(msg);
+    }
+}

--- a/core-services/src/main/java/org/zalando/nakadi/service/SchemaService.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/SchemaService.java
@@ -239,7 +239,6 @@ public class SchemaService implements SchemaProviderService {
         final EventOwnerSelector eventOwnerSelector = eventType.getEventOwnerSelector();
         if (eventOwnerSelector != null) {
             if (eventOwnerSelector.getType() == EventOwnerSelector.Type.PATH) {
-                // TODO: validate that it's a required property!
                 validateFieldsInSchema("event_owner_selector.value", List.of(eventOwnerSelector.getValue()),
                         effectiveSchema);
             }

--- a/core-services/src/main/java/org/zalando/nakadi/service/SchemaService.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/SchemaService.java
@@ -41,6 +41,7 @@ import org.zalando.nakadi.service.timeline.TimelineSync;
 import org.zalando.nakadi.util.AvroUtils;
 import org.zalando.nakadi.validation.JsonSchemaEnrichment;
 import org.zalando.nakadi.validation.SchemaIncompatibility;
+import org.zalando.nakadi.view.EventOwnerSelector;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -232,14 +233,24 @@ public class SchemaService implements SchemaProviderService {
             throw new SchemaValidationException("\"metadata\" property is reserved");
         }
 
+        final JSONObject effectiveSchemaAsJson = jsonSchemaEnrichment.effectiveSchema(eventType, eventTypeSchema);
+        final Schema effectiveSchema = SchemaLoader.load(effectiveSchemaAsJson);
+
+        final EventOwnerSelector eventOwnerSelector = eventType.getEventOwnerSelector();
+        if (eventOwnerSelector != null) {
+            if (eventOwnerSelector.getType() == EventOwnerSelector.Type.PATH) {
+                // TODO: validate that it's a required property!
+                validateFieldsInSchema("event_owner_selector.value", List.of(eventOwnerSelector.getValue()),
+                        effectiveSchema);
+            }
+        }
+
         final List<String> orderingInstanceIds = eventType.getOrderingInstanceIds();
         final List<String> orderingKeyFields = eventType.getOrderingKeyFields();
         if (!orderingInstanceIds.isEmpty() && orderingKeyFields.isEmpty()) {
             throw new SchemaValidationException(
                     "`ordering_instance_ids` field can not be defined without defining `ordering_key_fields`");
         }
-        final JSONObject effectiveSchemaAsJson = jsonSchemaEnrichment.effectiveSchema(eventType, eventTypeSchema);
-        final Schema effectiveSchema = SchemaLoader.load(effectiveSchemaAsJson);
         validateFieldsInSchema("ordering_key_fields", orderingKeyFields, effectiveSchema);
         validateFieldsInSchema("ordering_instance_ids", orderingInstanceIds, effectiveSchema);
 

--- a/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventOwnerExtractorFactory.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventOwnerExtractorFactory.java
@@ -8,6 +8,7 @@ import org.zalando.nakadi.domain.EventOwnerHeader;
 import org.zalando.nakadi.domain.EventType;
 import org.zalando.nakadi.domain.Feature;
 import org.zalando.nakadi.domain.NakadiMetadata;
+import org.zalando.nakadi.exceptions.runtime.EventOwnerExtractionException;
 import org.zalando.nakadi.exceptions.runtime.JsonPathAccessException;
 import org.zalando.nakadi.exceptions.runtime.NakadiBaseException;
 import org.zalando.nakadi.service.FeatureToggleService;
@@ -50,9 +51,12 @@ public class EventOwnerExtractorFactory {
                 try {
                     final JsonPathAccess jsonPath = new JsonPathAccess(event);
                     final Object value = jsonPath.get(path);
-                    return JSONObject.NULL == value ? null : new EventOwnerHeader(name, value.toString());
+                    if (JSONObject.NULL == value) {
+                        throw new EventOwnerExtractionException("Event owner value is null at path: " + path);
+                    }
+                    return new EventOwnerHeader(name, value.toString());
                 } catch (final JsonPathAccessException e) {
-                    return null;
+                    throw new EventOwnerExtractionException("Event owner field is not found at path: " + path, e);
                 }
             }
 

--- a/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventPublisher.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventPublisher.java
@@ -19,7 +19,6 @@ import org.zalando.nakadi.domain.BatchItem;
 import org.zalando.nakadi.domain.BatchItemResponse;
 import org.zalando.nakadi.domain.CleanupPolicy;
 import org.zalando.nakadi.domain.EventCategory;
-import org.zalando.nakadi.domain.EventOwnerHeader;
 import org.zalando.nakadi.domain.EventPublishResult;
 import org.zalando.nakadi.domain.EventPublishingStatus;
 import org.zalando.nakadi.domain.EventPublishingStep;

--- a/core-services/src/test/java/org/zalando/nakadi/service/SchemaServiceTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/SchemaServiceTest.java
@@ -26,6 +26,7 @@ import org.zalando.nakadi.repository.db.SchemaRepository;
 import org.zalando.nakadi.service.timeline.TimelineSync;
 import org.zalando.nakadi.utils.TestUtils;
 import org.zalando.nakadi.validation.JsonSchemaEnrichment;
+import org.zalando.nakadi.view.EventOwnerSelector;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -286,4 +287,25 @@ public class SchemaServiceTest {
         assertDoesNotThrow(() -> schemaService.validateSchema(eventType));
     }
 
+    @Test
+    public void whenEventOwnerSelectorFieldMissingInSchemaThenThrows() {
+        eventType.getSchema().setSchema("{}");
+        eventType.setEventOwnerSelector(
+                new EventOwnerSelector(EventOwnerSelector.Type.PATH, "selector_name", "retailer_id"));
+
+        assertThrows(SchemaValidationException.class, () -> schemaService.validateSchema(eventType));
+    }
+
+    @Test
+    public void whenEventOwnerSelectorFieldPresentInSchemaThenOK() throws IOException {
+        final String jsonSchemaString = Resources.toString(
+                Resources.getResource("schema-with-retailer-id.json"),
+                Charsets.UTF_8);
+
+        eventType.getSchema().setSchema(jsonSchemaString);
+        eventType.setEventOwnerSelector(
+                new EventOwnerSelector(EventOwnerSelector.Type.PATH, "selector_name", "info.retailer_id"));
+
+        assertDoesNotThrow(() -> schemaService.validateSchema(eventType));
+    }
 }

--- a/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventOwnerExtractorTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventOwnerExtractorTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.zalando.nakadi.domain.EventOwnerHeader;
 import org.zalando.nakadi.domain.NakadiMetadata;
 import org.zalando.nakadi.domain.StrictJsonParser;
+import org.zalando.nakadi.exceptions.runtime.EventOwnerExtractionException;
 
 import java.io.IOException;
 
@@ -26,21 +27,19 @@ public class EventOwnerExtractorTest {
     }
 
     @Test
-    public void testAbsenceOfPathValue() {
+    public void testAbsenceOfPathValueIsAnError() {
         final EventOwnerExtractor extractor = EventOwnerExtractorFactory.createPathExtractor(
                 "retailer_id", "example.nothing.here");
 
-        final EventOwnerHeader result = extractor.extractEventOwner(MOCK_EVENT);
-        Assert.assertNull(result);
+        Assert.assertThrows(EventOwnerExtractionException.class, () -> extractor.extractEventOwner(MOCK_EVENT));
     }
 
     @Test
-    public void testNullWithPathValue() {
+    public void testNullWithPathValueIsAnError() {
         final EventOwnerExtractor extractor = EventOwnerExtractorFactory.createPathExtractor(
                 "retailer_id", "other");
 
-        final EventOwnerHeader result = extractor.extractEventOwner(MOCK_EVENT);
-        Assert.assertNull(result);
+        Assert.assertThrows(EventOwnerExtractionException.class, () -> extractor.extractEventOwner(MOCK_EVENT));
     }
 
     @Test

--- a/core-services/src/test/resources/schema-with-retailer-id.json
+++ b/core-services/src/test/resources/schema-with-retailer-id.json
@@ -1,0 +1,14 @@
+{
+    "type": "object",
+    "properties": {
+        "info": {"$ref": "#/definitions/Info"}
+    },
+    "definitions": {
+        "Info": {
+            "type": "object",
+            "properties": {
+                "retailer_id": {"type": "string"}
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Validate that the field is present when creating/updating event types
- Log a warning if the field is still missing or `null` when publishing events

Internal ticket: 1431