### PR TITLE
Log debug topic id header for misplaced events

### DIFF
--- a/api-consumption/src/main/java/org/zalando/nakadi/service/EventStream.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/EventStream.java
@@ -6,6 +6,7 @@ import org.apache.kafka.common.KafkaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zalando.nakadi.domain.ConsumedEvent;
+import org.zalando.nakadi.domain.HeaderTag;
 import org.zalando.nakadi.domain.NakadiCursor;
 import org.zalando.nakadi.service.timeline.HighLevelConsumer;
 
@@ -84,7 +85,8 @@ public class EventStream {
                 if (consumedEvents.isEmpty()) {
                     final List<ConsumedEvent> eventsFromKafka = eventConsumer.readEvents();
                     for (final ConsumedEvent evt : eventsFromKafka) {
-                        if (eventStreamChecks.isConsumptionBlocked(evt) || !evt.getConsumerTags().isEmpty()) {
+                        if (evt.getConsumerTags().containsKey(HeaderTag.CONSUMER_SUBSCRIPTION_ID)
+                                || eventStreamChecks.isConsumptionBlocked(evt)) {
                             continue;
                         }
                         consumedEvents.add(evt);

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -311,10 +311,7 @@ public class StreamingContext implements SubscriptionStreamer {
                 return true;
             }
         }
-        if (event.getConsumerTags().isEmpty()) {
-            return eventStreamChecks.isConsumptionBlocked(event);
-        }
-        return !checkConsumptionAllowedFromConsumerTags(event)
+        return !isConsumptionAllowedFromConsumerTags(event)
                 || eventStreamChecks.isConsumptionBlocked(event);
     }
 
@@ -339,7 +336,7 @@ public class StreamingContext implements SubscriptionStreamer {
         return false;
     }
 
-    private boolean checkConsumptionAllowedFromConsumerTags(final ConsumedEvent event) {
+    private boolean isConsumptionAllowedFromConsumerTags(final ConsumedEvent event) {
         return event.getConsumerTags()
                 .getOrDefault(HeaderTag.CONSUMER_SUBSCRIPTION_ID, subscription.getId())
                 .equals(subscription.getId());

--- a/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
+++ b/api-consumption/src/main/java/org/zalando/nakadi/service/subscription/StreamingContext.java
@@ -324,8 +324,9 @@ public class StreamingContext implements SubscriptionStreamer {
             try {
                 final String actualEventTypeName = kafkaRecordDeserializer.getEventTypeName(event.getEvent());
                 if (!expectedEventTypeName.equals(actualEventTypeName)) {
-                    LOG.warn("Consumed event for event type '{}', but expected '{}' (at position {})",
-                            actualEventTypeName, expectedEventTypeName, event.getPosition());
+                    LOG.warn("Consumed event for event type '{}', but expected '{}' (at position {}), topic id: {}",
+                            actualEventTypeName, expectedEventTypeName, event.getPosition(),
+                            event.getConsumerTags().get(HeaderTag.DEBUG_PUBLISHER_TOPIC_ID));
                     return true;
                 }
             } catch (final IOException e) {
@@ -339,10 +340,9 @@ public class StreamingContext implements SubscriptionStreamer {
     }
 
     private boolean checkConsumptionAllowedFromConsumerTags(final ConsumedEvent event) {
-        return event.getConsumerTags().
-                getOrDefault(HeaderTag.CONSUMER_SUBSCRIPTION_ID,
-                        subscription.getId()).
-                equals(subscription.getId());
+        return event.getConsumerTags()
+                .getOrDefault(HeaderTag.CONSUMER_SUBSCRIPTION_ID, subscription.getId())
+                .equals(subscription.getId());
     }
 
     public CursorTokenService getCursorTokenService() {

--- a/api-consumption/src/test/java/org/zalando/nakadi/service/subscription/StreamingContextTest.java
+++ b/api-consumption/src/test/java/org/zalando/nakadi/service/subscription/StreamingContextTest.java
@@ -230,6 +230,7 @@ public class StreamingContextTest {
         final var incorrectEventTypeName = "incorrect_event_type";
         final var supportedEventTypeName = "correct_event_type";
         final var subscription = new Subscription();
+        subscription.setId(UUID.randomUUID().toString());
         subscription.setEventTypes(Set.of(supportedEventTypeName));
         final var et = new EventType();
         et.setCategory(EventCategory.BUSINESS);

--- a/api-publishing/src/main/java/org/zalando/nakadi/EventPublishingController.java
+++ b/api-publishing/src/main/java/org/zalando/nakadi/EventPublishingController.java
@@ -42,9 +42,11 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -338,8 +340,8 @@ public class EventPublishingController {
             throw new InvalidConsumerTagException(X_CONSUMER_TAG + ": is empty!");
         }
 
-        final var arr = consumerString.split(",");
-        final Map<HeaderTag, String> result = new HashMap<>();
+        final Map<HeaderTag, String> result = new EnumMap<>(HeaderTag.class);
+        final String[] arr = consumerString.split(",");
         for (final String entry : arr) {
             final var tagAndValue = entry.replaceAll("\\s", "").split("=");
             if (tagAndValue.length != 2) {
@@ -347,22 +349,30 @@ public class EventPublishingController {
                         "expected: 2 but provided " + arr.length);
             }
 
-            final var optHeaderTag = HeaderTag.fromString(tagAndValue[0]);
+            final Optional<HeaderTag> optHeaderTag = HeaderTag.fromString(tagAndValue[0]);
             if (optHeaderTag.isEmpty()) {
                 throw new InvalidConsumerTagException("invalid header tag: " + tagAndValue[0]);
             }
-            if (result.containsKey(optHeaderTag.get())) {
-                throw new InvalidConsumerTagException("duplicate header tag: "
-                        + optHeaderTag.get());
+
+            final HeaderTag headerTag = optHeaderTag.get();
+            if (result.containsKey(headerTag)) {
+                throw new InvalidConsumerTagException("duplicate header tag: " + headerTag);
             }
-            if (optHeaderTag.get() == HeaderTag.CONSUMER_SUBSCRIPTION_ID) {
+
+            switch (headerTag) {
+            case CONSUMER_SUBSCRIPTION_ID:
                 try {
                     UUID.fromString(tagAndValue[1]);
                 } catch (IllegalArgumentException e) {
                     throw new InvalidConsumerTagException("header tag value: " + tagAndValue[1] + " is not an UUID");
                 }
+                break;
+
+            default:
+                throw new InvalidConsumerTagException("header tag unsupported: " + tagAndValue[0]);
             }
-            result.put(optHeaderTag.get(), tagAndValue[1]);
+
+            result.put(headerTag, tagAndValue[1]);
         }
         return result;
     }

--- a/api-publishing/src/main/java/org/zalando/nakadi/EventPublishingController.java
+++ b/api-publishing/src/main/java/org/zalando/nakadi/EventPublishingController.java
@@ -43,7 +43,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/core-common/src/main/java/org/zalando/nakadi/domain/HeaderTag.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/HeaderTag.java
@@ -1,6 +1,5 @@
 package org.zalando.nakadi.domain;
 
-
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
@@ -9,13 +8,13 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public enum HeaderTag {
-    CONSUMER_SUBSCRIPTION_ID;
+    CONSUMER_SUBSCRIPTION_ID,
+    DEBUG_PUBLISHER_TOPIC_ID;
 
-    private static final Map<String, HeaderTag> STRING_TO_ENUM = HeaderTag.
-            stream().
-            collect(Collectors.toMap(HeaderTag::name, Function.identity()));
+    private static final Map<String, HeaderTag> STRING_TO_ENUM = HeaderTag.stream()
+            .collect(Collectors.toMap(HeaderTag::name, Function.identity()));
 
-    public static Optional<HeaderTag> fromString(final String headerTag){
+    public static Optional<HeaderTag> fromString(final String headerTag) {
         return Optional.ofNullable(STRING_TO_ENUM.get(headerTag.toUpperCase()));
     }
 

--- a/core-common/src/main/java/org/zalando/nakadi/domain/KafkaHeaderTagSerde.java
+++ b/core-common/src/main/java/org/zalando/nakadi/domain/KafkaHeaderTagSerde.java
@@ -4,19 +4,19 @@ import com.google.common.base.Charsets;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 
 public class KafkaHeaderTagSerde {
 
     public static void serialize(final Map<HeaderTag, String> consumerTags,
                                  final ProducerRecord<byte[], byte[]> record) {
-        consumerTags.
-                forEach((tag, value) -> record.headers().add(tag.name(), value.getBytes(Charsets.UTF_8)));
+        consumerTags.forEach((tag, value) ->
+                record.headers().add(tag.name(), value.getBytes(Charsets.UTF_8)));
     }
 
     public static Map<HeaderTag, String> deserialize(final ConsumerRecord<byte[], byte[]> record) {
-        final var result = new HashMap<HeaderTag, String>();
+        final Map<HeaderTag, String> result = new EnumMap<>(HeaderTag.class);
         record.headers().forEach(header -> {
             HeaderTag.fromString(header.key()).ifPresent(tag ->
                     result.put(tag, new String(header.value(), Charsets.UTF_8))

--- a/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
+++ b/core-common/src/main/java/org/zalando/nakadi/repository/kafka/KafkaTopicRepository.java
@@ -1,6 +1,5 @@
 package org.zalando.nakadi.repository.kafka;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -172,11 +171,9 @@ public class KafkaTopicRepository implements TopicRepository {
                 item.getOwner().serialize(kafkaRecord);
             }
 
-            if (consumerTags!= null && !consumerTags.isEmpty()) {
+            if (null != consumerTags && !consumerTags.isEmpty()) {
                 KafkaHeaderTagSerde.serialize(consumerTags, kafkaRecord);
             }
-
-            kafkaRecord.headers().add("X-Kafka-Topic", topicId.getBytes(Charsets.UTF_8));
 
             producer.send(kafkaRecord, ((metadata, exception) -> {
                 if (null != exception) {
@@ -420,11 +417,9 @@ public class KafkaTopicRepository implements TopicRepository {
                     nakadiRecord.getOwner().serialize(producerRecord);
                 }
 
-                if( null != consumerTags) {
+                if (null != consumerTags && !consumerTags.isEmpty()) {
                     KafkaHeaderTagSerde.serialize(consumerTags, producerRecord);
                 }
-
-                producerRecord.headers().add("X-Kafka-Topic", topic.getBytes(Charsets.UTF_8));
 
                 final Producer producer =
                         kafkaFactory.takeProducer(getProducerKey(topic, nakadiRecord.getMetadata().getPartition()));

--- a/core-common/src/main/java/org/zalando/nakadi/service/TracingService.java
+++ b/core-common/src/main/java/org/zalando/nakadi/service/TracingService.java
@@ -23,7 +23,9 @@ public class TracingService {
 
     private static final long BUCKET_5_KB = 5000L;
     private static final long BUCKET_50_KB = 50000L;
+
     public static final String ERROR_DESCRIPTION = "error.description";
+    public static final String TAG_EVENT_TYPE = "event_type";
 
     public static String getSLOBucketName(final long batchSize) {
         if (batchSize > BUCKET_50_KB) {

--- a/core-common/src/test/java/org/zalando/nakadi/domain/KafkaHeaderTagSerializerTest.java
+++ b/core-common/src/test/java/org/zalando/nakadi/domain/KafkaHeaderTagSerializerTest.java
@@ -12,30 +12,41 @@ import java.util.Map;
 public class KafkaHeaderTagSerializerTest {
 
     private static final String SUB_ID = "16120729-4a57-4607-ad3a-d526a4590e75";
+    private static final String TOPIC_ID = "010b65ff-7343-425d-821e-d64e014925c9";
 
     @Test
     public void testConsumerTagSerializer() {
-        final var consumerTags = Map.of(HeaderTag.CONSUMER_SUBSCRIPTION_ID, SUB_ID);
+        final Map<HeaderTag, String> consumerTags = Map.of(
+                HeaderTag.CONSUMER_SUBSCRIPTION_ID, SUB_ID,
+                HeaderTag.DEBUG_PUBLISHER_TOPIC_ID, TOPIC_ID);
+
         final ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(
-                "topic",
-                "value".getBytes(StandardCharsets.UTF_8));
+                "topic", "value".getBytes(StandardCharsets.UTF_8));
+
         KafkaHeaderTagSerde.serialize(consumerTags, record);
 
         Assert.assertEquals(SUB_ID,
                 new String(
-                        record.headers().lastHeader(HeaderTag.CONSUMER_SUBSCRIPTION_ID.name()).
-                                value(),
+                        record.headers().lastHeader(HeaderTag.CONSUMER_SUBSCRIPTION_ID.name()).value(),
+                        Charsets.UTF_8));
+
+        Assert.assertEquals(TOPIC_ID,
+                new String(
+                        record.headers().lastHeader(HeaderTag.DEBUG_PUBLISHER_TOPIC_ID.name()).value(),
                         Charsets.UTF_8));
     }
 
     @Test
     public void testConsumerTagDeserializer() {
-        final ConsumerRecord<byte[], byte[]> record =
-                new ConsumerRecord<>("topic", 1, 1L, "key".getBytes(), "value".getBytes());
+        final ConsumerRecord<byte[], byte[]> record = new ConsumerRecord<>(
+                "topic", 1, 1L, "key".getBytes(), "value".getBytes());
+
         record.headers().add(HeaderTag.CONSUMER_SUBSCRIPTION_ID.name(), SUB_ID.getBytes(Charsets.UTF_8));
+        record.headers().add(HeaderTag.DEBUG_PUBLISHER_TOPIC_ID.name(), TOPIC_ID.getBytes(Charsets.UTF_8));
 
-        final var consumerTags = KafkaHeaderTagSerde.deserialize(record);
+        final Map<HeaderTag, String> consumerTags = KafkaHeaderTagSerde.deserialize(record);
+
         Assert.assertEquals(consumerTags.get(HeaderTag.CONSUMER_SUBSCRIPTION_ID), SUB_ID);
+        Assert.assertEquals(consumerTags.get(HeaderTag.DEBUG_PUBLISHER_TOPIC_ID), TOPIC_ID);
     }
-
 }

--- a/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventPublisherTest.java
+++ b/core-services/src/test/java/org/zalando/nakadi/service/publishing/EventPublisherTest.java
@@ -212,7 +212,8 @@ public class EventPublisherTest {
 
         final List<NakadiRecord> records = Collections.singletonList(nakadiRecord);
         final List<NakadiRecordResult> publishResult = eventPublisher.publish(eventType, records, null);
-        Mockito.verify(topicRepository).sendEvents(ArgumentMatchers.eq(topic), ArgumentMatchers.eq(records), eq(null));
+
+        Mockito.verify(topicRepository).sendEvents(ArgumentMatchers.eq(topic), ArgumentMatchers.eq(records), any());
 
         Assert.assertNotEquals(NakadiRecordResult.Status.SUCCEEDED, publishResult.get(0).getStatus());
         Assert.assertEquals("1", publishResult.get(0).getMetadata().getPartition());
@@ -728,10 +729,10 @@ public class EventPublisherTest {
                 .thenReturn("1");
 
         final NakadiRecord nakadiRecord = mockNakadiRecord();
-
         final List<NakadiRecord> records = Collections.singletonList(nakadiRecord);
         eventPublisher.publish(eventType, records, null);
-        Mockito.verify(topicRepository).sendEvents(ArgumentMatchers.eq(topic), ArgumentMatchers.eq(records), eq(null));
+
+        Mockito.verify(topicRepository).sendEvents(ArgumentMatchers.eq(topic), ArgumentMatchers.eq(records), any());
     }
 
     @Test
@@ -929,7 +930,7 @@ public class EventPublisherTest {
                         new TimeoutException()));
             }
             return resps;
-        }).when(topicRepository).sendEvents(any(), any(), eq(null));
+         }).when(topicRepository).sendEvents(any(), any(), any());
     }
 
 }


### PR DESCRIPTION
1. Reuse `HeaderTag` for adding the debug header.
2. Use `EnumMap` for slightly more efficiency.
3. Log it when we detect misplaced event.