### PR TITLE
Rebalance subscription's sessions on DLQ event type attachment to topology

### DIFF
--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionStreamerFactory.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/SubscriptionStreamerFactory.java
@@ -115,7 +115,6 @@ public class SubscriptionStreamerFactory {
                 .setSession(session)
                 .setTimer(executorService)
                 .setZkClient(zkClient)
-                .setRebalancer(new SubscriptionRebalancer())
                 .setKafkaPollTimeout(kafkaPollTimeout)
                 .setCursorTokenService(cursorTokenService)
                 .setObjectMapper(objectMapper)

--- a/api-consumption/src/test/java/org/zalando/nakadi/service/subscription/StreamingContextTest.java
+++ b/api-consumption/src/test/java/org/zalando/nakadi/service/subscription/StreamingContextTest.java
@@ -87,7 +87,6 @@ public class StreamingContextTest {
                 .setSubscription(new Subscription())
                 .setTimer(null)
                 .setZkClient(zkClient)
-                .setRebalancer(null)
                 .setKafkaPollTimeout(0)
                 .setCursorTokenService(null)
                 .setObjectMapper(null)

--- a/app/src/main/java/org/zalando/nakadi/service/job/DlqRedriveEventTypeAttachmentJob.java
+++ b/app/src/main/java/org/zalando/nakadi/service/job/DlqRedriveEventTypeAttachmentJob.java
@@ -30,7 +30,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @Service
@@ -167,13 +166,10 @@ public class DlqRedriveEventTypeAttachmentJob {
                 return newPartitions;
         });
 
-        // shortcut to enable new partitions for streaming, otherwise they will stay unassigned. 
-        // the better way is to rebalance them.
         if (hasNewPartitions[0]) {
-            client.closeSubscriptionStreams(
-                    () -> LOG.info("Subscription `{}` streams were closed due to addition of " +
-                                   "Nakadi DLQ Event Type", subscription.getId()),
-                    TimeUnit.SECONDS.toMillis(nakadiSettings.getMaxCommitTimeout()));
+            LOG.info("Rebalancing `{}` subscription's sessions due to addition of " +
+                    "Nakadi DLQ Event Type", subscription.getId());
+            client.rebalanceSessions();
         }
     }
 

--- a/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/SubscriptionRebalancer.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/SubscriptionRebalancer.java
@@ -1,4 +1,4 @@
-package org.zalando.nakadi.service.subscription;
+package org.zalando.nakadi.service.subscription.zk;
 
 import com.google.common.collect.Lists;
 import org.zalando.nakadi.domain.EventTypePartition;

--- a/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClient.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/subscription/zk/ZkSubscriptionClient.java
@@ -72,6 +72,11 @@ public interface ZkSubscriptionClient extends Closeable {
     boolean isActiveSession(String streamId) throws ServiceTemporarilyUnavailableException;
 
     /**
+     * Re-assigns topology's partitions among sessions and updates the topology with new assignment.
+     */
+    void rebalanceSessions();
+
+    /**
      * Returns subscription {@link Topology} object from Zookeeper
      *
      * @return topology {@link Topology}

--- a/core-common/src/test/java/org/zalando/nakadi/service/subscription/zk/SubscriptionRebalancerTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/service/subscription/zk/SubscriptionRebalancerTest.java
@@ -1,4 +1,4 @@
-package org.zalando.nakadi.service.subscription;
+package org.zalando.nakadi.service.subscription.zk;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;


### PR DESCRIPTION
## Description

This change rebalances subscription's topology among current sessions dynamically, upon attaching the DLQ event type to the subscription's topology.

This is considered to be more graceful behavior (towards consuming applications), compared to the current (workaround, #1579) approach where the sessions got stopped (forcing consuming applications to reconnect).