### PR TITLE
extend the validations: retention period mandatory for materialisatio…

### DIFF
--- a/api-metastore/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -72,6 +72,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.Map;
+import java.util.Arrays;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -521,8 +523,38 @@ public class EventTypeService {
     private void updateAnnotationsAndLabels(final EventType original, final EventType eventType)
             throws InvalidEventTypeException {
 
+        final List<String> breakingCompatibilitiesNames = Arrays.asList(
+                "content-visibility.inference-log.v3.test",
+                "zoutlets.wm.article-decision",
+                "merchant-price-service.work-log",
+                "merchant-price-service.work-log-raw",
+                "content.customer-targeting.segments.sqate",
+                "merchant-price-service.price-update-called",
+                "merchant-price-service.price-update-processed",
+                "octopus.analysis-metrics-v2",
+                "wholesale.purchase-order-event",
+                "zoutlets.wm.commodity-group.updated",
+                "connected-retail.article-insights-service.configuration-changed",
+                "merchant-price-service.price-threshold-updates");
+
         if (eventType.getAnnotations() == null) {
-            eventType.setAnnotations(original.getAnnotations());
+            final Map<String, String> originalAnnotations = original.getAnnotations();
+            if (breakingCompatibilitiesNames.contains(original.getName())){
+                if (!originalAnnotations.containsKey("datalake.zalando.org/retention-period")) {
+                    originalAnnotations.put("datalake.zalando.org/retention-period", "unlimited");
+                }
+                eventType.setAnnotations(originalAnnotations);
+            } else {
+                eventType.setAnnotations(originalAnnotations);
+            }
+        } else {
+            final Map<String, String> eventTypeAnnotations = eventType.getAnnotations();
+            if (breakingCompatibilitiesNames.contains(eventType.getName())){
+                if (!eventTypeAnnotations.containsKey("datalake.zalando.org/retention-period")) {
+                    eventTypeAnnotations.put("datalake.zalando.org/retention-period", "unlimited");
+                }
+                eventType.setAnnotations(eventTypeAnnotations);
+            }
         }
         if (eventType.getLabels() == null) {
             eventType.setLabels(original.getLabels());

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -73,7 +73,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Map;
-import java.util.Arrays;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -534,43 +533,8 @@ public class EventTypeService {
     private void updateAnnotationsAndLabels(final EventType original, final EventType eventType)
             throws InvalidEventTypeException {
 
-       /* this is a temporary solution to ensure the backward compatibility and it is here because
-        the DataLakeAnnotationValidator.java does not have access to the event type */
-        final List<String> breakingCompatibilitiesNames = Arrays.asList(
-                "content-visibility.inference-log.v3.test",
-                "zoutlets.wm.article-decision",
-                "merchant-price-service.work-log",
-                "merchant-price-service.work-log-raw",
-                "content.customer-targeting.segments.sqate",
-                "merchant-price-service.price-update-called",
-                "merchant-price-service.price-update-processed",
-                "octopus.analysis-metrics-v2",
-                "wholesale.purchase-order-event",
-                "zoutlets.wm.commodity-group.updated",
-                "connected-retail.article-insights-service.configuration-changed",
-                "merchant-price-service.price-threshold-updates",
-                "product-data-quality.inference-pipeline.spp-updates-lineage",
-                "product-data-quality.inference-pipeline.decision-maker-lineage",
-                "product-data-quality.hitl.human-annotation-ui-lineage");
-
         if (eventType.getAnnotations() == null) {
-            final Map<String, String> originalAnnotations = original.getAnnotations();
-            if (breakingCompatibilitiesNames.contains(original.getName())){
-                if (!originalAnnotations.containsKey("datalake.zalando.org/retention-period")) {
-                    originalAnnotations.put("datalake.zalando.org/retention-period", "unlimited");
-                }
-                eventType.setAnnotations(originalAnnotations);
-            } else {
-                eventType.setAnnotations(originalAnnotations);
-            }
-        } else {
-            final Map<String, String> eventTypeAnnotations = eventType.getAnnotations();
-            if (breakingCompatibilitiesNames.contains(eventType.getName())){
-                if (!eventTypeAnnotations.containsKey("datalake.zalando.org/retention-period")) {
-                    eventTypeAnnotations.put("datalake.zalando.org/retention-period", "unlimited");
-                }
-                eventType.setAnnotations(eventTypeAnnotations);
-            }
+            eventType.setAnnotations(original.getAnnotations());
         }
         if (eventType.getLabels() == null) {
             eventType.setLabels(original.getLabels());

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -193,6 +193,17 @@ public class EventTypeService {
         if (eventType.getAnnotations() == null) {
             eventType.setAnnotations(new HashMap<>());
         }
+        else {
+            final String retentionPeriodAnnotation = "datalake.zalando.org/retention-period";
+            final String materialiseEventsAnnotationText = "datalake.zalando.org/materialize-events";
+            final Map<String, String> annotations = eventType.getAnnotations();
+            if (annotations.containsKey(materialiseEventsAnnotationText)) {
+                if (annotations.get(materialiseEventsAnnotationText).equals("on") &&
+                        !annotations.containsKey(retentionPeriodAnnotation)) {
+                    annotations.put(retentionPeriodAnnotation, "unlimited");
+                }
+            }
+        }
         if (eventType.getLabels() == null) {
             eventType.setLabels(new HashMap<>());
         }

--- a/api-metastore/src/main/java/org/zalando/nakadi/service/EventTypeService.java
+++ b/api-metastore/src/main/java/org/zalando/nakadi/service/EventTypeService.java
@@ -534,6 +534,8 @@ public class EventTypeService {
     private void updateAnnotationsAndLabels(final EventType original, final EventType eventType)
             throws InvalidEventTypeException {
 
+       /* this is a temporary solution to ensure the backward compatibility and it is here because
+        the DataLakeAnnotationValidator.java does not have access to the event type */
         final List<String> breakingCompatibilitiesNames = Arrays.asList(
                 "content-visibility.inference-log.v3.test",
                 "zoutlets.wm.article-decision",
@@ -546,7 +548,10 @@ public class EventTypeService {
                 "wholesale.purchase-order-event",
                 "zoutlets.wm.commodity-group.updated",
                 "connected-retail.article-insights-service.configuration-changed",
-                "merchant-price-service.price-threshold-updates");
+                "merchant-price-service.price-threshold-updates",
+                "product-data-quality.inference-pipeline.spp-updates-lineage",
+                "product-data-quality.inference-pipeline.decision-maker-lineage",
+                "product-data-quality.hitl.human-annotation-ui-lineage");
 
         if (eventType.getAnnotations() == null) {
             final Map<String, String> originalAnnotations = original.getAnnotations();

--- a/core-common/src/main/java/org/zalando/nakadi/annotations/validation/DataLakeAnnotationValidator.java
+++ b/core-common/src/main/java/org/zalando/nakadi/annotations/validation/DataLakeAnnotationValidator.java
@@ -19,24 +19,25 @@ public class DataLakeAnnotationValidator implements ConstraintValidator<DataLake
         if (annotations == null || annotations.size() == 0) {
             return true;
         }
+        String materialiseEventsAnnotation = annotations.get(MATERIALISE_EVENTS_ANNOTATION);
         if (annotations.containsKey(MATERIALISE_EVENTS_ANNOTATION)) {
-            if (!annotations.get(MATERIALISE_EVENTS_ANNOTATION).equals("off") &&
-                    !annotations.get(MATERIALISE_EVENTS_ANNOTATION).equals("on")) {
+            if (!materialiseEventsAnnotation.equals("off") &&
+                    !materialiseEventsAnnotation.equals("on")) {
                 context.disableDefaultConstraintViolation();
                 context.buildConstraintViolationWithTemplate("Annotation " + MATERIALISE_EVENTS_ANNOTATION
                                 + " is not valid. Provided value: \""
-                                + annotations.get(MATERIALISE_EVENTS_ANNOTATION)
+                                + materialiseEventsAnnotation
                                 + "\". Possible values are: \"on\" or \"off\".")
                         .addConstraintViolation();
                 return false;
             }
-            if (annotations.get(MATERIALISE_EVENTS_ANNOTATION).equals("on") &&
+            if (materialiseEventsAnnotation.equals("on") &&
                     !annotations.containsKey(RETENTION_PERIOD_ANNOTATION)) {
                 context.disableDefaultConstraintViolation();
                 context.buildConstraintViolationWithTemplate("Annotation " + RETENTION_PERIOD_ANNOTATION
                                 + " is required, when "
                                 + MATERIALISE_EVENTS_ANNOTATION + " with value: \""
-                                + annotations.get(MATERIALISE_EVENTS_ANNOTATION)
+                                + materialiseEventsAnnotation
                                 + "\" is specified.")
                         .addConstraintViolation();
                 return false;

--- a/core-common/src/main/java/org/zalando/nakadi/annotations/validation/DataLakeAnnotationValidator.java
+++ b/core-common/src/main/java/org/zalando/nakadi/annotations/validation/DataLakeAnnotationValidator.java
@@ -19,7 +19,7 @@ public class DataLakeAnnotationValidator implements ConstraintValidator<DataLake
         if (annotations == null || annotations.size() == 0) {
             return true;
         }
-        String materialiseEventsAnnotation = annotations.get(MATERIALISE_EVENTS_ANNOTATION);
+        final String materialiseEventsAnnotation = annotations.get(MATERIALISE_EVENTS_ANNOTATION);
         if (annotations.containsKey(MATERIALISE_EVENTS_ANNOTATION)) {
             if (!materialiseEventsAnnotation.equals("off") &&
                     !materialiseEventsAnnotation.equals("on")) {

--- a/core-common/src/main/java/org/zalando/nakadi/annotations/validation/DataLakeAnnotationValidator.java
+++ b/core-common/src/main/java/org/zalando/nakadi/annotations/validation/DataLakeAnnotationValidator.java
@@ -30,6 +30,17 @@ public class DataLakeAnnotationValidator implements ConstraintValidator<DataLake
                         .addConstraintViolation();
                 return false;
             }
+            if (annotations.get(MATERIALISE_EVENTS_ANNOTATION).equals("on") &&
+                    !annotations.containsKey(RETENTION_PERIOD_ANNOTATION)) {
+                context.disableDefaultConstraintViolation();
+                context.buildConstraintViolationWithTemplate("Annotation " + RETENTION_PERIOD_ANNOTATION
+                                + " is required, when "
+                                + MATERIALISE_EVENTS_ANNOTATION + " with value: \""
+                                + annotations.get(MATERIALISE_EVENTS_ANNOTATION)
+                                + "\" is specified.")
+                        .addConstraintViolation();
+                return false;
+            }
         }
 
         if (annotations.containsKey(RETENTION_PERIOD_ANNOTATION)) {

--- a/core-common/src/test/java/org/zalando/nakadi/annotations/validation/DataLakeAnnotationsTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/annotations/validation/DataLakeAnnotationsTest.java
@@ -45,6 +45,18 @@ public class DataLakeAnnotationsTest {
     }
 
     @Test
+    public void whenMaterializationEventIsOnNoRetentionPeriodFail() {
+        final var annotations = Map.of(
+                DataLakeAnnotationValidator.MATERIALISE_EVENTS_ANNOTATION, "on"
+        );
+        final Set<ConstraintViolation<TestClass>> result = validator.validate(new TestClass(annotations));
+        assertTrue("Annotation " + DataLakeAnnotationValidator.RETENTION_REASON_ANNOTATION + " is required," +
+                        " when " + DataLakeAnnotationValidator.RETENTION_PERIOD_ANNOTATION + " is specified.",
+                result.stream().anyMatch(r -> r.getMessage().contains(
+                        DataLakeAnnotationValidator.MATERIALISE_EVENTS_ANNOTATION)));
+    }
+
+    @Test
     public void whenRetentionPeriodThenRetentionReasonRequired() {
         final var annotations = Map.of(
                 DataLakeAnnotationValidator.RETENTION_PERIOD_ANNOTATION, "1 day"

--- a/core-common/src/test/java/org/zalando/nakadi/annotations/validation/DataLakeAnnotationsTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/annotations/validation/DataLakeAnnotationsTest.java
@@ -50,8 +50,7 @@ public class DataLakeAnnotationsTest {
                 DataLakeAnnotationValidator.MATERIALISE_EVENTS_ANNOTATION, "on"
         );
         final Set<ConstraintViolation<TestClass>> result = validator.validate(new TestClass(annotations));
-        assertTrue("Annotation " + DataLakeAnnotationValidator.RETENTION_REASON_ANNOTATION + " is required," +
-                        " when " + DataLakeAnnotationValidator.RETENTION_PERIOD_ANNOTATION + " is specified.",
+        assertTrue(DataLakeAnnotationValidator.RETENTION_PERIOD_ANNOTATION + " is specified.",
                 result.stream().anyMatch(r -> r.getMessage().contains(
                         DataLakeAnnotationValidator.MATERIALISE_EVENTS_ANNOTATION)));
     }


### PR DESCRIPTION
extend the validations: retention period mandatory for materialisation opt-in

# One-line summary

> Zalando ticket : https://jira.zalando.net/browse/ZDLK-5203

## Description
We have extended the validations for the annotations field, to make the retention period field mandatory when the materialise_events field has value "on"

## Review
- [ x] Tests
- [ ] Documentation

