### PR TITLE
Feed events one by one until the end of problematic batch

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/utils/TestStreamingClient.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/webservice/utils/TestStreamingClient.java
@@ -140,11 +140,12 @@ public class TestStreamingClient {
                     if (batch.getEvents() != null && !batch.getEvents().isEmpty()) {
                         try {
                             final SubscriptionCursor cursor = batch.getCursor();
+                            LOG.debug("Committing: {}", cursor);
                             final int responseCode = NakadiTestUtils.commitCursors(
                                     client.subscriptionId,
                                     Collections.singletonList(batch.getCursor()),
                                     client.getSessionId());
-                            LOG.info("Committing " + responseCode + ": " + cursor);
+                            LOG.info("Commit response code: {}", responseCode);
                         } catch (JsonProcessingException e) {
                             throw new RuntimeException(e);
                         }
@@ -164,11 +165,14 @@ public class TestStreamingClient {
     }
 
     public boolean close() {
+        LOG.debug("Closing...");
         if (running) {
+            LOG.debug("Set not running!");
             running = false;
             connection.disconnect();
             return true;
         } else {
+            LOG.debug("Already closed!");
             return false;
         }
     }
@@ -277,10 +281,13 @@ public class TestStreamingClient {
             final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, Charsets.UTF_8));
             while (running) {
                 try {
+                    LOG.debug("Reading next line...");
                     final String line = reader.readLine();
                     if (line == null) {
+                        LOG.debug("Got null line, stopping.");
                         return;
                     }
+                    LOG.trace("Got line: {}", line);
                     final StreamBatch streamBatch = MAPPER.readValue(line, StreamBatch.class);
                     synchronized (jsonBatches) {
                         jsonBatches.add(streamBatch);

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/state/StreamingState.java
@@ -310,14 +310,11 @@ class StreamingState extends State {
                     getAutocommit().addSkippedEvent(failedEvent.getPosition());
                     this.addTask(() -> getAutocommit().autocommit());
 
-                    // reset looking dead letter flag in zookeeper
+                    // reset failed commits, but keep looking until last dead letter offset
                     getZk().updateTopology(topology -> Arrays.stream(topology.getPartitions())
                             .filter(p -> p.getPartition().equals(etp.getPartition()))
-                            .map(p -> p.toLastDeadLetterOffset(null))
+                            .map(p -> p.toZeroFailedCommits())
                             .toArray(Partition[]::new));
-
-                    // clean local copy of failed commits just in case that update from zookeeper is later or lost
-                    failedCommitPartitions.remove(etp);
 
                     // we are sure the batch is empty
                     break;


### PR DESCRIPTION
The current behaviour that Auto DLQ goes back to normal mode once it found one bad event.  It can happen that there are more events after that bad one. Current behaviour will create longer bad events identification time.

Internal ticket: 1537