### PR TITLE
Update documentation note for allowed/supported event types' `cleanup_policy` updates.

### DIFF
--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -2943,7 +2943,7 @@ definitions:
             For more details about compaction implementation please read the documentation of Log Compaction in Kafka
             https://kafka.apache.org/documentation/#compaction, Nakadi currently relies on this implementation.
 
-          It's not possible to change the value of this field for existing event type.
+          For an existing event type, it is possible to change the value of this field only from `delete` to `compact_and_delete`.
 
       default_statistic:
         $ref: '#/definitions/EventTypeStatistics'


### PR DESCRIPTION

## Description

Make the update `cleanup_policy` documentation in sync with implementation:
https://github.com/zalando/nakadi/blob/964ca19d5c5e96a314f44122c1f7178e18be09ce/api-metastore/src/main/java/org/zalando/nakadi/service/EventTypeService.java#L286-L289


## Review
- [x] Documentation
