### PR TITLE
Return client error on unknown meta schema

### DIFF
--- a/core-services/src/main/java/org/zalando/nakadi/service/SchemaService.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/SchemaService.java
@@ -221,12 +221,17 @@ public class SchemaService implements SchemaProviderService {
             throw new SchemaValidationException("\"type\" of root element in schema can only be \"object\"");
         }
 
-        final Schema schema = SchemaLoader
-                .builder()
-                .httpClient(new BlockedHttpClient())
-                .schemaJson(schemaAsJson)
-                .build()
-                .load()
+        final SchemaLoader schemaLoader;
+        try {
+            schemaLoader = SchemaLoader.builder()
+                    .httpClient(new BlockedHttpClient())
+                    .schemaJson(schemaAsJson)
+                    .build();
+        } catch (IllegalArgumentException ex) {
+            throw new SchemaValidationException(ex.getMessage());
+        }
+
+        final Schema schema = schemaLoader.load()
                 .build();
 
         if (eventType.getCategory() == EventCategory.BUSINESS && schema.definesProperty("#/metadata")) {

--- a/core-services/src/test/java/org/zalando/nakadi/service/SchemaServiceTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/SchemaServiceTest.java
@@ -151,6 +151,15 @@ public class SchemaServiceTest {
     }
 
     @Test
+    public void whenPostWithUnsupportedMetaSchemaThenThrows() throws Exception {
+        eventType.getSchema().setSchema(
+                "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\", \"type\":\"object\"}");
+        eventType.setCategory(BUSINESS);
+
+        assertThrows(SchemaValidationException.class, () -> schemaService.validateSchema(eventType));
+    }
+
+    @Test
     public void whenPostWithRootElementOfTypeArrayThenThrows() throws Exception {
         eventType.getSchema().setSchema(
                 "{\\\"type\\\":\\\"array\\\" }");

--- a/core-services/src/test/java/org/zalando/nakadi/service/SchemaServiceTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/SchemaServiceTest.java
@@ -197,42 +197,42 @@ public class SchemaServiceTest {
 
     @Test(expected = SchemaValidationException.class)
     public void testValidateSchemaEndingBracket() {
-        SchemaService.isStrictlyValidJson("{\"additionalProperties\": true}}");
+        SchemaService.parseJsonSchema("{\"additionalProperties\": true}}");
     }
 
     @Test(expected = SchemaValidationException.class)
     public void testValidateSchemaMultipleRoots() {
-        SchemaService.isStrictlyValidJson("{\"additionalProperties\": true}{\"additionalProperties\": true}");
+        SchemaService.parseJsonSchema("{\"additionalProperties\": true}{\"additionalProperties\": true}");
     }
 
     @Test(expected = SchemaValidationException.class)
     public void testValidateSchemaArbitraryEnding() {
-        SchemaService.isStrictlyValidJson("{\"additionalProperties\": true}NakadiRocks");
+        SchemaService.parseJsonSchema("{\"additionalProperties\": true}NakadiRocks");
     }
 
     @Test(expected = SchemaValidationException.class)
     public void testValidateSchemaArrayEnding() {
-        SchemaService.isStrictlyValidJson("[{\"additionalProperties\": true}]]");
+        SchemaService.parseJsonSchema("[{\"additionalProperties\": true}]]");
     }
 
     @Test(expected = SchemaValidationException.class)
     public void testValidateSchemaEndingCommaArray() {
-        SchemaService.isStrictlyValidJson("[{\"test\": true},]");
+        SchemaService.parseJsonSchema("[{\"test\": true},]");
     }
 
     @Test(expected = SchemaValidationException.class)
     public void testValidateSchemaEndingCommaArray2() {
-        SchemaService.isStrictlyValidJson("[\"test\",]");
+        SchemaService.parseJsonSchema("[\"test\",]");
     }
 
     @Test(expected = SchemaValidationException.class)
     public void testValidateSchemaEndingCommaObject() {
-        SchemaService.isStrictlyValidJson("{\"test\": true,}");
+        SchemaService.parseJsonSchema("{\"test\": true,}");
     }
 
     @Test
     public void testValidateSchemaFormattedJson() {
-        SchemaService.isStrictlyValidJson("{\"properties\":{\"event_class\":{\"type\":\"string\"}," +
+        SchemaService.parseJsonSchema("{\"properties\":{\"event_class\":{\"type\":\"string\"}," +
                 "\"app_domain_id\":{\"type\":\"integer\"},\"event_type\":{\"type\":\"string\"},\"time\"" +
                 ":{\"type\":\"number\"},\"partitioning_key\":{\"type\":\"string\"},\"body\":{\"type\"" +
                 ":\"object\"}},\"additionalProperties\":true}");


### PR DESCRIPTION
## Description

Change JSON event-type creation/validation to throw client error (`422`) instead of server error (`5xx`) on unsupported/unknown meta-schema URLs (`"$schema": "..."` in schema-JSON).


## Review
- [x] Tests

