### PR TITLE
Workaround: reset subscriptions' running sessions on attaching DLQ pa…

### DIFF
--- a/app/src/main/java/org/zalando/nakadi/service/job/DlqRedriveEventTypeAttachmentJob.java
+++ b/app/src/main/java/org/zalando/nakadi/service/job/DlqRedriveEventTypeAttachmentJob.java
@@ -166,9 +166,13 @@ public class DlqRedriveEventTypeAttachmentJob {
                 }
                 return newPartitions;
         });
+
+        // shortcut to enable new partitions for streaming, otherwise they will stay unassigned. 
+        // the better way is to rebalance them.
         if (hasNewPartitions[0]) {
             client.closeSubscriptionStreams(
-                    () -> LOG.info("subscription streams were closed, after repartitioning"),
+                    () -> LOG.info("Subscription `{}` streams were closed due to addition of " +
+                                   "Nakadi DLQ Event Type", subscription.getId()),
                     TimeUnit.SECONDS.toMillis(nakadiSettings.getMaxCommitTimeout()));
         }
     }


### PR DESCRIPTION
# One-line summary

## Description

This change resets (stops) subscription's running sessions upon attaching to the subscription the DLQ partitions. This would force a consuming application to re-connect to subscription (create new sessions) where they would be able to observe (consume) partitions of DLQ into addition to partitions from normal event types.

Note: this is a workaround (quick) solution. A better approach would be to rebalance partitions among running session without stopping them.

