### PR TITLE
Move setting of `number_of_events` tag to controller

### DIFF
--- a/api-publishing/src/main/java/org/zalando/nakadi/EventPublishingController.java
+++ b/api-publishing/src/main/java/org/zalando/nakadi/EventPublishingController.java
@@ -184,11 +184,11 @@ public class EventPublishingController {
                 final int eventCount = nakadiRecords.size();
                 TracingService.setTag("number_of_events", eventCount);
 
-                reportMetrics(eventTypeMetrics, result, totalSizeBytes, eventCount);
-                reportSLOs(startingNanos, totalSizeBytes, eventCount, result, eventTypeName, client);
-
                 final long totalSizeBytes = countingInputStream.getCount();
                 TracingService.setTag("slo_bucket", TracingService.getSLOBucketName(totalSizeBytes));
+
+                reportMetrics(eventTypeMetrics, result, totalSizeBytes, eventCount);
+                reportSLOs(startingNanos, totalSizeBytes, eventCount, result, eventTypeName, client);
 
                 if (result.getStatus() == EventPublishingStatus.FAILED) {
                     TracingService.setErrorFlag();

--- a/core-services/src/main/java/org/zalando/nakadi/service/publishing/BinaryEventPublisher.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/publishing/BinaryEventPublisher.java
@@ -82,9 +82,6 @@ public class BinaryEventPublisher {
                                                      final List<NakadiRecord> records,
                                                      final List<Check> checks,
                                                      final Map<HeaderTag, String> consumerTags) {
-
-        TracingService.setTag("number_of_events", records.size());
-
         for (final Check check : checks) {
             final List<NakadiRecordResult> res = check.execute(eventType, records);
             if (res != null && !res.isEmpty()) {

--- a/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventPublisher.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/publishing/EventPublisher.java
@@ -137,9 +137,6 @@ public class EventPublisher {
 
         Closeable publishingCloser = null;
         final List<BatchItem> batch = BatchFactory.from(events);
-
-        TracingService.setTag("number_of_events", batch.size());
-
         try {
             publishingCloser = timelineSync.workWithEventType(eventTypeName, nakadiSettings.getTimelineWaitTimeoutMs());
 


### PR DESCRIPTION
Turns out we don't always have the span in the binary publisher (due to it being used for internal KPI events publishing).