### PR TITLE
Add support submitting DLQ refeed offsets for subscription api

### DIFF
--- a/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClient.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClient.java
@@ -1,10 +1,8 @@
 package org.zalando.nakadi.service.subscription.zk;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.function.Function;
 import org.apache.commons.codec.binary.Hex;
 import org.zalando.nakadi.domain.EventTypePartition;
-import org.zalando.nakadi.exceptions.runtime.NakadiBaseException;
 import org.zalando.nakadi.exceptions.runtime.NakadiRuntimeException;
 import org.zalando.nakadi.exceptions.runtime.OperationTimeoutException;
 import org.zalando.nakadi.exceptions.runtime.ServiceTemporarilyUnavailableException;
@@ -17,12 +15,15 @@ import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.IntStream;
 
 public interface ZkSubscriptionClient extends Closeable {
 
@@ -32,7 +33,7 @@ public interface ZkSubscriptionClient extends Closeable {
      * @return true if subscription was created. False if subscription already present. To operate on this value
      * additional field 'state' is used /nakadi/subscriptions/{subscriptionId}/state. Just after creation it has value
      * CREATED. After {{@link #fillEmptySubscription}} call it will have value INITIALIZED. So true
-     * will be returned in case of state is equal to CREATED.
+     * will be returned in case of state is equal to INITIALIZED.
      */
     boolean isSubscriptionCreatedAndInitialized() throws NakadiRuntimeException;
 
@@ -202,21 +203,18 @@ public interface ZkSubscriptionClient extends Closeable {
         }
 
         public Topology withUpdatedPartitions(final Partition[] partitions) {
-            final Partition[] resultPartitions = Arrays.copyOf(this.partitions, this.partitions.length);
+            final var resultPartitions = new ArrayList<>(Arrays.asList(this.partitions));
             for (final Partition newValue : partitions) {
-                int selectedIdx = -1;
-                for (int idx = 0; idx < resultPartitions.length; ++idx) {
-                    if (resultPartitions[idx].getKey().equals(newValue.getKey())) {
-                        selectedIdx = idx;
-                    }
+                final var selected = IntStream.range(0, resultPartitions.size())
+                        .filter(idx -> resultPartitions.get(idx).getKey().equals(newValue.getKey()))
+                        .findFirst();
+                if (selected.isPresent()) {
+                    resultPartitions.set(selected.getAsInt(), newValue);
+                } else {
+                    resultPartitions.add(newValue);
                 }
-                if (selectedIdx < 0) {
-                    throw new NakadiBaseException(
-                            "Failed to find partition " + newValue.getKey() + " in " + this);
-                }
-                resultPartitions[selectedIdx] = newValue;
             }
-            return new Topology(resultPartitions, Optional.ofNullable(version).orElse(0) + 1);
+            return new Topology(resultPartitions.toArray(new Partition[0]), Optional.ofNullable(version).orElse(0) + 1);
         }
 
         @Override

--- a/core-common/src/test/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClientTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClientTest.java
@@ -12,6 +12,55 @@ import java.util.stream.Stream;
 public class ZkSubscriptionClientTest {
 
     @Test
+    public void testUpdatePartitionsOverridesExistingPartitions() {
+        final var topology = new ZkSubscriptionClient.Topology(
+                new Partition[] {
+                        new Partition("event-type-1", "0", null, null, Partition.State.ASSIGNED),
+                        new Partition("event-type-1", "1", null, null, Partition.State.ASSIGNED),
+                },
+                0);
+
+        final var updatedTopology = topology.withUpdatedPartitions(
+                new Partition[] {
+                        new Partition("event-type-1", "0", null, null, Partition.State.UNASSIGNED),
+                });
+
+        Assert.assertNotEquals(topology, updatedTopology);
+        Assert.assertArrayEquals(
+                new Partition[] {
+                        new Partition("event-type-1", "0", null, null, Partition.State.UNASSIGNED),
+                        new Partition("event-type-1", "1", null, null, Partition.State.ASSIGNED),
+                },
+                updatedTopology.getPartitions()
+        );
+    }
+
+    @Test
+    public void testUpdatePartitionsExtendsPartitionsList() {
+        final var topology = new ZkSubscriptionClient.Topology(
+                new Partition[] {
+                        new Partition("event-type-1", "0", null, null, Partition.State.ASSIGNED),
+                        new Partition("event-type-1", "1", null, null, Partition.State.ASSIGNED),
+                },
+                0);
+
+        final var updatedTopology = topology.withUpdatedPartitions(
+                new Partition[] {
+                        new Partition("event-type-2", "0", null, null, Partition.State.UNASSIGNED),
+                });
+
+        Assert.assertNotEquals(topology, updatedTopology);
+        Assert.assertArrayEquals(
+                new Partition[] {
+                        new Partition("event-type-1", "0", null, null, Partition.State.ASSIGNED),
+                        new Partition("event-type-1", "1", null, null, Partition.State.ASSIGNED),
+                        new Partition("event-type-2", "0", null, null, Partition.State.UNASSIGNED),
+                },
+                updatedTopology.getPartitions()
+        );
+    }
+
+    @Test
     public void testHashCalculationOrder() {
         Assert.assertEquals(
                 ZkSubscriptionClient.Topology.calculateSessionsHash(Stream.of("1", "2").collect(Collectors.toList())),

--- a/core-services/src/main/java/org/zalando/nakadi/service/SubscriptionValidationService.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/SubscriptionValidationService.java
@@ -128,6 +128,9 @@ public class SubscriptionValidationService {
             throw new InvalidStreamParametersException("Duplicated partition specified");
         }
         // check that partitions belong to subscription
+        // Note: currently, this check validates the partitions (passed by the client) against only explicit event types
+        // of the subscription. If the client passes partitions for implicit event types (like DLQ event type), this
+        // check would fail.
         final List<EventTypePartition> allPartitions = getAllPartitions(subscription.getEventTypes());
         final List<EventTypePartition> wrongPartitions = partitions.stream()
                 .filter(p -> !allPartitions.contains(p))
@@ -145,6 +148,8 @@ public class SubscriptionValidationService {
                                         final List<EventTypePartition> allPartitions)
             throws InvalidInitialCursorsException, RepositoryProblemException {
 
+        // Note: this check only verifies explicitly listed event types for a subscription.
+        // Implicit event types (like DLQ) are not checked here on creation of the subscription.
         final boolean cursorsMissing = allPartitions.stream()
                 .anyMatch(p -> !subscription.getInitialCursors().stream().anyMatch(p::ownsCursor));
         if (cursorsMissing) {


### PR DESCRIPTION
# One-line summary

 * Add support submitting DLQ refeed offsets for subscription api
 * Allows to add new event types to subscription's topology (stored in Zookeeper)

Note: this is shared code for verified PoC (#1554) and the planned rollout approach #1558.

