### PR TITLE
Mention that event_stream.read|write scopes are not used

### DIFF
--- a/docs/_data/nakadi-event-bus-api.yaml
+++ b/docs/_data/nakadi-event-bus-api.yaml
@@ -91,9 +91,9 @@ securityDefinitions:
       nakadi.event_type.write: |
         Grants access for applications to define and update EventTypes.
       nakadi.event_stream.write: |
-        Grants access for applications to submit Events.
+        Grants access for applications to submit Events. Note: On Zalando's installation this scope is not needed anymore, instead the access depends on the per-event-type authorization.
       nakadi.event_stream.read: |
-        Grants access for consuming Event streams.
+        Grants access for consuming Event streams. Note: On Zalando's installation this scope is not needed anymore, instead the access depends on the per-event-type authorization.
 
 paths:
   /metrics:


### PR DESCRIPTION
# One-line summary

Mention that event_stream.read|write scopes are not used

> Zalando ticket : –

## Description

This adds two lines to the API definition indicating that the nakadi.event_stream.read|write scopes are not used in Zalando's main Nakadi installation.
(That's the case since mid 2017.)

If you think we should instead remove all traces of these scopes from the whole document, I can do that too.

## Review
- [ ] Tests
- [ ] Documentation

## Deployment Notes
This doesn't change any behavior, just the documentation.