### PR TITLE
Add configurable timeout for publishing

### DIFF
--- a/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
+++ b/acceptance-test/src/acceptance-test/java/org/zalando/nakadi/repository/kafka/KafkaRepositoryAT.java
@@ -242,7 +242,8 @@ public class KafkaRepositoryAT extends BaseAT {
             items.add(item);
         }
 
-        kafkaTopicRepository.syncPostBatch(topicId, items, null, null, false);
+        kafkaTopicRepository.syncPostBatch(topicId, items, null, null,
+                Optional.empty(), false);
 
         for (int i = 0; i < 10; i++) {
             assertThat(items.get(i).getResponse().getPublishingStatus(), equalTo(EventPublishingStatus.SUBMITTED));
@@ -261,7 +262,8 @@ public class KafkaRepositoryAT extends BaseAT {
             item.setOwner(new EventOwnerHeader("unit", "Nakadi"));
             items.add(item);
         }
-        kafkaTopicRepository.syncPostBatch(topicId, items, null, null, false);
+        kafkaTopicRepository.syncPostBatch(topicId, items, null, null,
+                Optional.empty(), false);
 
         for (int i = 0; i < 10; i++) {
             assertThat(items.get(i).getResponse().getPublishingStatus(), equalTo(EventPublishingStatus.SUBMITTED));

--- a/api-publishing/src/main/java/org/zalando/nakadi/PublishRequest.java
+++ b/api-publishing/src/main/java/org/zalando/nakadi/PublishRequest.java
@@ -1,0 +1,91 @@
+package org.zalando.nakadi;
+
+import org.zalando.nakadi.domain.HeaderTag;
+import org.zalando.nakadi.exceptions.runtime.InvalidPublishingParamException;
+import org.zalando.nakadi.security.Client;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+public class PublishRequest<T> {
+    private final String eventTypeName;
+    private final T eventsRaw;
+    private final Client client;
+    private final Map<HeaderTag, String> consumerTags;
+    private final Optional<Integer> desiredPublishingTimeout;
+    private final boolean isDeleteRequest;
+
+    public PublishRequest(final String eventTypeName,
+                          final T eventsRaw,
+                          final Client client,
+                          final Map<HeaderTag, String> consumerTags,
+                          final int desiredPublishingTimeout,
+                          final boolean isDeleteRequest) {
+        this.eventTypeName = eventTypeName;
+        this.eventsRaw = eventsRaw;
+        this.client = client;
+        this.consumerTags = consumerTags;
+        //TODO: better way to get max timeout instead of hardcoding
+        if (desiredPublishingTimeout < 0 || desiredPublishingTimeout > 30_000) {
+            throw new InvalidPublishingParamException("X-TIMEOUT cannot be less than 0 or greater than 30000 ms");
+        }
+        //0 means either nothing was supplied or 0 was supplied, in both cases it means we will leave
+        //the timeout to be current default
+        this.desiredPublishingTimeout = Optional.of(desiredPublishingTimeout).filter(v -> v != 0);
+        this.isDeleteRequest = isDeleteRequest;
+    }
+
+    public String getEventTypeName() {
+        return eventTypeName;
+    }
+
+    public T getEventsRaw() {
+        return eventsRaw;
+    }
+
+    public Client getClient() {
+        return client;
+    }
+
+    public Map<HeaderTag, String> getConsumerTags() {
+        return consumerTags;
+    }
+
+    public Optional<Integer> getDesiredPublishingTimeout() {
+        return desiredPublishingTimeout;
+    }
+
+    public boolean isDeleteRequest() {
+        return isDeleteRequest;
+    }
+
+    @Override
+    public String toString() {
+        return "PublishRequest{" +
+                "eventTypeName='" + eventTypeName + '\'' +
+                ", eventsAsString='" + eventsRaw + '\'' +
+                ", client=" + client +
+                ", consumerTags=" + consumerTags +
+                ", desiredPublishingTimeout=" + desiredPublishingTimeout +
+                ", isDeleteRequest=" + isDeleteRequest +
+                '}';
+    }
+
+    public static <T> PublishRequest<T> asPublish(final String eventTypeName,
+                                                  final T eventsRaw,
+                                                  final Client client,
+                                                  final Map<HeaderTag, String> consumerTags,
+                                                  final int desiredPublishingTimeout) {
+        return new PublishRequest<>(eventTypeName, eventsRaw, client,
+                consumerTags, desiredPublishingTimeout, false);
+    }
+
+    public static <T> PublishRequest<T> asDelete(final String eventTypeName,
+                                                 final T eventsRaw,
+                                                 final Client client) {
+        return new PublishRequest<>(eventTypeName, eventsRaw, client,
+                Collections.emptyMap(), 0, true);
+    }
+
+}

--- a/core-common/src/main/java/org/zalando/nakadi/exceptions/runtime/InvalidPublishingParamException.java
+++ b/core-common/src/main/java/org/zalando/nakadi/exceptions/runtime/InvalidPublishingParamException.java
@@ -1,0 +1,7 @@
+package org.zalando.nakadi.exceptions.runtime;
+
+public class InvalidPublishingParamException extends NakadiBaseException {
+    public InvalidPublishingParamException(final String message) {
+        super(message);
+    }
+}

--- a/core-common/src/main/java/org/zalando/nakadi/repository/TopicRepository.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/TopicRepository.java
@@ -51,11 +51,12 @@ public interface TopicRepository {
     boolean topicExists(String topic) throws TopicRepositoryException;
 
     void syncPostBatch(String topicId, List<BatchItem> batch, String eventTypeName,
-                       Map<HeaderTag, String> consumerTags, boolean delete)
+                       Map<HeaderTag, String> consumerTags, Optional<Integer> publishTimeout, boolean delete)
             throws EventPublishingException;
 
     List<NakadiRecordResult> sendEvents(String topic, List<NakadiRecord> nakadiRecords,
-                                        Map<HeaderTag, String> consumerTags);
+                                        Map<HeaderTag, String> consumerTags,
+                                        Optional<Integer> publishTimeout);
 
     void repartition(String topic, int partitionsNumber) throws CannotAddPartitionToTopicException,
             TopicConfigException;

--- a/core-services/src/main/java/org/zalando/nakadi/controller/advice/NakadiProblemExceptionHandler.java
+++ b/core-services/src/main/java/org/zalando/nakadi/controller/advice/NakadiProblemExceptionHandler.java
@@ -19,6 +19,7 @@ import org.zalando.nakadi.exceptions.runtime.ForbiddenOperationException;
 import org.zalando.nakadi.exceptions.runtime.IllegalClientIdException;
 import org.zalando.nakadi.exceptions.runtime.InternalNakadiException;
 import org.zalando.nakadi.exceptions.runtime.InvalidLimitException;
+import org.zalando.nakadi.exceptions.runtime.InvalidPublishingParamException;
 import org.zalando.nakadi.exceptions.runtime.InvalidVersionNumberException;
 import org.zalando.nakadi.exceptions.runtime.NakadiBaseException;
 import org.zalando.nakadi.exceptions.runtime.NakadiRuntimeException;
@@ -120,7 +121,8 @@ public class NakadiProblemExceptionHandler implements ProblemHandling {
         return create(Problem.valueOf(INTERNAL_SERVER_ERROR, exception.getMessage()), request);
     }
 
-    @ExceptionHandler({InvalidLimitException.class, InvalidVersionNumberException.class})
+    @ExceptionHandler({InvalidLimitException.class, InvalidVersionNumberException.class,
+            InvalidPublishingParamException.class})
     public ResponseEntity<Problem> handleBadRequestResponses(final NakadiBaseException exception,
                                                              final NativeWebRequest request) {
         LOG.debug(exception.getMessage());

--- a/core-services/src/main/java/org/zalando/nakadi/service/publishing/JsonEventProcessor.java
+++ b/core-services/src/main/java/org/zalando/nakadi/service/publishing/JsonEventProcessor.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @Qualifier("json-publisher")
@@ -33,7 +34,8 @@ public class JsonEventProcessor extends EventsProcessor<JSONObject> {
     public void sendEvents(final String etName, final List<JSONObject> events) {
         try {
             // sending events batch with disabled authz check
-            eventPublisher.processInternal(new JSONArray(events).toString(), etName, null, false, false);
+            eventPublisher.processInternal(new JSONArray(events).toString(), etName, null, Optional.empty(),
+                    false,  false);
         } catch (final RuntimeException ex) {
             LOG.error("Failed to send single batch for unknown reason", ex);
         }

--- a/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventPublisherTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventPublisherTest.java
@@ -122,10 +122,12 @@ public class EventPublisherTest {
 
         mockSuccessfulValidation(eventType);
 
-        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null);
+        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.SUBMITTED));
-        verify(topicRepository, times(1)).syncPostBatch(any(), any(), any(), any(), eq(false));
+        verify(topicRepository, times(1)).syncPostBatch(any(), any(), any(), any(),
+                any(), eq(false));
     }
 
     @Test
@@ -135,7 +137,8 @@ public class EventPublisherTest {
         mockSuccessfulValidation(eventType);
 
         Mockito.when(eventOwnerExtractorFactory.createExtractor(eq(eventType))).thenReturn(null);
-        publisher.publish(batch.toString(), eventType.getName(), null);
+        publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         // invoked once for a batch
         Mockito.verify(eventOwnerExtractorFactory, Mockito.times(1)).createExtractor(eq(eventType));
@@ -151,7 +154,8 @@ public class EventPublisherTest {
         Mockito.when(eventOwnerExtractorFactory.createExtractor(eq(eventType))).thenReturn(
                 EventOwnerExtractorFactory.createStaticExtractor("retailer", "nakadi"));
 
-        publisher.publish(batch.toString(), eventType.getName(), null);
+        publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
         Mockito.verify(authzValidator, Mockito.times(3)).authorizeEventWrite(any(BatchItem.class));
     }
 
@@ -165,7 +169,8 @@ public class EventPublisherTest {
                 .when(authzValidator)
                 .authorizeEventTypeWrite(Mockito.eq(et));
 
-        publisher.publish(buildDefaultBatch(1).toString(), et.getName(), null);
+        publisher.publish(buildDefaultBatch(1).toString(), et.getName(), null,
+                Optional.empty());
     }
 
     @Test
@@ -176,10 +181,12 @@ public class EventPublisherTest {
 
         mockSuccessfulValidation(eventType);
 
-        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null);
+        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         assertThat(result.getResponses().get(0).getEid(), equalTo(event.getJSONObject("metadata").optString("eid")));
-        verify(topicRepository, times(1)).syncPostBatch(any(), any(), any(), any(), eq(false));
+        verify(topicRepository, times(1)).syncPostBatch(any(), any(), any(), any(),
+                any(), eq(false));
     }
 
     @Test
@@ -191,7 +198,8 @@ public class EventPublisherTest {
         final Closeable etCloser = mock(Closeable.class);
         Mockito.when(timelineSync.workWithEventType(any(String.class), anyLong())).thenReturn(etCloser);
 
-        publisher.publish(batch.toString(), eventType.getName(), null);
+        publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         verify(timelineSync, times(1)).workWithEventType(eq(eventType.getName()), eq(TIMELINE_WAIT_TIMEOUT_MS));
         verify(etCloser, times(1)).close();
@@ -200,7 +208,8 @@ public class EventPublisherTest {
     @Test(expected = EventTypeTimeoutException.class)
     public void whenPublishAndTimelineLockTimedOutThenException() throws Exception {
         Mockito.when(timelineSync.workWithEventType(any(String.class), anyLong())).thenThrow(new TimeoutException());
-        publisher.publish(buildDefaultBatch(0).toString(), "blahET", null);
+        publisher.publish(buildDefaultBatch(0).toString(), "blahET", null,
+                Optional.empty());
     }
 
     @Test
@@ -211,12 +220,14 @@ public class EventPublisherTest {
 
         mockFaultValidation(eventType, "error");
 
-        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null);
+        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.ABORTED));
         verify(enrichment, times(0)).enrich(any(), any());
         verify(partitionResolver, times(0)).resolvePartition(any(EventType.class), any(BatchItem.class), any());
-        verify(topicRepository, times(0)).syncPostBatch(any(), any(), any(), any(), anyBoolean());
+        verify(topicRepository, times(0)).syncPostBatch(any(), any(), any(), any(),
+                any(), anyBoolean());
     }
 
     @Test
@@ -227,7 +238,8 @@ public class EventPublisherTest {
 
         mockFaultValidation(eventType, "error");
 
-        EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null);
+        EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.ABORTED));
 
@@ -245,7 +257,8 @@ public class EventPublisherTest {
 
         // test with event header being set
         mockSuccessfulOwnerExtraction(eventType);
-        result = publisher.publish(batch.toString(), eventType.getName(), null);
+        result = publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.ABORTED));
         second = result.getResponses().get(1);
@@ -260,12 +273,14 @@ public class EventPublisherTest {
 
         mockSuccessfulValidation(eventType);
 
-        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null);
+        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.ABORTED));
         verify(enrichment, times(0)).enrich(any(), any());
         verify(partitionResolver, times(0)).resolvePartition(any(EventType.class), any(BatchItem.class), any());
-        verify(topicRepository, times(0)).syncPostBatch(any(), any(), any(), any(), anyBoolean());
+        verify(topicRepository, times(0)).syncPostBatch(any(), any(), any(), any(),
+                any(), anyBoolean());
     }
 
     @Test
@@ -281,7 +296,8 @@ public class EventPublisherTest {
 
         mockSuccessfulValidation(eventType);
 
-        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null);
+        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.ABORTED));
 
@@ -314,7 +330,8 @@ public class EventPublisherTest {
 
         mockSuccessfulValidation(eventType);
 
-        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null);
+        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.ABORTED));
 
@@ -341,12 +358,14 @@ public class EventPublisherTest {
 
         mockSuccessfulValidation(eventType);
 
-        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null);
+        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.SUBMITTED));
         verify(enrichment, times(1)).enrich(any(), any());
         verify(partitionResolver, times(1)).resolvePartition(any(EventType.class), any(BatchItem.class), any());
-        verify(topicRepository, times(1)).syncPostBatch(any(), any(), any(), any(), eq(false));
+        verify(topicRepository, times(1)).syncPostBatch(any(), any(), any(), any(),
+                any(), eq(false));
     }
 
     @Test
@@ -356,12 +375,14 @@ public class EventPublisherTest {
 
         mockSuccessfulValidation(eventType);
 
-        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null);
+        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.ABORTED));
         verify(enrichment, times(0)).enrich(any(), any());
         verify(partitionResolver, times(0)).resolvePartition(any(EventType.class), any(BatchItem.class), any());
-        verify(topicRepository, times(0)).syncPostBatch(any(), any(), any(), any(), anyBoolean());
+        verify(topicRepository, times(0)).syncPostBatch(any(), any(), any(), any(),
+                any(), anyBoolean());
     }
 
     @Test
@@ -371,12 +392,14 @@ public class EventPublisherTest {
 
         mockSuccessfulValidation(eventType);
 
-        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null);
+        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.ABORTED));
         verify(enrichment, times(0)).enrich(any(), any());
         verify(partitionResolver, times(0)).resolvePartition(any(EventType.class), any(BatchItem.class), any());
-        verify(topicRepository, times(0)).syncPostBatch(any(), any(), any(), any(), anyBoolean());
+        verify(topicRepository, times(0)).syncPostBatch(any(), any(), any(), any(),
+                any(), anyBoolean());
     }
 
     @Test
@@ -386,12 +409,14 @@ public class EventPublisherTest {
 
         mockSuccessfulValidation(eventType);
 
-        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null);
+        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.SUBMITTED));
         verify(enrichment, times(1)).enrich(any(), any());
         verify(partitionResolver, times(1)).resolvePartition(any(EventType.class), any(BatchItem.class), any());
-        verify(topicRepository, times(1)).syncPostBatch(any(), any(), any(), any(), eq(false));
+        verify(topicRepository, times(1)).syncPostBatch(any(), any(), any(), any(),
+                any(), eq(false));
     }
 
     @Test
@@ -405,7 +430,7 @@ public class EventPublisherTest {
         mockFaultPartition();
 
         final EventPublishResult result = publisher.publish(createStringFromBatchItems(batch),
-                eventType.getName(), null);
+                eventType.getName(), null, Optional.empty());
 
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.ABORTED));
     }
@@ -422,7 +447,7 @@ public class EventPublisherTest {
         mockFaultPartition();
 
         final EventPublishResult result = publisher.publish(createStringFromBatchItems(batch),
-                eventType.getName(), null);
+                eventType.getName(), null, Optional.empty());
 
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.ABORTED));
 
@@ -448,10 +473,12 @@ public class EventPublisherTest {
         mockSuccessfulValidation(eventType);
         mockFailedPublishing();
 
-        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null);
+        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.FAILED));
-        verify(topicRepository, times(1)).syncPostBatch(any(), any(), any(), any(), eq(false));
+        verify(topicRepository, times(1)).syncPostBatch(any(), any(), any(), any(),
+                any(), eq(false));
     }
 
     @Test
@@ -463,13 +490,15 @@ public class EventPublisherTest {
         mockSuccessfulValidation(eventType);
         mockFaultEnrichment();
 
-        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null);
+        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.ABORTED));
         verify(cache, atLeastOnce()).getValidator(eventType.getName());
         verify(partitionResolver, times(1)).resolvePartition(any(EventType.class), any(BatchItem.class), any());
         verify(enrichment, times(1)).enrich(any(), any());
-        verify(topicRepository, times(0)).syncPostBatch(any(), any(), any(), any(), anyBoolean());
+        verify(topicRepository, times(0)).syncPostBatch(any(), any(), any(), any(),
+                any(), anyBoolean());
     }
 
     @Test
@@ -483,7 +512,8 @@ public class EventPublisherTest {
         final JSONObject event = new JSONObject("{\"my_field\": \"my_key\"}");
         final JSONArray batch = new JSONArray(List.of(event));
 
-        publisher.publish(batch.toString(), eventType.getName(), null);
+        publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         final List<BatchItem> publishedBatch = capturePublishedBatch();
         final BatchItem publishedItem = publishedBatch.get(0);
@@ -502,7 +532,8 @@ public class EventPublisherTest {
         final JSONObject event = new JSONObject("{\"my_field\": \"my_key\", \"other_field\": \"other_value\"}");
         final JSONArray batch = new JSONArray(List.of(event));
 
-        publisher.publish(batch.toString(), eventType.getName(), null);
+        publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         final List<BatchItem> publishedBatch = capturePublishedBatch();
         final BatchItem publishedItem = publishedBatch.get(0);
@@ -524,7 +555,8 @@ public class EventPublisherTest {
                         " \"my_field\": \"my_key\"}");
         final JSONArray batch = new JSONArray(List.of(event));
 
-        publisher.publish(batch.toString(), eventType.getName(), null);
+        publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         final List<BatchItem> publishedBatch = capturePublishedBatch();
         final BatchItem publishedItem = publishedBatch.get(0);
@@ -543,7 +575,8 @@ public class EventPublisherTest {
 
         final JSONArray batch = buildDefaultBatch(1);
 
-        publisher.publish(batch.toString(), eventType.getName(), null);
+        publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         final List<BatchItem> publishedBatch = capturePublishedBatch();
         final BatchItem publishedItem = publishedBatch.get(0);
@@ -554,7 +587,8 @@ public class EventPublisherTest {
     @SuppressWarnings("unchecked")
     private List<BatchItem> capturePublishedBatch() {
         final ArgumentCaptor<List> batchCaptor = ArgumentCaptor.forClass(List.class);
-        verify(topicRepository, atLeastOnce()).syncPostBatch(any(), batchCaptor.capture(), any(), any(), eq(false));
+        verify(topicRepository, atLeastOnce()).syncPostBatch(any(), batchCaptor.capture(), any(), any(),
+                any(), eq(false));
         return (List<BatchItem>) batchCaptor.getValue();
     }
 
@@ -566,7 +600,8 @@ public class EventPublisherTest {
         mockSuccessfulValidation(eventType);
         mockFaultEnrichment();
 
-        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null);
+        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.ABORTED));
 
@@ -595,7 +630,8 @@ public class EventPublisherTest {
                 .when(authzValidator)
                 .authorizeEventWrite(any(BatchItem.class));
 
-        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null);
+        final EventPublishResult result = publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         assertThat(result.getStatus(), equalTo(EventPublishingStatus.ABORTED));
 
@@ -617,7 +653,8 @@ public class EventPublisherTest {
         final EventType eventType = EventTypeTestBuilder.builder().build();
         Mockito.when(cache.getEventType(eventType.getName())).thenReturn(eventType);
         mockSuccessfulValidation(eventType);
-        final EventPublishResult result = publisher.publish(buildDefaultBatch(0).toString(), eventType.getName(), null);
+        final EventPublishResult result = publisher.publish(buildDefaultBatch(0).toString(), eventType.getName(), null,
+                Optional.empty());
 
         Assert.assertEquals(result.getStatus(), EventPublishingStatus.SUBMITTED);
     }
@@ -670,8 +707,10 @@ public class EventPublisherTest {
                 .fromAvroRecord(metadata, event);
 
         final List<NakadiRecord> records = Collections.singletonList(nakadiRecord);
-        eventPublisher.publish(eventType, records, null);
-        Mockito.verify(topicRepository).sendEvents(ArgumentMatchers.eq(topic), ArgumentMatchers.eq(records), eq(null));
+        eventPublisher.publish(eventType, records,
+                null, Optional.empty());
+        Mockito.verify(topicRepository).sendEvents(ArgumentMatchers.eq(topic), ArgumentMatchers.eq(records),
+                eq(null), any());
     }
 
     @Test
@@ -685,7 +724,8 @@ public class EventPublisherTest {
 
         final Set<String> uniqueEventTypePartitions = publisher.getUniqueEventTypePartitions();
         uniqueEventTypePartitions.clear();
-        publisher.publish(batch.toString(), eventType.getName(), null);
+        publisher.publish(batch.toString(), eventType.getName(), null,
+                Optional.empty());
 
         Assert.assertEquals(1, uniqueEventTypePartitions.size());
         final String expectedEntry = String.format("%s:%s", eventType.getName(), 0);
@@ -696,7 +736,8 @@ public class EventPublisherTest {
         Mockito
                 .doThrow(EventPublishingException.class)
                 .when(topicRepository)
-                .syncPostBatch(any(), any(), any(), any(), anyBoolean());
+                .syncPostBatch(any(), any(), any(), any(),
+                        any(), anyBoolean());
     }
 
     private void mockFaultPartition() throws PartitioningException {

--- a/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventsProcessorTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventsProcessorTest.java
@@ -22,7 +22,7 @@ public class EventsProcessorTest {
             eventsProcessor.queueEvent("test_et_name", event);
             TestUtils.waitFor(() -> {
                 try {
-                    Mockito.verify(eventPublisher).processInternal(any(), any(), any(), eq(false), eq(false));
+                    Mockito.verify(eventPublisher).processInternal(any(), any(), any(), any(), eq(false), eq(false));
                 } catch (final Exception e) {
                     throw new AssertionError(e);
                 }


### PR DESCRIPTION
# One-line summary

> Zalando ticket : 1622

## Description
Add ability to specify timeout when using publishing apis and is taken from custom header `X-TIMEOUT`.

- This ability will allow users to fail fast in case the latency during publishing becomes too high for their use case. 
- Originally if the publishing request timed out from user side (due to setting smaller client timeout) then users would assume all events failed publishing and retry the whole batch. With the addition of this custom publish timeout, they can retry only the truly failed events.
