### PR TITLE
Add `number_of_events` tag to `publish_events` spans

### DIFF
--- a/core-common/src/main/java/org/zalando/nakadi/service/TracingService.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/TracingService.java
@@ -85,6 +85,10 @@ public class TracingService {
         return getActiveSpan().setTag(key, value);
     }
 
+    public static Span setTag(final String key, final Number value) {
+        return getActiveSpan().setTag(key, value);
+    }
+
     public static Span setErrorFlag() {
         return setErrorFlag(getActiveSpan());
     }

--- a/core-services/src/main/java/org/zalando/nakadi/service/publishing/BinaryEventPublisher.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/publishing/BinaryEventPublisher.java
@@ -82,6 +82,9 @@ public class BinaryEventPublisher {
                                                      final List<NakadiRecord> records,
                                                      final List<Check> checks,
                                                      final Map<HeaderTag, String> consumerTags) {
+
+        TracingService.setTag("number_of_events", String.valueOf(records.size()));
+
         for (final Check check : checks) {
             final List<NakadiRecordResult> res = check.execute(eventType, records);
             if (res != null && !res.isEmpty()) {

--- a/core-services/src/main/java/org/zalando/nakadi/service/publishing/BinaryEventPublisher.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/publishing/BinaryEventPublisher.java
@@ -83,7 +83,7 @@ public class BinaryEventPublisher {
                                                      final List<Check> checks,
                                                      final Map<HeaderTag, String> consumerTags) {
 
-        TracingService.setTag("number_of_events", String.valueOf(records.size()));
+        TracingService.setTag("number_of_events", records.size());
 
         for (final Check check : checks) {
             final List<NakadiRecordResult> res = check.execute(eventType, records);

--- a/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventPublisher.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventPublisher.java
@@ -137,6 +137,9 @@ public class EventPublisher {
 
         Closeable publishingCloser = null;
         final List<BatchItem> batch = BatchFactory.from(events);
+
+        TracingService.setTag("number_of_events", String.valueOf(batch.size()));
+
         try {
             publishingCloser = timelineSync.workWithEventType(eventTypeName, nakadiSettings.getTimelineWaitTimeoutMs());
 

--- a/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventPublisher.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventPublisher.java
@@ -138,7 +138,7 @@ public class EventPublisher {
         Closeable publishingCloser = null;
         final List<BatchItem> batch = BatchFactory.from(events);
 
-        TracingService.setTag("number_of_events", String.valueOf(batch.size()));
+        TracingService.setTag("number_of_events", batch.size());
 
         try {
             publishingCloser = timelineSync.workWithEventType(eventTypeName, nakadiSettings.getTimelineWaitTimeoutMs());


### PR DESCRIPTION
To allow the publishers to learn about their batch size distribution.

Using the same name as in `nakadi.batch.published` event: https://github.com/zalando/nakadi/blob/master/core-common/src/main/resources/avro-schema/nakadi.batch.published.avsc#L24