### PR TITLE
Extend the validations: retention period mandatory for materialisation opt-in

### DIFF
--- a/core-common/src/main/java/org/zalando/nakadi/annotations/validation/DataLakeAnnotationValidator.java
+++ b/core-common/src/main/java/org/zalando/nakadi/annotations/validation/DataLakeAnnotationValidator.java
@@ -12,21 +12,33 @@ public class DataLakeAnnotationValidator implements ConstraintValidator<DataLake
                     "(([1-9]|[1-9]\\d|[1][01]\\d|120)((\\smonths?)|(m)))|(([1-9]|(10))((\\syears?)|(y))))$");
     public static final String RETENTION_PERIOD_ANNOTATION = "datalake.zalando.org/retention-period";
     public static final String RETENTION_REASON_ANNOTATION = "datalake.zalando.org/retention-period-reason";
-    public static final String MATERIALISE_EVENTS_ANNOTATION = "datalake.zalando.org/materialize-events";
+    public static final String MATERIALIZE_EVENTS_ANNOTATION = "datalake.zalando.org/materialize-events";
 
     @Override
     public boolean isValid(final Map<String, String> annotations, final ConstraintValidatorContext context) {
         if (annotations == null || annotations.size() == 0) {
             return true;
         }
-        if (annotations.containsKey(MATERIALISE_EVENTS_ANNOTATION)) {
-            if (!annotations.get(MATERIALISE_EVENTS_ANNOTATION).equals("off") &&
-                    !annotations.get(MATERIALISE_EVENTS_ANNOTATION).equals("on")) {
+        final String materializeEventsAnnotation = annotations.get(MATERIALIZE_EVENTS_ANNOTATION);
+        if (annotations.containsKey(MATERIALIZE_EVENTS_ANNOTATION)) {
+            if (!materializeEventsAnnotation.equals("off") &&
+                    !materializeEventsAnnotation.equals("on")) {
                 context.disableDefaultConstraintViolation();
-                context.buildConstraintViolationWithTemplate("Annotation " + MATERIALISE_EVENTS_ANNOTATION
+                context.buildConstraintViolationWithTemplate("Annotation " + MATERIALIZE_EVENTS_ANNOTATION
                                 + " is not valid. Provided value: \""
-                                + annotations.get(MATERIALISE_EVENTS_ANNOTATION)
+                                + materializeEventsAnnotation
                                 + "\". Possible values are: \"on\" or \"off\".")
+                        .addConstraintViolation();
+                return false;
+            }
+
+            if (materializeEventsAnnotation.equals("on") && !annotations.containsKey(RETENTION_PERIOD_ANNOTATION)) {
+                context.disableDefaultConstraintViolation();
+                context.buildConstraintViolationWithTemplate("Annotation " + RETENTION_PERIOD_ANNOTATION
+                                + " is required, when "
+                                + MATERIALIZE_EVENTS_ANNOTATION + " with value: \""
+                                + materializeEventsAnnotation
+                                + "\" is specified.")
                         .addConstraintViolation();
                 return false;
             }

--- a/core-common/src/test/java/org/zalando/nakadi/annotations/validation/DataLakeAnnotationsTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/annotations/validation/DataLakeAnnotationsTest.java
@@ -35,13 +35,28 @@ public class DataLakeAnnotationsTest {
     @Test
     public void whenMaterializationEventFormatIsWrongThenFail() {
         final var annotations = Map.of(
-                DataLakeAnnotationValidator.MATERIALISE_EVENTS_ANNOTATION, "1 day"
+                DataLakeAnnotationValidator.MATERIALIZE_EVENTS_ANNOTATION, "1 day"
         );
         final Set<ConstraintViolation<TestClass>> result = validator.validate(new TestClass(annotations));
         assertTrue("When the format of the Materialize Event annotation is wrong, the name of the annotation " +
                         "should be present",
                 result.stream().anyMatch(r -> r.getMessage().contains(
-                        DataLakeAnnotationValidator.MATERIALISE_EVENTS_ANNOTATION)));
+                        DataLakeAnnotationValidator.MATERIALIZE_EVENTS_ANNOTATION)));
+    }
+
+    @Test
+    public void whenMaterializationEventIsOnAndNoRetentionPeriodThenFail() {
+        final var materializeAnnotation = DataLakeAnnotationValidator.MATERIALIZE_EVENTS_ANNOTATION;
+        final var retentionAnnotation = DataLakeAnnotationValidator.RETENTION_PERIOD_ANNOTATION;
+
+        final var annotations = Map.of(
+                materializeAnnotation, "on"
+        );
+        final Set<ConstraintViolation<TestClass>> result = validator.validate(new TestClass(annotations));
+        assertTrue(String.format("If %s annotation is specified and %s is not, then error message should include" +
+                        " both annotations", materializeAnnotation, retentionAnnotation),
+                result.stream().anyMatch(r -> r.getMessage().contains(materializeAnnotation) &&
+                        r.getMessage().contains(retentionAnnotation)));
     }
 
     @Test
@@ -108,7 +123,7 @@ public class DataLakeAnnotationsTest {
         final String materialisationEventValue = "off";
 
         final var annotations = Map.of(
-                DataLakeAnnotationValidator.MATERIALISE_EVENTS_ANNOTATION, materialisationEventValue
+                DataLakeAnnotationValidator.MATERIALIZE_EVENTS_ANNOTATION, materialisationEventValue
         );
 
         final Set<ConstraintViolation<TestClass>> result = validator.validate(new TestClass(annotations));


### PR DESCRIPTION
Extend the validations: retention period mandatory for materialisation opt-in

# One-line summary

> Zalando ticket : https://jira.zalando.net/browse/ZDLK-5203

## Description
We have extended the validations for the annotations field, to make the retention period field mandatory when the materialise_events field has value "on".
This PR replaces https://github.com/zalando/nakadi/pull/1543 since Adriana is no longer available.

## Review
- [x] Tests
- [ ] Documentation

## Deployment Notes
N/A
