### PR TITLE
Expose partition in BatchItemResponse (useful for 207s)

### DIFF
--- a/api-publishing/src/main/java/org/zalando/nakadi/PublishingResultConverter.java
+++ b/api-publishing/src/main/java/org/zalando/nakadi/PublishingResultConverter.java
@@ -9,6 +9,7 @@ import org.zalando.nakadi.domain.NakadiRecordResult;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -22,6 +23,7 @@ public class PublishingResultConverter {
                     .setStep(EventPublishingStep.PUBLISHING)
                     .setPublishingStatus(status)
                     .setEid(recordMetadata.getMetadata().getEid())
+                    .setPartition(Optional.of(recordMetadata.getMetadata().getPartition()))
                     .setDetail((recordMetadata.getException() != null) ?
                             recordMetadata.getException().getMessage() : ""));
         }

--- a/core-common/src/main/java/org/zalando/nakadi/domain/BatchItem.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/BatchItem.java
@@ -64,7 +64,6 @@ public class BatchItem implements Resource<BatchItem> {
     private final InjectionConfiguration[] injections;
     private String[] injectionValues;
     private final List<Integer> skipCharacters;
-    private String partition;
     private String eventKey;
     private List<String> partitionKeys;
     private int eventSize;
@@ -108,11 +107,11 @@ public class BatchItem implements Resource<BatchItem> {
 
     @Nullable
     public String getPartition() {
-        return partition;
+        return this.response.getPartition().orElse(null);
     }
 
     public void setPartition(final String partition) {
-        this.partition = partition;
+        this.response.setPartition(Optional.ofNullable(partition));
     }
 
     @Nullable

--- a/core-common/src/main/java/org/zalando/nakadi/domain/BatchItemResponse.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/BatchItemResponse.java
@@ -1,13 +1,25 @@
 package org.zalando.nakadi.domain;
 
+import java.util.Optional;
+
 public class BatchItemResponse {
     private volatile EventPublishingStatus publishingStatus = EventPublishingStatus.ABORTED;
     private volatile String detail = "";
     private EventPublishingStep step = EventPublishingStep.NONE;
     private String eid = "";
+    private Optional<String> partition = Optional.empty();
 
     public String getEid() {
         return eid;
+    }
+
+    public Optional<String> getPartition() {
+        return partition;
+    }
+
+    public BatchItemResponse setPartition(Optional<String> partition) {
+        this.partition = partition;
+        return this;
     }
 
     public BatchItemResponse setEid(final String eid) {


### PR DESCRIPTION
# One-line summary

Expose partition in partial success reponses.

Zalando ticket : ARUHA-1619

## Description

Currently if an event fails to be published it returns a response of the following format:

```
HTTP/1.1 207 Multi-Status
...
[
  {
    "eid": "669B7E68-7654-4733-B3A9-BF36B41E4E59",
    "publishing_status": "submitted",
    "step": "publishing",
    "detail": ""
  },
  {
    "eid": "26f29c33-a9e2-421f-80fb-1696ee2d60d9",
    "publishing_status": "failed", <-- NOTICE: failed event
    "step": "publishing",
    "detail": "internal error"
  }
]
```

with this change each event's response record will contain a `partition` field with the partition number i.e. the response would look like:

```
HTTP/1.1 207 Multi-Status
...
[
  {
    "eid": "669B7E68-7654-4733-B3A9-BF36B41E4E59",
    "publishing_status": "submitted",
    "partition": "3", <-- newly exposed field
    "step": "publishing",
    "detail": ""
  },
  {
    "eid": "26f29c33-a9e2-421f-80fb-1696ee2d60d9",
    "publishing_status": "failed",
    "partition": "7", <-- newly exposed field
    "step": "publishing",
    "detail": "internal error"
  }
]
```

this will inform the users about the unavailability of some partitions, possibly allowing them to forward the events to other partitions (in some scenarios).

## Review
- [ ] Tests
- [ ] Documentation

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
